### PR TITLE
feat: Add single file IO

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,12 @@ packages = ["src/fluxopt"]
 [tool.hatch.build.targets.sdist]
 include = ["src/fluxopt/", "LICENSE", "README.md"]
 
+[project.optional-dependencies]
+io = [
+    "xarray>=2024.1.0",
+    "netcdf4>=1.6.0",
+]
+
 [dependency-groups]
 dev = [
     "mypy==1.19.1",
@@ -132,6 +138,8 @@ module = [
     "pyoframe.*",
     "pyoptinterface.*",
     "highsbox.*",
+    "xarray.*",
+    "netCDF4.*",
 ]
 ignore_missing_imports = true
 

--- a/src/fluxopt/io.py
+++ b/src/fluxopt/io.py
@@ -1,0 +1,601 @@
+"""NetCDF IO for fluxopt — serialize SolvedModel to/from NetCDF via xarray.
+
+Requires the ``io`` extra: ``pip install fluxopt[io]``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import polars as pl
+
+if TYPE_CHECKING:
+    import xarray as xr
+
+    from fluxopt.results import SolvedModel
+    from fluxopt.tables import ModelData
+
+
+def _require_xarray() -> Any:
+    """Import and return xarray, raising a helpful error if missing. Also checks netCDF4."""
+    try:
+        import xarray
+    except ModuleNotFoundError:
+        msg = "xarray is required for NetCDF IO. Install it with: pip install 'fluxopt[io]'"
+        raise ModuleNotFoundError(msg) from None
+    try:
+        import netCDF4
+    except ModuleNotFoundError:
+        msg = "netCDF4 is required for NetCDF IO. Install it with: pip install 'fluxopt[io]'"
+        raise ModuleNotFoundError(msg) from None
+    _ = netCDF4  # ensure it's not flagged as unused
+    return xarray
+
+
+def _time_dtype_label(dtype: pl.DataType) -> str:
+    """Return 'datetime' or 'int64' based on a Polars dtype."""
+    if dtype.is_integer():
+        return 'int64'
+    return 'datetime'
+
+
+# ---------------------------------------------------------------------------
+# Polars <-> xarray helpers
+# ---------------------------------------------------------------------------
+
+
+def _polars_long_to_dataarray(
+    df: pl.DataFrame,
+    dims: list[str],
+    value_col: str,
+    name: str,
+) -> xr.DataArray:
+    """Convert a Polars long-format DataFrame to a sparse xarray DataArray (NaN fill)."""
+    _xr = _require_xarray()
+    if len(df) == 0:
+        return _xr.DataArray(name=name)
+    pdf = df.to_pandas()
+    series = pdf.set_index(dims)[value_col]
+    da: xr.DataArray = series.to_xarray()
+    da.name = name
+    return da
+
+
+def _dataarray_to_polars_long(
+    da: xr.DataArray,
+    value_col: str,
+    time_dtype: pl.DataType | None = None,
+) -> pl.DataFrame:
+    """Convert an xarray DataArray back to a Polars long-format DataFrame."""
+    if da.size == 0 or da.dims == ():
+        return pl.DataFrame()
+    pdf = da.to_dataframe(name=value_col).reset_index()
+    pdf = pdf.dropna(subset=[value_col])
+    result: pl.DataFrame = pl.from_pandas(pdf)
+    # Cast time columns back to the correct dtype
+    if time_dtype is not None:
+        for col in result.columns:
+            if col == 'time':
+                result = result.with_columns(pl.col(col).cast(time_dtype))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Solution -> xarray Dataset
+# ---------------------------------------------------------------------------
+
+
+def solved_model_to_xarray(result: SolvedModel) -> xr.Dataset:
+    """Convert solution data to an xarray Dataset (root group contents)."""
+    _xr = _require_xarray()
+
+    data_vars: dict[str, xr.DataArray] = {}
+
+    # Flow rates (flow, time)
+    if len(result.flow_rates) > 0:
+        data_vars['flow_rates'] = _polars_long_to_dataarray(
+            result.flow_rates, ['flow', 'time'], 'solution', 'flow_rates'
+        )
+
+    # Charge states (storage, time)
+    if len(result.charge_states) > 0:
+        da = _polars_long_to_dataarray(result.charge_states, ['storage', 'time'], 'solution', 'charge_states')
+        # Rename time -> cs_time to distinguish from flow timesteps
+        da = da.rename({'time': 'cs_time'})
+        data_vars['charge_states'] = da
+
+    # Effects (effect,)
+    if len(result.effects) > 0:
+        data_vars['effects'] = _polars_long_to_dataarray(result.effects, ['effect'], 'solution', 'effects')
+
+    # Effects per timestep (effect, time)
+    if len(result.effects_per_timestep) > 0:
+        data_vars['effects_per_timestep'] = _polars_long_to_dataarray(
+            result.effects_per_timestep, ['effect', 'time'], 'solution', 'effects_per_timestep'
+        )
+
+    # Contributions (source, contributor, effect, time)
+    if len(result.contributions) > 0:
+        data_vars['contributions'] = _polars_long_to_dataarray(
+            result.contributions, ['source', 'contributor', 'effect', 'time'], 'solution', 'contributions'
+        )
+
+    ds = _xr.Dataset(data_vars)
+
+    # Attrs
+    ds.attrs['objective_value'] = result.objective_value
+    if result.data is not None:
+        ds.attrs['objective_effect'] = result.data.effects.objective_effect
+        ds.attrs['time_dtype'] = _time_dtype_label(result.data.timesteps.schema['time'])
+    else:
+        # Infer from flow_rates time column
+        time_dtype = result.flow_rates.schema.get('time', pl.Datetime())
+        ds.attrs['time_dtype'] = _time_dtype_label(time_dtype)
+
+    return ds
+
+
+# ---------------------------------------------------------------------------
+# Model data -> NetCDF group
+# ---------------------------------------------------------------------------
+
+
+def _write_model_data(data: ModelData, path: str | Path) -> None:
+    """Append a 'model' group to an existing NetCDF file with model input data."""
+    _xr = _require_xarray()
+
+    data_vars: dict[str, xr.DataArray] = {}
+
+    # dt and weight (time,)
+    data_vars['dt'] = _polars_long_to_dataarray(data.dt, ['time'], 'dt', 'dt')
+    data_vars['weight'] = _polars_long_to_dataarray(data.weights, ['time'], 'weight', 'weight')
+
+    # charge_state_times -- store as a coordinate-only variable
+    cs_times = data.charge_state_times['time'].to_list()
+    data_vars['charge_state_times'] = _xr.DataArray(cs_times, dims=['cs_time'], name='charge_state_times')
+
+    # Flow bounds (flow, time)
+    if len(data.flows.relative_bounds) > 0:
+        bounds = data.flows.relative_bounds
+        lb_df = bounds.select('flow', 'time', pl.col('rel_lb').alias('value'))
+        ub_df = bounds.select('flow', 'time', pl.col('rel_ub').alias('value'))
+        data_vars['flow_lb'] = _polars_long_to_dataarray(lb_df, ['flow', 'time'], 'value', 'flow_lb')
+        data_vars['flow_ub'] = _polars_long_to_dataarray(ub_df, ['flow', 'time'], 'value', 'flow_ub')
+
+    # Flow fixed (flow, time)
+    if len(data.flows.fixed) > 0:
+        data_vars['flow_fixed'] = _polars_long_to_dataarray(data.flows.fixed, ['flow', 'time'], 'value', 'flow_fixed')
+
+    # Flow sizes (flow,)
+    if len(data.flows.sizes) > 0:
+        data_vars['flow_size'] = _polars_long_to_dataarray(data.flows.sizes, ['flow'], 'size', 'flow_size')
+
+    # Effect coefficients (flow, effect, time)
+    if len(data.flows.effect_coefficients) > 0:
+        data_vars['effect_coeff'] = _polars_long_to_dataarray(
+            data.flows.effect_coefficients, ['flow', 'effect', 'time'], 'coeff', 'effect_coeff'
+        )
+
+    # Bus flow coefficients (bus, flow)
+    if len(data.buses.flow_coefficients) > 0:
+        data_vars['bus_flow_coeff'] = _polars_long_to_dataarray(
+            data.buses.flow_coefficients, ['bus', 'flow'], 'coeff', 'bus_flow_coeff'
+        )
+
+    # Converter flow coefficients (converter, eq_idx, flow, time)
+    if len(data.converters.flow_coefficients) > 0:
+        data_vars['converter_flow_coeff'] = _polars_long_to_dataarray(
+            data.converters.flow_coefficients,
+            ['converter', 'eq_idx', 'flow', 'time'],
+            'coeff',
+            'converter_flow_coeff',
+        )
+
+    # Effect bounds
+    if len(data.effects.bounds) > 0:
+        bounds_e = data.effects.bounds
+        min_df = bounds_e.select('effect', pl.col('min_total').alias('value'))
+        max_df = bounds_e.select('effect', pl.col('max_total').alias('value'))
+        data_vars['effect_min_total'] = _polars_long_to_dataarray(min_df, ['effect'], 'value', 'effect_min_total')
+        data_vars['effect_max_total'] = _polars_long_to_dataarray(max_df, ['effect'], 'value', 'effect_max_total')
+
+    # Effect time bounds
+    if len(data.effects.time_bounds_lb) > 0:
+        data_vars['effect_time_lb'] = _polars_long_to_dataarray(
+            data.effects.time_bounds_lb, ['effect', 'time'], 'value', 'effect_time_lb'
+        )
+    if len(data.effects.time_bounds_ub) > 0:
+        data_vars['effect_time_ub'] = _polars_long_to_dataarray(
+            data.effects.time_bounds_ub, ['effect', 'time'], 'value', 'effect_time_ub'
+        )
+
+    # Storage params
+    if len(data.storages.params) > 0:
+        params = data.storages.params
+        data_vars['storage_capacity'] = _polars_long_to_dataarray(
+            params.select('storage', pl.col('capacity').alias('value')), ['storage'], 'value', 'storage_capacity'
+        )
+        data_vars['storage_initial_charge'] = _polars_long_to_dataarray(
+            params.select('storage', pl.col('initial_charge').alias('value')),
+            ['storage'],
+            'value',
+            'storage_initial_charge',
+        )
+        # cyclic is boolean -> store as int
+        data_vars['storage_cyclic'] = _polars_long_to_dataarray(
+            params.select('storage', pl.col('cyclic').cast(pl.Int8).alias('value')),
+            ['storage'],
+            'value',
+            'storage_cyclic',
+        )
+
+    # Storage time params (storage, time)
+    if len(data.storages.time_params) > 0:
+        tp = data.storages.time_params
+        for col in ['eta_c', 'eta_d', 'loss']:
+            data_vars[f'storage_{col}'] = _polars_long_to_dataarray(
+                tp.select('storage', 'time', pl.col(col).alias('value')),
+                ['storage', 'time'],
+                'value',
+                f'storage_{col}',
+            )
+
+    # Storage charge state bounds (storage, time)
+    if len(data.storages.cs_bounds) > 0:
+        csb = data.storages.cs_bounds
+        data_vars['storage_cs_lb'] = _polars_long_to_dataarray(
+            csb.select('storage', 'time', pl.col('cs_lb').alias('value')),
+            ['storage', 'time'],
+            'value',
+            'storage_cs_lb',
+        )
+        data_vars['storage_cs_ub'] = _polars_long_to_dataarray(
+            csb.select('storage', 'time', pl.col('cs_ub').alias('value')),
+            ['storage', 'time'],
+            'value',
+            'storage_cs_ub',
+        )
+
+    # Storage flow map (storage,)
+    if len(data.storages.flow_map) > 0:
+        fm = data.storages.flow_map
+        data_vars['storage_charge_flow'] = _polars_long_to_dataarray(
+            fm.select('storage', pl.col('charge_flow').alias('value')),
+            ['storage'],
+            'value',
+            'storage_charge_flow',
+        )
+        data_vars['storage_discharge_flow'] = _polars_long_to_dataarray(
+            fm.select('storage', pl.col('discharge_flow').alias('value')),
+            ['storage'],
+            'value',
+            'storage_discharge_flow',
+        )
+
+    # Objective effect
+    ds = _xr.Dataset(data_vars)
+    ds.attrs['objective_effect'] = data.effects.objective_effect
+
+    # Write to the 'model' group
+    ds.to_netcdf(path, mode='a', group='model')
+
+
+def _read_model_data(path: str | Path, time_dtype: pl.DataType) -> ModelData:
+    """Read ModelData from the 'model' group of a NetCDF file."""
+    _xr = _require_xarray()
+    from fluxopt.tables import (
+        BusesTable,
+        ConvertersTable,
+        EffectsTable,
+        FlowsTable,
+        ModelData,
+        StoragesTable,
+    )
+
+    ds = _xr.open_dataset(path, group='model')
+    objective_effect: str = ds.attrs['objective_effect']
+
+    # Helper to read a DataArray back to Polars
+    def _read_da(name: str, dims: list[str], value_col: str) -> pl.DataFrame:
+        if name not in ds:
+            return pl.DataFrame()
+        return _dataarray_to_polars_long(ds[name], value_col, time_dtype)
+
+    # Timesteps from dt
+    dt_df = _read_da('dt', ['time'], 'dt')
+    timesteps_df = dt_df.select('time')
+    weights_df = _read_da('weight', ['time'], 'weight')
+
+    # Charge state times
+    if 'charge_state_times' in ds:
+        cs_vals = ds['charge_state_times'].values.tolist()
+        cs_times = pl.DataFrame({'time': pl.Series('time', cs_vals, dtype=time_dtype)})
+    else:
+        cs_times = pl.DataFrame({'time': pl.Series('time', [], dtype=time_dtype)})
+
+    # Flows
+    flow_lb_df = _read_da('flow_lb', ['flow', 'time'], 'value')
+    flow_ub_df = _read_da('flow_ub', ['flow', 'time'], 'value')
+
+    if len(flow_lb_df) > 0 and len(flow_ub_df) > 0:
+        relative_bounds = flow_lb_df.rename({'value': 'rel_lb'}).join(
+            flow_ub_df.rename({'value': 'rel_ub'}), on=['flow', 'time']
+        )
+    else:
+        relative_bounds = pl.DataFrame(
+            schema={'flow': pl.String, 'time': time_dtype, 'rel_lb': pl.Float64, 'rel_ub': pl.Float64}
+        )
+
+    if len(relative_bounds) > 0:
+        flow_index = pl.DataFrame({'flow': relative_bounds['flow'].unique().sort()})
+    else:
+        flow_index = pl.DataFrame({'flow': pl.Series([], dtype=pl.String)})
+
+    sizes_df = _read_da('flow_size', ['flow'], 'size')
+    if len(sizes_df) == 0:
+        sizes_df = pl.DataFrame(schema={'flow': pl.String, 'size': pl.Float64})
+
+    fixed_df = _read_da('flow_fixed', ['flow', 'time'], 'value')
+    if len(fixed_df) == 0:
+        fixed_df = pl.DataFrame(schema={'flow': pl.String, 'time': time_dtype, 'value': pl.Float64})
+
+    effect_coefficients = _read_da('effect_coeff', ['flow', 'effect', 'time'], 'coeff')
+    if len(effect_coefficients) == 0:
+        effect_coefficients = pl.DataFrame(
+            schema={'flow': pl.String, 'effect': pl.String, 'time': time_dtype, 'coeff': pl.Float64}
+        )
+
+    flows_table = FlowsTable(
+        index=flow_index,
+        sizes=sizes_df,
+        relative_bounds=relative_bounds,
+        fixed=fixed_df,
+        effect_coefficients=effect_coefficients,
+    )
+
+    # Buses
+    bus_coeffs = _read_da('bus_flow_coeff', ['bus', 'flow'], 'coeff')
+    if len(bus_coeffs) == 0:
+        bus_coeffs = pl.DataFrame(schema={'bus': pl.String, 'flow': pl.String, 'coeff': pl.Float64})
+    if len(bus_coeffs) > 0:
+        bus_index = pl.DataFrame({'bus': bus_coeffs['bus'].unique().sort()})
+    else:
+        bus_index = pl.DataFrame({'bus': pl.Series([], dtype=pl.String)})
+    buses_table = BusesTable(index=bus_index, flow_coefficients=bus_coeffs)
+
+    # Converters
+    conv_coeffs = _read_da('converter_flow_coeff', ['converter', 'eq_idx', 'flow', 'time'], 'coeff')
+    if len(conv_coeffs) == 0:
+        conv_coeffs = pl.DataFrame(
+            schema={
+                'converter': pl.String,
+                'eq_idx': pl.Int64,
+                'flow': pl.String,
+                'time': time_dtype,
+                'coeff': pl.Float64,
+            }
+        )
+    if len(conv_coeffs) > 0:
+        conv_index = pl.DataFrame({'converter': conv_coeffs['converter'].unique().sort()})
+    else:
+        conv_index = pl.DataFrame({'converter': pl.Series([], dtype=pl.String)})
+    converters_table = ConvertersTable(index=conv_index, flow_coefficients=conv_coeffs)
+
+    # Effects
+    effect_min_df = _read_da('effect_min_total', ['effect'], 'value')
+    effect_max_df = _read_da('effect_max_total', ['effect'], 'value')
+
+    if len(effect_min_df) > 0 and len(effect_max_df) > 0:
+        effects_bounds = effect_min_df.rename({'value': 'min_total'}).join(
+            effect_max_df.rename({'value': 'max_total'}), on='effect'
+        )
+    elif len(effect_min_df) > 0:
+        effects_bounds = effect_min_df.rename({'value': 'min_total'}).with_columns(
+            pl.lit(None).cast(pl.Float64).alias('max_total')
+        )
+    elif len(effect_max_df) > 0:
+        effects_bounds = (
+            effect_max_df.rename({'value': 'max_total'})
+            .with_columns(pl.lit(None).cast(pl.Float64).alias('min_total'))
+            .select('effect', 'min_total', 'max_total')
+        )
+    else:
+        effects_bounds = pl.DataFrame(schema={'effect': pl.String, 'min_total': pl.Float64, 'max_total': pl.Float64})
+
+    if len(effects_bounds) > 0:
+        effects_index = pl.DataFrame({'effect': effects_bounds['effect']})
+    else:
+        effects_index = pl.DataFrame({'effect': pl.Series([], dtype=pl.String)})
+
+    effect_time_lb = _read_da('effect_time_lb', ['effect', 'time'], 'value')
+    if len(effect_time_lb) == 0:
+        effect_time_lb = pl.DataFrame(schema={'effect': pl.String, 'time': time_dtype, 'value': pl.Float64})
+
+    effect_time_ub = _read_da('effect_time_ub', ['effect', 'time'], 'value')
+    if len(effect_time_ub) == 0:
+        effect_time_ub = pl.DataFrame(schema={'effect': pl.String, 'time': time_dtype, 'value': pl.Float64})
+
+    effects_table = EffectsTable(
+        index=effects_index,
+        objective_effect=objective_effect,
+        bounds=effects_bounds,
+        time_bounds_lb=effect_time_lb,
+        time_bounds_ub=effect_time_ub,
+    )
+
+    # Storages
+    stor_capacity = _read_da('storage_capacity', ['storage'], 'value')
+    if len(stor_capacity) > 0:
+        stor_initial = _read_da('storage_initial_charge', ['storage'], 'value')
+        stor_cyclic = _read_da('storage_cyclic', ['storage'], 'value')
+
+        storage_params = (
+            stor_capacity.rename({'value': 'capacity'})
+            .join(stor_initial.rename({'value': 'initial_charge'}), on='storage')
+            .join(stor_cyclic.rename({'value': 'cyclic'}), on='storage')
+            .with_columns(pl.col('cyclic').cast(pl.Boolean))
+        )
+        storage_index = pl.DataFrame({'storage': storage_params['storage']})
+
+        # Time params
+        eta_c = _read_da('storage_eta_c', ['storage', 'time'], 'value').rename({'value': 'eta_c'})
+        eta_d = _read_da('storage_eta_d', ['storage', 'time'], 'value').rename({'value': 'eta_d'})
+        loss = _read_da('storage_loss', ['storage', 'time'], 'value').rename({'value': 'loss'})
+
+        storage_time_params = eta_c.join(eta_d, on=['storage', 'time']).join(loss, on=['storage', 'time'])
+
+        # Flow map
+        charge_flow = _read_da('storage_charge_flow', ['storage'], 'value').rename({'value': 'charge_flow'})
+        discharge_flow = _read_da('storage_discharge_flow', ['storage'], 'value').rename({'value': 'discharge_flow'})
+        storage_flow_map = charge_flow.join(discharge_flow, on='storage')
+
+        # CS bounds
+        cs_lb = _read_da('storage_cs_lb', ['storage', 'time'], 'value')
+        cs_ub = _read_da('storage_cs_ub', ['storage', 'time'], 'value')
+        if len(cs_lb) > 0 and len(cs_ub) > 0:
+            cs_bounds = cs_lb.rename({'value': 'cs_lb'}).join(cs_ub.rename({'value': 'cs_ub'}), on=['storage', 'time'])
+        else:
+            cs_bounds = pl.DataFrame(
+                schema={'storage': pl.String, 'time': time_dtype, 'cs_lb': pl.Float64, 'cs_ub': pl.Float64}
+            )
+    else:
+        storage_index = pl.DataFrame({'storage': pl.Series([], dtype=pl.String)})
+        storage_params = pl.DataFrame(
+            schema={
+                'storage': pl.String,
+                'capacity': pl.Float64,
+                'initial_charge': pl.Float64,
+                'cyclic': pl.Boolean,
+            }
+        )
+        storage_time_params = pl.DataFrame(
+            schema={
+                'storage': pl.String,
+                'time': time_dtype,
+                'eta_c': pl.Float64,
+                'eta_d': pl.Float64,
+                'loss': pl.Float64,
+            }
+        )
+        storage_flow_map = pl.DataFrame(
+            schema={'storage': pl.String, 'charge_flow': pl.String, 'discharge_flow': pl.String}
+        )
+        cs_bounds = pl.DataFrame(
+            schema={'storage': pl.String, 'time': time_dtype, 'cs_lb': pl.Float64, 'cs_ub': pl.Float64}
+        )
+
+    storages_table = StoragesTable(
+        index=storage_index,
+        params=storage_params,
+        time_params=storage_time_params,
+        flow_map=storage_flow_map,
+        cs_bounds=cs_bounds,
+    )
+
+    return ModelData(
+        flows=flows_table,
+        buses=buses_table,
+        converters=converters_table,
+        effects=effects_table,
+        storages=storages_table,
+        timesteps=timesteps_df,
+        dt=dt_df,
+        weights=weights_df,
+        charge_state_times=cs_times,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def solved_model_to_netcdf(result: SolvedModel, path: str | Path) -> None:
+    """Write a SolvedModel to a NetCDF file (solution in root group, model data in 'model' group)."""
+    path = Path(path)
+
+    # Write solution to root group
+    ds = solved_model_to_xarray(result)
+    ds.to_netcdf(path, mode='w')
+
+    # Write model data to 'model' group
+    if result.data is not None:
+        _write_model_data(result.data, path)
+
+
+def solved_model_from_netcdf(path: str | Path) -> SolvedModel:
+    """Read a SolvedModel from a NetCDF file."""
+    _xr = _require_xarray()
+    from fluxopt.results import SolvedModel
+
+    path = Path(path)
+
+    # Read solution from root group
+    ds = _xr.open_dataset(path)
+
+    objective_value: float = float(ds.attrs['objective_value'])
+    time_dtype_label: str = ds.attrs.get('time_dtype', 'datetime')
+    time_dtype: pl.DataType = pl.Int64() if time_dtype_label == 'int64' else pl.Datetime()
+
+    # Flow rates
+    if 'flow_rates' in ds:
+        flow_rates = _dataarray_to_polars_long(ds['flow_rates'], 'solution', time_dtype)
+    else:
+        flow_rates = pl.DataFrame(schema={'flow': pl.String, 'time': time_dtype, 'solution': pl.Float64})
+
+    # Charge states
+    if 'charge_states' in ds:
+        cs_df = _dataarray_to_polars_long(ds['charge_states'], 'solution')
+        # Rename cs_time -> time
+        if 'cs_time' in cs_df.columns:
+            cs_df = cs_df.rename({'cs_time': 'time'})
+        if 'time' in cs_df.columns:
+            cs_df = cs_df.with_columns(pl.col('time').cast(time_dtype))
+        charge_states = cs_df
+    else:
+        charge_states = pl.DataFrame(schema={'storage': pl.String, 'time': time_dtype, 'solution': pl.Float64})
+
+    # Effects
+    if 'effects' in ds:
+        effects = _dataarray_to_polars_long(ds['effects'], 'solution')
+    else:
+        effects = pl.DataFrame(schema={'effect': pl.String, 'solution': pl.Float64})
+
+    # Effects per timestep
+    if 'effects_per_timestep' in ds:
+        effects_per_timestep = _dataarray_to_polars_long(ds['effects_per_timestep'], 'solution', time_dtype)
+    else:
+        effects_per_timestep = pl.DataFrame(schema={'effect': pl.String, 'time': time_dtype, 'solution': pl.Float64})
+
+    # Contributions
+    if 'contributions' in ds:
+        contributions = _dataarray_to_polars_long(ds['contributions'], 'solution', time_dtype)
+    else:
+        contributions = pl.DataFrame(
+            schema={
+                'source': pl.String,
+                'contributor': pl.String,
+                'effect': pl.String,
+                'time': time_dtype,
+                'solution': pl.Float64,
+            }
+        )
+
+    ds.close()
+
+    # Read model data if 'model' group exists
+    data: ModelData | None = None
+    with contextlib.suppress(Exception):
+        data = _read_model_data(path, time_dtype)
+
+    return SolvedModel(
+        objective_value=objective_value,
+        flow_rates=flow_rates,
+        charge_states=charge_states,
+        effects=effects,
+        effects_per_timestep=effects_per_timestep,
+        contributions=contributions,
+        data=data,
+    )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+xr = pytest.importorskip('xarray')
+
+from fluxopt import Bus, Converter, Effect, Flow, Port, Storage, solve
+
+
+@pytest.fixture
+def tmp_nc(tmp_path: Path) -> Path:
+    return tmp_path / 'result.nc'
+
+
+def _solve_simple(timesteps: list[datetime] | list[int]) -> solve:
+    """Simple source → demand system with cost tracking."""
+    demand = Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])
+    source = Flow(bus='elec', size=200, effects_per_flow_hour={'cost': 0.04})
+    return solve(
+        timesteps=timesteps,
+        buses=[Bus('elec')],
+        effects=[Effect('cost', is_objective=True)],
+        ports=[Port('grid', imports=[source]), Port('demand', exports=[demand])],
+    )
+
+
+def _solve_with_converter(timesteps: list[datetime]) -> solve:
+    """Gas source → boiler → heat demand with cost tracking."""
+    demand = Flow(bus='heat', size=100, fixed_relative_profile=[0.4, 0.7, 0.5])
+    gas_source = Flow(bus='gas', size=500, effects_per_flow_hour={'cost': 0.04})
+    fuel = Flow(bus='gas', size=300)
+    heat = Flow(bus='heat', size=200)
+    return solve(
+        timesteps=timesteps,
+        buses=[Bus('gas'), Bus('heat')],
+        effects=[Effect('cost', is_objective=True)],
+        ports=[Port('grid', imports=[gas_source]), Port('demand', exports=[demand])],
+        converters=[Converter.boiler('boiler', 0.9, fuel, heat)],
+    )
+
+
+def _solve_with_storage(timesteps: list[datetime]) -> solve:
+    """Boiler + storage system."""
+    demand = Flow(bus='heat', size=100, fixed_relative_profile=[0.5, 0.5, 0.5])
+    gas_source = Flow(bus='gas', size=500, effects_per_flow_hour={'cost': [0.02, 0.08, 0.02]})
+    fuel = Flow(bus='gas', size=300)
+    heat_out = Flow(bus='heat', size=200)
+    charge = Flow(bus='heat', size=100)
+    discharge = Flow(bus='heat', size=100)
+    storage = Storage('heat_store', charging=charge, discharging=discharge, capacity=200.0)
+    return solve(
+        timesteps=timesteps,
+        buses=[Bus('gas'), Bus('heat')],
+        effects=[Effect('cost', is_objective=True)],
+        ports=[Port('grid', imports=[gas_source]), Port('demand', exports=[demand])],
+        converters=[Converter.boiler('boiler', 0.9, fuel, heat_out)],
+        storages=[storage],
+    )
+
+
+class TestRoundtrip:
+    def test_simple_datetime(self, tmp_nc: Path) -> None:
+        """Roundtrip: simple model with datetime timesteps."""
+        ts = [datetime(2024, 1, 1, h) for h in range(3)]
+        result = _solve_simple(ts)
+
+        result.to_netcdf(tmp_nc)
+        loaded = type(result).from_netcdf(tmp_nc)
+
+        assert loaded.objective_value == pytest.approx(result.objective_value, abs=1e-6)
+        assert loaded.flow_rates['solution'].to_list() == pytest.approx(
+            result.flow_rates['solution'].to_list(), abs=1e-6
+        )
+        assert loaded.effects['solution'].to_list() == pytest.approx(result.effects['solution'].to_list(), abs=1e-6)
+        assert loaded.effects_per_timestep['solution'].to_list() == pytest.approx(
+            result.effects_per_timestep['solution'].to_list(), abs=1e-6
+        )
+
+    def test_simple_int_timesteps(self, tmp_nc: Path) -> None:
+        """Roundtrip with integer timesteps."""
+        result = _solve_simple([0, 1, 2])
+
+        result.to_netcdf(tmp_nc)
+        loaded = type(result).from_netcdf(tmp_nc)
+
+        assert loaded.objective_value == pytest.approx(result.objective_value, abs=1e-6)
+        assert loaded.flow_rates['time'].dtype == pl.Int64
+
+    def test_with_converter(self, tmp_nc: Path) -> None:
+        """Roundtrip: model with converter."""
+        ts = [datetime(2024, 1, 1, h) for h in range(3)]
+        result = _solve_with_converter(ts)
+
+        result.to_netcdf(tmp_nc)
+        loaded = type(result).from_netcdf(tmp_nc)
+
+        assert loaded.objective_value == pytest.approx(result.objective_value, abs=1e-6)
+        assert len(loaded.flow_rates) == len(result.flow_rates)
+        assert len(loaded.contributions) == len(result.contributions)
+
+    def test_with_storage(self, tmp_nc: Path) -> None:
+        """Roundtrip: model with storage."""
+        ts = [datetime(2024, 1, 1, h) for h in range(3)]
+        result = _solve_with_storage(ts)
+
+        result.to_netcdf(tmp_nc)
+        loaded = type(result).from_netcdf(tmp_nc)
+
+        assert loaded.objective_value == pytest.approx(result.objective_value, abs=1e-6)
+        assert len(loaded.charge_states) == len(result.charge_states)
+        assert loaded.charge_states['solution'].to_list() == pytest.approx(
+            result.charge_states['solution'].to_list(), abs=1e-6
+        )
+
+    def test_contributions_roundtrip(self, tmp_nc: Path) -> None:
+        """Verify contributions survive roundtrip."""
+        ts = [datetime(2024, 1, 1, h) for h in range(3)]
+        result = _solve_with_converter(ts)
+        assert len(result.contributions) > 0
+
+        result.to_netcdf(tmp_nc)
+        loaded = type(result).from_netcdf(tmp_nc)
+
+        # Same shape
+        assert len(loaded.contributions) == len(result.contributions)
+        # Same total
+        assert loaded.contributions['solution'].sum() == pytest.approx(result.contributions['solution'].sum(), abs=1e-6)
+
+
+class TestXarrayDataset:
+    def test_root_group_shows_solution(self, tmp_nc: Path) -> None:
+        """xr.open_dataset(path) shows solution data by default."""
+        ts = [datetime(2024, 1, 1, h) for h in range(3)]
+        result = _solve_simple(ts)
+        result.to_netcdf(tmp_nc)
+
+        ds = xr.open_dataset(tmp_nc)
+        assert 'flow_rates' in ds
+        assert 'effects' in ds
+        assert 'objective_value' in ds.attrs
+        ds.close()
+
+    def test_model_group_accessible(self, tmp_nc: Path) -> None:
+        """xr.open_dataset(path, group='model') shows model data."""
+        ts = [datetime(2024, 1, 1, h) for h in range(3)]
+        result = _solve_simple(ts)
+        result.to_netcdf(tmp_nc)
+
+        ds = xr.open_dataset(tmp_nc, group='model')
+        assert 'dt' in ds
+        assert 'weight' in ds
+        assert 'flow_lb' in ds
+        ds.close()
+
+    def test_to_xarray_returns_dataset(self) -> None:
+        """to_xarray() returns an xr.Dataset with solution data."""
+        ts = [datetime(2024, 1, 1, h) for h in range(3)]
+        result = _solve_simple(ts)
+
+        ds = result.to_xarray()
+        assert isinstance(ds, xr.Dataset)
+        assert 'flow_rates' in ds
+        assert ds.attrs['objective_value'] == pytest.approx(result.objective_value)
+
+
+class TestModelDataRoundtrip:
+    def test_model_data_preserved(self, tmp_nc: Path) -> None:
+        """Model data is preserved through roundtrip."""
+        ts = [datetime(2024, 1, 1, h) for h in range(3)]
+        result = _solve_simple(ts)
+        assert result.data is not None
+
+        result.to_netcdf(tmp_nc)
+        loaded = type(result).from_netcdf(tmp_nc)
+
+        assert loaded.data is not None
+        assert loaded.data.effects.objective_effect == result.data.effects.objective_effect
+        assert len(loaded.data.flows.relative_bounds) == len(result.data.flows.relative_bounds)
+        assert loaded.data.dt['dt'].to_list() == pytest.approx(result.data.dt['dt'].to_list())
+
+    def test_storage_model_data(self, tmp_nc: Path) -> None:
+        """Storage model data is preserved through roundtrip."""
+        ts = [datetime(2024, 1, 1, h) for h in range(3)]
+        result = _solve_with_storage(ts)
+        assert result.data is not None
+
+        result.to_netcdf(tmp_nc)
+        loaded = type(result).from_netcdf(tmp_nc)
+
+        assert loaded.data is not None
+        assert len(loaded.data.storages.params) == len(result.data.storages.params)
+        assert loaded.data.storages.params['capacity'].to_list() == result.data.storages.params['capacity'].to_list()
+
+
+class TestEdgeCases:
+    def test_no_data_field(self, tmp_nc: Path) -> None:
+        """SolvedModel without data field still serializes solution."""
+        ts = [datetime(2024, 1, 1, h) for h in range(3)]
+        result = _solve_simple(ts)
+        result.data = None
+
+        result.to_netcdf(tmp_nc)
+        loaded = type(result).from_netcdf(tmp_nc)
+
+        assert loaded.objective_value == pytest.approx(result.objective_value, abs=1e-6)
+        # Model data is None since it wasn't written
+        assert loaded.data is None


### PR DESCRIPTION
  - pyproject.toml — Added [project.optional-dependencies] io = ["xarray>=2024.1.0", "netcdf4>=1.6.0"] and mypy ignore for xarray.*, netCDF4.*
  - src/fluxopt/results.py — Added data: ModelData | None field to SolvedModel, updated from_model() to pass data=model.data, added to_xarray(), to_netcdf(path), and from_netcdf(path) methods
  - src/fluxopt/io.py — New file with all IO logic:
    - _require_xarray() — import guard with helpful error
    - _polars_long_to_dataarray() / _dataarray_to_polars_long() — generic Polars↔xarray converters
    - solved_model_to_xarray() — solution data → xr.Dataset
    - solved_model_to_netcdf() — writes root group (solution) + model group (inputs)
    - solved_model_from_netcdf() — reads back to SolvedModel with data populated
  - tests/test_io.py — 11 tests covering: datetime/int roundtrips, converter models, storage models, contributions, xarray Dataset access (root + model groups), model data preservation, and edge case (no data field)

  Verification: 83/83 tests pass, ruff clean, mypy clean.

## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Related Issues
Closes #(issue number)

## Testing
- [ ] I have tested my changes
- [ ] Existing tests still pass

## Checklist
- [x] My code follows the project style
- [x] I have updated documentation if needed
- [x] I have added tests for new functionality (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Solved models can now be exported to NetCDF files and imported back, enabling persistent storage and later retrieval.
  * New methods provide xarray dataset representation of results for advanced analysis workflows.
  * Optional "io" dependency group includes xarray and netCDF4 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->