### PR TITLE
Add per-contributor effect breakdown and split effect domains

### DIFF
--- a/docs/guide/effects.md
+++ b/docs/guide/effects.md
@@ -140,6 +140,34 @@ print(result.effects_temporal)
 print(result.effects_periodic)
 ```
 
+### Per-Flow Breakdown
+
+`effect_contributions()` decomposes effect totals into per-flow contributions,
+including cross-effect propagation:
+
+```python
+contrib = result.effect_contributions()
+
+# Per-flow operational contributions (flow, effect, time)
+contrib['operational']
+
+# Per-flow investment contributions (flow, effect)
+contrib['investment']
+
+# Storage investment contributions (storage, effect) — only if storages present
+contrib['storage_investment']
+
+# Total per flow: operational summed over time + investment (flow, effect)
+contrib['total']
+```
+
+The contributions are validated against the solver totals — if they don't sum
+to `effect_totals`, a `ValueError` is raised.
+
+Cross-effects (e.g., CO₂ → cost) are attributed to the originating flow. If
+a gas flow emits CO₂ priced at 50 €/kg, its cost contribution includes both
+the direct cost and the carbon tax portion.
+
 ## Full Example
 
 Two sources with different cost/CO2 tradeoffs, subject to an emission cap:

--- a/docs/guide/effects.md
+++ b/docs/guide/effects.md
@@ -133,8 +133,11 @@ print(result.objective)
 # Total effect values as (effect,) DataArray
 print(result.effect_totals)
 
-# Per-timestep effect values as (effect, time) DataArray
-print(result.effects_per_timestep)
+# Temporal: per-timestep effect values as (effect, time) DataArray
+print(result.effects_temporal)
+
+# Periodic: investment effect values as (effect,) DataArray
+print(result.effects_periodic)
 ```
 
 ## Full Example
@@ -180,5 +183,5 @@ print(result.effect_totals)
 | `minimum_total` | `float \| None` | `None` | Lower bound on total |
 | `maximum_per_hour` | `TimeSeries \| None` | `None` | Upper bound per timestep |
 | `minimum_per_hour` | `TimeSeries \| None` | `None` | Lower bound per timestep |
-| `contribution_from` | `dict[str, float]` | `{}` | Scalar cross-effect factors (invest + per-hour) |
-| `contribution_from_per_hour` | `dict[str, TimeSeries]` | `{}` | Time-varying cross-effect factors (per-hour only) |
+| `contribution_from` | `dict[str, float]` | `{}` | Scalar cross-effect factors (temporal + periodic) |
+| `contribution_from_per_hour` | `dict[str, TimeSeries]` | `{}` | Time-varying cross-effect factors (temporal only) |

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -105,7 +105,7 @@ print(result.flow_rates)
 print(result.effect_totals)
 
 # Per-timestep effects
-print(result.effects_per_timestep)
+print(result.effects_temporal)
 ```
 
 Flow ids are qualified as `{component}({bus_or_id})` — e.g., `boiler(gas)`,

--- a/docs/math/effects.md
+++ b/docs/math/effects.md
@@ -9,7 +9,7 @@ minimize.
 Effects are split into two **domains**:
 
 - **Temporal** (with time dimension): per-timestep flow contributions, status costs
-- **Periodic** (without time dimension): investment costs from sizing
+- **Periodic** (without time dimension): sizing costs, fixed yearly costs
 
 Both domains support cross-effect chains via `contribution_from`.
 
@@ -31,7 +31,7 @@ multi-level chains (e.g., PE → CO₂ → cost) automatically.
 
 ## Periodic Domain
 
-Investment costs from sizing (per-size and fixed) are accumulated per effect:
+Sizing costs and fixed costs (not time-varying) are accumulated per effect:
 
 \[
 \Phi_k^{\text{periodic}} = \underbrace{\Phi_k^{\text{invest,direct}}}_{\text{direct sizing costs}} + \underbrace{\sum_{j \in \mathcal{K}} \alpha_{k,j} \cdot \Phi_j^{\text{periodic}}}_{\text{cross-effect contributions}} \quad \forall \, k
@@ -44,7 +44,7 @@ where the direct investment term is:
 \]
 
 Because \(\Phi_k^{\text{periodic}}\) is a **variable** (not an expression), the
-solver resolves multi-level investment chains correctly: if PE has investment costs
+solver resolves multi-level chains correctly: if PE has sizing costs
 and CO₂ depends on PE and cost depends on CO₂, the chain propagates through the
 periodic domain just as it does through the temporal domain.
 
@@ -98,7 +98,7 @@ This enforces per-hour limits (e.g., maximum hourly emissions).
 | Symbol | Description | Reference |
 |---|---|---|
 | \(\Phi_{k,t}^{\text{temporal}}\) | Per-timestep effect variable | `effect_temporal[effect, time]` |
-| \(\Phi_k^{\text{periodic}}\) | Per-period (investment) effect variable | `effect_periodic[effect]` |
+| \(\Phi_k^{\text{periodic}}\) | Periodic effect variable (sizing, fixed costs) | `effect_periodic[effect]` |
 | \(\Phi_k\) | Total effect variable | `effect_total[effect]` |
 | \(c_{f,k,t}\) | Effect coefficient per flow-hour | `Flow.effects_per_flow_hour` |
 | \(\alpha_{k,j,t}\) | Cross-effect contribution factor (per hour) | `Effect.contribution_from_per_hour` |

--- a/docs/math/effects.md
+++ b/docs/math/effects.md
@@ -6,16 +6,47 @@ Effects represent quantities that are tracked across the optimization horizon (e
 cost, CO₂ emissions, primary energy). One effect is designated as the objective to
 minimize.
 
-## Per-Timestep Tracking
+Effects are split into two **domains**:
+
+- **Temporal** (with time dimension): per-timestep flow contributions, status costs
+- **Periodic** (without time dimension): investment costs from sizing
+
+Both domains support cross-effect chains via `contribution_from`.
+
+## Temporal Domain
 
 Each effect accumulates contributions from all flows at each timestep:
 
 \[
-\Phi_{k,t} = \sum_{f \in \mathcal{F}} c_{f,k,t} \cdot P_{f,t} \cdot \Delta t_t \quad \forall \, k \in \mathcal{K}, \; t \in \mathcal{T}
+\Phi_{k,t}^{\text{temporal}} = \underbrace{\sum_{f \in \mathcal{F}} c_{f,k,t} \cdot P_{f,t} \cdot \Delta t_t}_{\text{direct flow contributions}} + \underbrace{\sum_{j \in \mathcal{K}} \alpha_{k,j,t} \cdot \Phi_{j,t}^{\text{temporal}}}_{\text{cross-effect contributions}} \quad \forall \, k, t
 \]
 
 The coefficient \(c_{f,k,t}\) specifies how much of effect \(k\) is produced per
 flow-hour of flow \(f\) (e.g., €/MWh for cost, kg/MWh for emissions).
+
+The cross-effect factor \(\alpha_{k,j,t}\) can be time-varying
+(`contribution_from_per_hour`) or constant (`contribution_from`).
+Because \(\Phi_{k,t}^{\text{temporal}}\) is a **variable**, the solver resolves
+multi-level chains (e.g., PE → CO₂ → cost) automatically.
+
+## Periodic Domain
+
+Investment costs from sizing (per-size and fixed) are accumulated per effect:
+
+\[
+\Phi_k^{\text{periodic}} = \underbrace{\Phi_k^{\text{invest,direct}}}_{\text{direct sizing costs}} + \underbrace{\sum_{j \in \mathcal{K}} \alpha_{k,j} \cdot \Phi_j^{\text{periodic}}}_{\text{cross-effect contributions}} \quad \forall \, k
+\]
+
+where the direct investment term is:
+
+\[
+\Phi_k^{\text{invest,direct}} = \sum_{f} \gamma_{f,k} \cdot S_f + \sum_{f} \phi_{f,k} \cdot y_f + \sum_{s} \gamma_{s,k} \cdot S_s + \sum_{s} \phi_{s,k} \cdot y_s
+\]
+
+Because \(\Phi_k^{\text{periodic}}\) is a **variable** (not an expression), the
+solver resolves multi-level investment chains correctly: if PE has investment costs
+and CO₂ depends on PE and cost depends on CO₂, the chain propagates through the
+periodic domain just as it does through the temporal domain.
 
 ## Cross-Effect Contributions
 
@@ -23,30 +54,9 @@ An effect can include a weighted fraction of another effect's value via
 `contribution_from`. This enables patterns like carbon pricing (CO₂ → cost)
 or transitive chains (PE → CO₂ → cost).
 
-### Per-Timestep
-
-The per-timestep tracking becomes:
-
-\[
-\Phi_{k,t} = \underbrace{\sum_{f \in \mathcal{F}} c_{f,k,t} \cdot P_{f,t} \cdot \Delta t_t}_{\text{direct flow contributions}} + \underbrace{\sum_{j \in \mathcal{K}} \alpha_{k,j,t} \cdot \Phi_{j,t}}_{\text{cross-effect contributions}} \quad \forall \, k, t
-\]
-
-where \(\alpha_{k,j,t}\) is the contribution factor from source effect \(j\) to
-target effect \(k\) at timestep \(t\). This factor can be time-varying
-(`contribution_from_per_hour`) or constant (`contribution_from`, applied to both
-invest and per-hour).
-
-### Investment
-
-Cross-effect contributions also apply to investment costs:
-
-\[
-\Phi_k^{\text{invest,cross}} = \sum_{j \in \mathcal{K}} \alpha_{k,j} \cdot \Phi_j^{\text{invest,direct}}
-\]
-
-where \(\alpha_{k,j}\) is the scalar contribution factor from `contribution_from`,
-and \(\Phi_j^{\text{invest,direct}}\) is the direct investment cost of effect \(j\)
-(from `Sizing.effects_per_size` and `Sizing.effects_fixed`).
+The scalar factor \(\alpha_{k,j}\) from `contribution_from` applies to **both**
+domains. The time-varying factor from `contribution_from_per_hour` overrides the
+temporal factor only.
 
 ### Validation
 
@@ -55,10 +65,10 @@ Self-references (\(\alpha_{k,k}\)) and circular dependencies
 
 ## Total Aggregation
 
-The total effect sums per-timestep values, weights, and investment contributions:
+The total effect combines both domains:
 
 \[
-\Phi_k = \sum_{t \in \mathcal{T}} \Phi_{k,t} \cdot w_t + \Phi_k^{\text{invest,direct}} + \Phi_k^{\text{invest,cross}} \quad \forall \, k \in \mathcal{K}
+\Phi_k = \sum_{t \in \mathcal{T}} \Phi_{k,t}^{\text{temporal}} \cdot w_t + \Phi_k^{\text{periodic}} \quad \forall \, k \in \mathcal{K}
 \]
 
 Weights \(w_t\) allow scaling timesteps (e.g., a representative week scaled to a year).
@@ -87,7 +97,8 @@ This enforces per-hour limits (e.g., maximum hourly emissions).
 
 | Symbol | Description | Reference |
 |---|---|---|
-| \(\Phi_{k,t}\) | Per-timestep effect variable | `effect_per_timestep[effect, time]` |
+| \(\Phi_{k,t}^{\text{temporal}}\) | Per-timestep effect variable | `effect_temporal[effect, time]` |
+| \(\Phi_k^{\text{periodic}}\) | Per-period (investment) effect variable | `effect_periodic[effect]` |
 | \(\Phi_k\) | Total effect variable | `effect_total[effect]` |
 | \(c_{f,k,t}\) | Effect coefficient per flow-hour | `Flow.effects_per_flow_hour` |
 | \(\alpha_{k,j,t}\) | Cross-effect contribution factor (per hour) | `Effect.contribution_from_per_hour` |

--- a/docs/math/notation.md
+++ b/docs/math/notation.md
@@ -19,7 +19,8 @@ Each symbol maps to a specific field or variable in the code.
 |---|---|---|---|---|
 | \(P_{f,t}\) | `flow_rate[flow, time]` | \(\geq 0\) | MW | Flow rate |
 | \(E_{s,t}\) | `storage--level[storage, time]` | \(\geq 0\) | MWh | Stored energy |
-| \(\Phi_{k,t}\) | `effect_per_timestep[effect, time]` | \(\mathbb{R}\) | varies | Per-timestep effect |
+| \(\Phi_{k,t}^{\text{temporal}}\) | `effect_temporal[effect, time]` | \(\mathbb{R}\) | varies | Temporal (per-timestep) effect |
+| \(\Phi_k^{\text{periodic}}\) | `effect_periodic[effect]` | \(\mathbb{R}\) | varies | Periodic (investment) effect |
 | \(\Phi_k\) | `effect_total[effect]` | \(\mathbb{R}\) | varies | Total effect over horizon |
 | \(S_f\) | `flow_size[flow]` | \(\geq 0\) | MW | Invested flow capacity |
 | \(y_f\) | `flow_size_indicator[flow]` | \(\{0, 1\}\) | — | Binary invest indicator (flow) |

--- a/docs/math/objective.md
+++ b/docs/math/objective.md
@@ -9,23 +9,23 @@ The model minimizes the total value of the designated objective effect \(k^*\)
 \min \; \Phi_{k^*}
 \]
 
-The total effect aggregates per-timestep contributions, weights, and investment:
+The total effect combines the temporal and periodic domains:
 
 \[
-\Phi_k = \sum_{t \in \mathcal{T}} \Phi_{k,t} \cdot w_t + \Phi_k^{\text{invest,direct}} + \Phi_k^{\text{invest,cross}}
+\Phi_k = \sum_{t \in \mathcal{T}} \Phi_{k,t}^{\text{temporal}} \cdot w_t + \Phi_k^{\text{periodic}}
 \]
 
-Each per-timestep effect is the sum of flow contributions, status costs, and
-cross-effect contributions:
+The **temporal** domain accumulates flow contributions, status costs, and
+cross-effect contributions per timestep:
 
 \[
-\Phi_{k,t} = \underbrace{\sum_{f} c_{f,k,t} \cdot P_{f,t} \cdot \Delta t_t}_{\text{flow}} + \underbrace{\sum_{f} r_{f,k,t} \cdot \sigma_{f,t} \cdot \Delta t_t}_{\text{running}} + \underbrace{\sum_{f} u_{f,k,t} \cdot \tau^+_{f,t}}_{\text{startup}} + \underbrace{\sum_{j} \alpha_{k,j,t} \cdot \Phi_{j,t}}_{\text{cross-effect}}
+\Phi_{k,t}^{\text{temporal}} = \underbrace{\sum_{f} c_{f,k,t} \cdot P_{f,t} \cdot \Delta t_t}_{\text{flow}} + \underbrace{\sum_{f} r_{f,k,t} \cdot \sigma_{f,t} \cdot \Delta t_t}_{\text{running}} + \underbrace{\sum_{f} u_{f,k,t} \cdot \tau^+_{f,t}}_{\text{startup}} + \underbrace{\sum_{j} \alpha_{k,j,t} \cdot \Phi_{j,t}^{\text{temporal}}}_{\text{cross-effect}}
 \]
 
-Investment effects feed into the total via per-size and fixed costs:
+The **periodic** domain accumulates investment costs and cross-effect contributions:
 
 \[
-\Phi_k^{\text{invest,direct}} = \sum_{f} \gamma_{f,k} \cdot S_f + \sum_{f} \phi_{f,k} \cdot y_f + \sum_{s} \gamma_{s,k} \cdot S_s + \sum_{s} \phi_{s,k} \cdot y_s
+\Phi_k^{\text{periodic}} = \underbrace{\sum_{f} \gamma_{f,k} \cdot S_f + \sum_{f} \phi_{f,k} \cdot y_f + \sum_{s} \gamma_{s,k} \cdot S_s + \sum_{s} \phi_{s,k} \cdot y_s}_{\text{direct sizing costs}} + \underbrace{\sum_{j} \alpha_{k,j} \cdot \Phi_j^{\text{periodic}}}_{\text{cross-effect}}
 \]
 
 See [Sizing](sizing.md), [Status](status.md), and [Effects](effects.md) for
@@ -40,7 +40,8 @@ full formulations of each term.
 | \(P_{f,t}\) | Flow rate variable | `flow_rate[flow, time]` |
 | \(\Delta t_t\) | Timestep duration | dt |
 | \(w_t\) | Timestep weight | weights |
-| \(\Phi_{k,t}\) | Per-timestep effect variable | `effect_per_timestep[effect, time]` |
+| \(\Phi_{k,t}^{\text{temporal}}\) | Temporal (per-timestep) effect variable | `effect_temporal[effect, time]` |
+| \(\Phi_k^{\text{periodic}}\) | Periodic (investment) effect variable | `effect_periodic[effect]` |
 | \(\Phi_k\) | Total effect variable | `effect_total[effect]` |
 
 See [Notation](notation.md) for the full symbol table.

--- a/docs/math/objective.md
+++ b/docs/math/objective.md
@@ -22,7 +22,7 @@ cross-effect contributions per timestep:
 \Phi_{k,t}^{\text{temporal}} = \underbrace{\sum_{f} c_{f,k,t} \cdot P_{f,t} \cdot \Delta t_t}_{\text{flow}} + \underbrace{\sum_{f} r_{f,k,t} \cdot \sigma_{f,t} \cdot \Delta t_t}_{\text{running}} + \underbrace{\sum_{f} u_{f,k,t} \cdot \tau^+_{f,t}}_{\text{startup}} + \underbrace{\sum_{j} \alpha_{k,j,t} \cdot \Phi_{j,t}^{\text{temporal}}}_{\text{cross-effect}}
 \]
 
-The **periodic** domain accumulates investment costs and cross-effect contributions:
+The **periodic** domain accumulates sizing costs, fixed costs, and cross-effect contributions:
 
 \[
 \Phi_k^{\text{periodic}} = \underbrace{\sum_{f} \gamma_{f,k} \cdot S_f + \sum_{f} \phi_{f,k} \cdot y_f + \sum_{s} \gamma_{s,k} \cdot S_s + \sum_{s} \phi_{s,k} \cdot y_s}_{\text{direct sizing costs}} + \underbrace{\sum_{j} \alpha_{k,j} \cdot \Phi_j^{\text{periodic}}}_{\text{cross-effect}}
@@ -41,7 +41,7 @@ full formulations of each term.
 | \(\Delta t_t\) | Timestep duration | dt |
 | \(w_t\) | Timestep weight | weights |
 | \(\Phi_{k,t}^{\text{temporal}}\) | Temporal (per-timestep) effect variable | `effect_temporal[effect, time]` |
-| \(\Phi_k^{\text{periodic}}\) | Periodic (investment) effect variable | `effect_periodic[effect]` |
+| \(\Phi_k^{\text{periodic}}\) | Periodic effect variable (sizing, fixed costs) | `effect_periodic[effect]` |
 | \(\Phi_k\) | Total effect variable | `effect_total[effect]` |
 
 See [Notation](notation.md) for the full symbol table.

--- a/docs/notebooks/01-quickstart.ipynb
+++ b/docs/notebooks/01-quickstart.ipynb
@@ -242,7 +242,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = result.effects_per_timestep.to_dataframe('EUR').reset_index()\n",
+    "df = result.effects_temporal.to_dataframe('EUR').reset_index()\n",
     "px.bar(df, x='time', y='EUR', color='effect', title='Effects per Timestep')"
    ]
   },
@@ -258,7 +258,7 @@
     "1. **Define** flows with size, bounds, and cost coefficients\n",
     "2. **Group** flows into ports (sources/sinks) and converters\n",
     "3. **Optimize** with `optimize(timesteps, buses, effects, ports, converters)`\n",
-    "4. **Inspect** results via `result.flow_rates`, `result.effect_totals`, `result.effects_per_timestep`\n",
+    "4. **Inspect** results via `result.flow_rates`, `result.effect_totals`, `result.effects_temporal`\n",
     "\n",
     "### Next Steps\n",
     "\n",

--- a/docs/notebooks/02-heat-system.ipynb
+++ b/docs/notebooks/02-heat-system.ipynb
@@ -291,7 +291,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = result.effects_per_timestep.to_dataframe('EUR').reset_index()\n",
+    "df = result.effects_temporal.to_dataframe('EUR').reset_index()\n",
     "px.bar(df, x='time', y='EUR', color='effect', title='Effects per Timestep')"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dev = [
     "pre-commit==4.5.1",
     "pytest==9.0.2",
     "pytest-cov==7.0.0",
-    "pytest-xdist==3.6.1",
+    "pytest-xdist==3.8.0",
     "ruff==0.15.0",
 ]
 viz = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dev = [
     "pre-commit==4.5.1",
     "pytest==9.0.2",
     "pytest-cov==7.0.0",
+    "pytest-xdist==3.6.1",
     "ruff==0.15.0",
 ]
 viz = [
@@ -144,6 +145,7 @@ module = [
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
+addopts = "-n auto"
 markers = [
     "slow: marks tests as slow",
 ]

--- a/scripts/explore_pyoframe_dims.py
+++ b/scripts/explore_pyoframe_dims.py
@@ -1,0 +1,177 @@
+"""Explore how pyoframe handles expressions with differing dimensions.
+
+Goal: Can we accumulate effect contributions from different sources where each
+source has different sparsity (not every source contributes to every effect)?
+
+Findings:
+- Pyoframe requires explicit dimension alignment for addition
+- .keep_extras() on the LARGER expression preserves its unmatched rows
+- The accumulator pattern: acc.keep_extras() + sparse_contrib at each step
+- Alternative: build full (effect, time, contributor) Param and .sum('contributor')
+"""
+
+import polars as pl
+import pyoframe as pf
+
+effects = pl.DataFrame({'effect': ['costs', 'co2']})
+times = pl.DataFrame({'time': [0, 1, 2]})
+flows = pl.DataFrame({'flow': ['boiler(gas)', 'grid(elec)']})
+comps = pl.DataFrame({'comp': ['boiler', 'grid']})
+
+m = pf.Model('highs')
+m.flow_rate = pf.Variable(flows, times, lb=0)
+m.on_off = pf.Variable(comps, times, lb=0, ub=1)
+
+# ---------------------------------------------------------------------------
+# 1. Contributors with different sparsity
+# ---------------------------------------------------------------------------
+print('=== 1. Build contributions with different effect coverage ===\n')
+
+# Flow costs: covers BOTH effects (costs, co2)
+flow_coeffs = pl.DataFrame(
+    {
+        'effect': ['costs', 'costs', 'co2', 'co2'],
+        'flow': ['boiler(gas)', 'grid(elec)', 'boiler(gas)', 'grid(elec)'],
+        'value': [50.0, 80.0, 0.5, 1.2],
+    }
+)
+flow_contrib = (pf.Param(flow_coeffs) * m.flow_rate).sum('flow')
+print(
+    f'flow_contrib covers: costs, co2  (shape: effect={flow_contrib.data["effect"].n_unique()}, time={flow_contrib.data["time"].n_unique()})'
+)
+
+# Status costs: covers ONLY 'costs'
+status_coeffs = pl.DataFrame(
+    {
+        'effect': ['costs', 'costs'],
+        'comp': ['boiler', 'grid'],
+        'value': [5.0, 2.0],
+    }
+)
+status_contrib = (pf.Param(status_coeffs) * m.on_off).sum('comp')
+print(
+    f'status_contrib covers: costs only (shape: effect={status_contrib.data["effect"].n_unique()}, time={status_contrib.data["time"].n_unique()})'
+)
+
+# ---------------------------------------------------------------------------
+# 2. Direct addition fails when sparsity differs
+# ---------------------------------------------------------------------------
+print('\n=== 2. Direct addition fails ===\n')
+
+try:
+    flow_contrib + status_contrib
+except Exception:
+    print('flow_contrib + status_contrib → PyoframeError')
+    print('  "expression 1 has extra labels" (the co2 rows)\n')
+
+# ---------------------------------------------------------------------------
+# 3. keep_extras() on the LARGER expression preserves unmatched rows
+# ---------------------------------------------------------------------------
+print('=== 3. keep_extras() on the larger expression ===\n')
+
+total = flow_contrib.keep_extras() + status_contrib
+print(f'flow_contrib.keep_extras() + status_contrib:\n{total}\n')
+print('→ co2 rows kept intact (only flow_rate terms)')
+print('→ costs rows have both flow_rate AND on_off terms\n')
+
+# ---------------------------------------------------------------------------
+# 4. Accumulator pattern with keep_extras
+# ---------------------------------------------------------------------------
+print('=== 4. Accumulator pattern ===\n')
+
+# Startup costs: also sparse (only 'costs')
+m.startup = pf.Variable(comps, times, lb=0, ub=1)
+startup_coeffs = pl.DataFrame(
+    {
+        'effect': ['costs'],
+        'comp': ['boiler'],
+        'value': [100.0],
+    }
+)
+startup_contrib = (pf.Param(startup_coeffs) * m.startup).sum('comp')
+
+# Chain: keep_extras on the growing accumulator at each step
+acc = flow_contrib  # (costs, co2) × time
+acc = acc.keep_extras() + status_contrib  # status only on costs
+acc = acc.keep_extras() + startup_contrib  # startup only on costs
+print(f'Chained accumulator:\n{acc}\n')
+
+# ---------------------------------------------------------------------------
+# 5. Two-bucket total: sum_time(temporal) + periodic
+# ---------------------------------------------------------------------------
+print('=== 5. Two-bucket total: temporal.sum(time) + periodic ===\n')
+
+periodic = pf.Param(
+    pl.DataFrame(
+        {
+            'effect': ['costs', 'co2'],
+            'value': [1000.0, 500.0],
+        }
+    )
+)
+
+m.effect_total = pf.Variable(effects)
+m.total_eq = m.effect_total == acc.sum('time') + periodic
+print(f'Total constraint:\n{m.total_eq}\n')
+
+# ---------------------------------------------------------------------------
+# 6. Per-timestep bounds directly on expression (no intermediate variable)
+# ---------------------------------------------------------------------------
+print('=== 6. Per-timestep bounds on expression ===\n')
+
+time_ub = pf.Param(
+    pl.DataFrame(
+        {
+            'effect': ['costs', 'costs', 'costs'],
+            'time': [0, 1, 2],
+            'value': [500.0, 500.0, 500.0],
+        }
+    )
+)
+# acc is (effect, time) — can constrain directly
+m.temporal_ub = acc.drop_extras() <= time_ub
+print(f'Bound on expression (no variable needed):\n{m.temporal_ub}\n')
+
+# ---------------------------------------------------------------------------
+# 7. With intermediate variable (for solution extraction)
+# ---------------------------------------------------------------------------
+print('=== 7. With intermediate variable ===\n')
+
+m.effect_per_ts = pf.Variable(effects, times)
+m.temporal_eq = m.effect_per_ts == acc
+print(f'Intermediate variable constraint:\n{m.temporal_eq}\n')
+
+# ---------------------------------------------------------------------------
+# 8. Alternative: explicit contributor Param with .sum('contributor')
+# ---------------------------------------------------------------------------
+print('=== 8. Alternative: explicit contributor column ===\n')
+print('If all coefficients are known at table-build time (no variables),')
+print('you can build a single (effect, time, contributor, value) DataFrame')
+print('and .sum("contributor"). But since our contributions involve different')
+print('variables (flow_rate, on_off, startup), we MUST use the accumulator pattern.')
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+print('\n=== SUMMARY ===\n')
+print("""
+Recommended pattern for accumulating sparse effect contributions:
+
+    # Each source: (effect, <source_dim>, time) → .sum(<source_dim>) → (effect, time)
+    # Note: each source may cover different subsets of effects!
+
+    acc = flow_cost_contrib                     # full (effect, time) — or start with zero base
+    acc = acc.keep_extras() + status_contrib    # sparse: only some effects
+    acc = acc.keep_extras() + startup_contrib   # sparse: only some effects
+
+    # Constrain:
+    m.effect_temporal == acc                # (effect, time) = (effect, time)
+    m.effect_total == acc.sum('time') + periodic_costs   # (effect,) = (effect,)
+
+Key rules:
+  1. .keep_extras() goes on the LARGER expression (the one with extra index labels)
+  2. In the accumulator pattern, the accumulator grows → always acc.keep_extras()
+  3. After .sum('time'), dimensions align to (effect,) for periodic addition
+  4. .drop_extras() needed when constraining against a param that covers fewer labels
+  5. No intermediate variable needed for bounds — can constrain expressions directly
+""")

--- a/src/fluxopt/constraints/sparse.py
+++ b/src/fluxopt/constraints/sparse.py
@@ -21,7 +21,7 @@ def sparse_weighted_sum(
     coeffs: xr.DataArray,
     sum_dim: str,
     group_dim: str,
-) -> object:
+) -> linopy.LinearExpression:
     """Compute ``(var * coeffs).sum(sum_dim)`` using only non-zero pairs.
 
     When *coeffs* is sparse along ``(group_dim, sum_dim)`` — e.g. a
@@ -96,4 +96,5 @@ def sparse_weighted_sum(
     result = result.sel({group_dim: group_ids})
 
     # Vectorized sel() leaves sum_dim as a non-dim coord — drop it
-    return result.drop_vars(sum_dim, errors='ignore')
+    result = result.drop_vars(sum_dim, errors='ignore')
+    return result

--- a/src/fluxopt/constraints/sparse.py
+++ b/src/fluxopt/constraints/sparse.py
@@ -7,7 +7,7 @@ out of hundreds).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import xarray as xr
@@ -96,5 +96,4 @@ def sparse_weighted_sum(
     result = result.sel({group_dim: group_ids})
 
     # Vectorized sel() leaves sum_dim as a non-dim coord — drop it
-    result = result.drop_vars(sum_dim, errors='ignore')
-    return result
+    return cast('linopy.LinearExpression', result.drop_vars(sum_dim, errors='ignore'))

--- a/src/fluxopt/constraints/status.py
+++ b/src/fluxopt/constraints/status.py
@@ -91,7 +91,7 @@ def add_duration_tracking(
         mega = mega + previous.fillna(0)
 
     # Variable upper bound: use maximum where provided, else mega
-    upper: xr.DataArray = xr.where(maximum.notnull(), maximum, mega) if maximum is not None else mega
+    upper: xr.DataArray = maximum.where(maximum.notnull(), mega) if maximum is not None else mega
 
     coords = [state.coords[element_dim], state.coords[dim]]
     duration = m.add_variables(lower=0, upper=upper, coords=coords, name=name)

--- a/src/fluxopt/contributions.py
+++ b/src/fluxopt/contributions.py
@@ -1,0 +1,212 @@
+"""Per-flow effect contribution breakdown.
+
+Computes how much each flow contributes to each effect, broken down into
+operational and investment parts. Storage investment costs are reported
+separately on the storage dimension. All math is post-hoc xarray arithmetic
+on solved values — no linopy variables.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import xarray as xr
+
+if TYPE_CHECKING:
+    from fluxopt.model_data import ModelData
+
+
+def _topological_order(cf: xr.DataArray, dim: str = 'effect', src_dim: str = 'source_effect') -> list[str]:
+    """Return effects in dependency order (leaves first).
+
+    Args:
+        cf: Cross-effect coefficient array with *dim* and *src_dim* axes.
+        dim: Target effect dimension name.
+        src_dim: Source effect dimension name.
+    """
+    effect_ids: list[str] = list(cf.coords[dim].values)
+    # Build in-degree map: effect k depends on j when cf[k, j] != 0
+    in_degree: dict[str, int] = dict.fromkeys(effect_ids, 0)
+    dependents: dict[str, list[str]] = {e: [] for e in effect_ids}
+    for k in effect_ids:
+        for j in effect_ids:
+            if k == j:
+                continue
+            sel = cf.sel({dim: k, src_dim: j})
+            if float(np.abs(sel).max()) > 0:
+                in_degree[k] += 1
+                dependents[j].append(k)
+
+    # Kahn's algorithm
+    queue = [e for e in effect_ids if in_degree[e] == 0]
+    order: list[str] = []
+    while queue:
+        node = queue.pop(0)
+        order.append(node)
+        for dep in dependents[node]:
+            in_degree[dep] -= 1
+            if in_degree[dep] == 0:
+                queue.append(dep)
+    return order
+
+
+def _apply_cross_effects_2d(
+    arr: xr.DataArray,
+    cf: xr.DataArray,
+    effect_ids: list[str],
+    entity_dim: str,
+) -> None:
+    """Propagate cross-effects in-place on a 2D (entity, effect) array.
+
+    Args:
+        arr: Mutable array with dims (*entity_dim*, 'effect').
+        cf: Cross-effect coefficients (effect, source_effect).
+        effect_ids: All effect ids.
+        entity_dim: Name of the non-effect dimension ('flow' or 'storage').
+    """
+    order = _topological_order(cf)
+    for k in order:
+        for j in effect_ids:
+            if k == j:
+                continue
+            cf_kj = float(cf.sel(effect=k, source_effect=j))
+            if abs(cf_kj) > 0:
+                arr.loc[{entity_dim: slice(None), 'effect': k}] = arr.sel(effect=k) + cf_kj * arr.sel(effect=j)
+
+
+def compute_effect_contributions(solution: xr.Dataset, data: ModelData) -> xr.Dataset:
+    """Compute per-flow effect contributions from solved values.
+
+    Args:
+        solution: Solved variable dataset from ``Result.solution``.
+        data: Model data used to build the optimization.
+
+    Returns:
+        Dataset with:
+        - ``operational`` (flow, effect, time) — per-flow operational contributions
+        - ``investment`` (flow, effect) — per-flow investment (flow sizing)
+        - ``storage_investment`` (storage, effect) — storage sizing investment
+        - ``total`` (flow, effect) — operational summed over time + flow investment
+    """
+    flow_ids: list[str] = list(data.flows.effect_coeff.coords['flow'].values)
+    effect_ids: list[str] = list(data.effects.min_total.coords['effect'].values)
+
+    if len(effect_ids) == 0:
+        return xr.Dataset()
+
+    n_flows = len(flow_ids)
+    n_eff = len(effect_ids)
+
+    rate = solution['flow--rate']  # (flow, time)
+    dt = data.dt  # (time,)
+
+    # --- Operational: direct per-flow contributions (flow, effect, time) ---
+    flow_op = data.flows.effect_coeff * rate * dt
+
+    # Status running costs
+    if data.flows.status_effects_running is not None and 'flow--on' in solution:
+        er = data.flows.status_effects_running.rename({'status_flow': 'flow'})
+        on = solution['flow--on']
+        flow_op = flow_op + (er * on * dt).reindex(flow=flow_ids, fill_value=0.0)
+
+    # Status startup costs
+    if data.flows.status_effects_startup is not None and 'flow--startup' in solution:
+        es = data.flows.status_effects_startup.rename({'status_flow': 'flow'})
+        startup = solution['flow--startup']
+        flow_op = flow_op + (es * startup).reindex(flow=flow_ids, fill_value=0.0)
+
+    # Cross-effects on operational (topological order)
+    if data.effects.cf_per_hour is not None:
+        cf = data.effects.cf_per_hour  # (effect, source_effect, time)
+        order = _topological_order(cf)
+        for k in order:
+            for j in effect_ids:
+                if k == j:
+                    continue
+                cf_kj = cf.sel(effect=k, source_effect=j)
+                if float(np.abs(cf_kj).max()) > 0:
+                    flow_op.loc[:, k, :] = flow_op.sel(effect=k) + cf_kj * flow_op.sel(effect=j)
+
+    # --- Investment: per-flow (flow sizing) ---
+    flow_inv = xr.DataArray(
+        np.zeros((n_flows, n_eff)),
+        dims=['flow', 'effect'],
+        coords={'flow': flow_ids, 'effect': effect_ids},
+    )
+
+    # Flow sizing: per-size costs
+    if data.flows.sizing_effects_per_size is not None and 'flow--size' in solution:
+        eps = data.flows.sizing_effects_per_size.rename({'sizing_flow': 'flow'})  # (flow, effect)
+        flow_size = solution['flow--size']  # (flow,)
+        flow_inv = flow_inv + (eps * flow_size).reindex(flow=flow_ids, fill_value=0.0)
+
+    # Flow sizing: fixed costs — optional (binary * cost)
+    if data.flows.sizing_effects_fixed is not None and 'flow--size_indicator' in solution:
+        indicator = solution['flow--size_indicator']  # (flow,)
+        opt_ids = list(indicator.coords['flow'].values)
+        ef = data.flows.sizing_effects_fixed.rename({'sizing_flow': 'flow'}).sel(flow=opt_ids)
+        flow_inv = flow_inv + (ef * indicator).reindex(flow=flow_ids, fill_value=0.0)
+
+    # Flow sizing: fixed costs — mandatory (constant)
+    if data.flows.sizing_effects_fixed is not None and data.flows.sizing_mandatory is not None:
+        mand_mask = data.flows.sizing_mandatory.values
+        if mand_mask.any():
+            mand_ids = list(data.flows.sizing_mandatory.coords['sizing_flow'].values[mand_mask])
+            ef_mand = data.flows.sizing_effects_fixed.sel(sizing_flow=mand_ids).rename({'sizing_flow': 'flow'})
+            flow_inv = flow_inv + ef_mand.reindex(flow=flow_ids, fill_value=0.0)
+
+    # Cross-effects on flow investment (topological order)
+    if data.effects.cf_invest is not None:
+        _apply_cross_effects_2d(flow_inv, data.effects.cf_invest, effect_ids, 'flow')
+
+    # --- Storage investment ---
+    stor_inv: xr.DataArray | None = None
+    if data.storages is not None:
+        stor_ids: list[str] = list(data.storages.capacity.coords['storage'].values)
+        n_stor = len(stor_ids)
+        stor_inv = xr.DataArray(
+            np.zeros((n_stor, n_eff)),
+            dims=['storage', 'effect'],
+            coords={'storage': stor_ids, 'effect': effect_ids},
+        )
+
+        # Storage sizing: per-size costs
+        if data.storages.sizing_effects_per_size is not None and 'storage--capacity' in solution:
+            eps_s = data.storages.sizing_effects_per_size.rename({'sizing_storage': 'storage'})
+            cap = solution['storage--capacity']
+            stor_inv = stor_inv + (eps_s * cap).reindex(storage=stor_ids, fill_value=0.0)
+
+        # Storage sizing: fixed costs — optional (binary * cost)
+        if data.storages.sizing_effects_fixed is not None and 'storage--size_indicator' in solution:
+            s_indicator = solution['storage--size_indicator']
+            opt_ids_s = list(s_indicator.coords['storage'].values)
+            ef_s = data.storages.sizing_effects_fixed.rename({'sizing_storage': 'storage'}).sel(storage=opt_ids_s)
+            stor_inv = stor_inv + (ef_s * s_indicator).reindex(storage=stor_ids, fill_value=0.0)
+
+        # Storage sizing: fixed costs — mandatory (constant)
+        if data.storages.sizing_effects_fixed is not None and data.storages.sizing_mandatory is not None:
+            mand_mask_s = data.storages.sizing_mandatory.values
+            if mand_mask_s.any():
+                mand_ids_s = list(data.storages.sizing_mandatory.coords['sizing_storage'].values[mand_mask_s])
+                ef_mand_s = data.storages.sizing_effects_fixed.sel(sizing_storage=mand_ids_s).rename(
+                    {'sizing_storage': 'storage'}
+                )
+                stor_inv = stor_inv + ef_mand_s.reindex(storage=stor_ids, fill_value=0.0)
+
+        # Cross-effects on storage investment
+        if data.effects.cf_invest is not None:
+            _apply_cross_effects_2d(stor_inv, data.effects.cf_invest, effect_ids, 'storage')
+
+    # --- Total per flow: operational (weighted sum over time) + flow investment ---
+    total = (flow_op * data.weights).sum('time') + flow_inv
+
+    result_vars: dict[str, xr.DataArray] = {
+        'operational': flow_op,
+        'investment': flow_inv,
+        'total': total,
+    }
+    if stor_inv is not None:
+        result_vars['storage_investment'] = stor_inv
+
+    return xr.Dataset(result_vars)

--- a/src/fluxopt/contributions.py
+++ b/src/fluxopt/contributions.py
@@ -89,9 +89,9 @@ def _compute_periodic(
 
     # Fixed costs — optional (binary indicator * cost)
     if effects_fixed is not None and indicator_var in solution:
-        indicator = solution[indicator_var]
+        indicator = solution[indicator_var].dropna(entity_dim)
         opt_ids = list(indicator.coords[entity_dim].values)
-        ef = effects_fixed.rename(rename).sel({entity_dim: opt_ids})
+        ef = effects_fixed.rename(rename).reindex({entity_dim: opt_ids}, fill_value=0.0)
         term = (ef * indicator).reindex({entity_dim: contributor_ids}, fill_value=0.0)
         result = result + term.rename({entity_dim: 'contributor'})
 

--- a/src/fluxopt/elements.py
+++ b/src/fluxopt/elements.py
@@ -20,7 +20,7 @@ class Sizing:
 
     min_size: float
     max_size: float
-    mandatory: bool = False
+    mandatory: bool = True
     effects_per_size: dict[str, float] = field(default_factory=dict)
     effects_fixed: dict[str, float] = field(default_factory=dict)
 

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -636,7 +636,8 @@ class FlowSystem:
         periodic_rhs: Any = periodic_direct
         if ds.cf_periodic is not None:
             source_p = self.effect_periodic.rename({'effect': 'source_effect'})
-            periodic_rhs = periodic_rhs + (ds.cf_periodic * source_p).sum('source_effect')
+            cross = (ds.cf_periodic * source_p).sum('source_effect')
+            periodic_rhs = cross + periodic_direct  # linopy expr must be left operand
 
         self.m.add_constraints(self.effect_periodic == periodic_rhs, name='effect_periodic_eq')
 

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field, fields
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, Self
+from typing import TYPE_CHECKING, Any, Literal, Self
 
 import numpy as np
 import pandas as pd
@@ -313,7 +313,7 @@ class FlowsData:
         Args:
             ds: Dataset with matching variable names.
         """
-        kwargs: dict[str, object] = {f.name: ds.get(f.name) for f in fields(cls)}
+        kwargs: dict[str, Any] = {f.name: ds.get(f.name) for f in fields(cls)}
         return cls(**kwargs)
 
     @classmethod
@@ -762,7 +762,7 @@ class StoragesData:
         Args:
             ds: Dataset with matching variable names.
         """
-        kwargs: dict[str, object] = {f.name: ds.get(f.name) for f in fields(cls)}
+        kwargs: dict[str, Any] = {f.name: ds.get(f.name) for f in fields(cls)}
         return cls(**kwargs)
 
     @classmethod

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -313,7 +313,7 @@ class FlowsData:
         Args:
             ds: Dataset with matching variable names.
         """
-        kwargs: dict[str, xr.DataArray | None] = {f.name: ds.get(f.name) for f in fields(cls)}
+        kwargs: dict[str, object] = {f.name: ds.get(f.name) for f in fields(cls)}
         return cls(**kwargs)
 
     @classmethod
@@ -762,7 +762,7 @@ class StoragesData:
         Args:
             ds: Dataset with matching variable names.
         """
-        kwargs: dict[str, xr.DataArray | None] = {f.name: ds.get(f.name) for f in fields(cls)}
+        kwargs: dict[str, object] = {f.name: ds.get(f.name) for f in fields(cls)}
         return cls(**kwargs)
 
     @classmethod

--- a/src/fluxopt/results.py
+++ b/src/fluxopt/results.py
@@ -48,9 +48,14 @@ class Result:
         return self.solution['effect--total']
 
     @property
-    def effects_per_timestep(self) -> xr.DataArray:
+    def effects_temporal(self) -> xr.DataArray:
         """Per-timestep effect values as (effect, time) DataArray."""
-        return self.solution['effect--per_timestep']
+        return self.solution['effect--temporal']
+
+    @property
+    def effects_periodic(self) -> xr.DataArray:
+        """Per-period (investment) effect values as (effect,) DataArray."""
+        return self.solution['effect--periodic']
 
     def flow_rate(self, id: str) -> xr.DataArray:
         """Get flow rate time series for a single flow.
@@ -125,7 +130,8 @@ class Result:
         sol_vars: dict[str, xr.DataArray] = {
             'flow--rate': model.flow_rate.solution,
             'effect--total': model.effect_total.solution,
-            'effect--per_timestep': model.effect_per_timestep.solution,
+            'effect--temporal': model.effect_temporal.solution,
+            'effect--periodic': model.effect_periodic.solution,
         }
 
         if model.storage_level is not None:

--- a/src/fluxopt/results.py
+++ b/src/fluxopt/results.py
@@ -74,12 +74,13 @@ class Result:
         return self.storage_levels.sel(storage=id)
 
     def effect_contributions(self) -> xr.Dataset:
-        """Per-flow breakdown of effect contributions.
+        """Per-contributor breakdown of effect contributions.
 
         Returns:
-            Dataset with ``operational`` (flow, effect, time),
-            ``investment`` (flow, effect), ``total`` (flow, effect),
-            and optionally ``storage_investment`` (storage, effect).
+            Dataset with ``temporal`` (contributor, effect, time),
+            ``periodic`` (contributor, effect), and ``total``
+            (contributor, effect). The contributor dim contains flow
+            IDs and (if present) storage IDs.
 
         Raises:
             ValueError: If ``data`` is not available on this Result.

--- a/src/fluxopt/types.py
+++ b/src/fluxopt/types.py
@@ -94,8 +94,9 @@ def fast_concat(arrays: list[xr.DataArray], dim: pd.Index) -> xr.DataArray:
     dims = [name, *expected_dims]
     coords: dict[str, object] = {name: dim}
     for d in expected_dims:
-        if d in first.coords:
-            coords[d] = first.coords[d]
+        key = str(d)
+        if key in first.coords:
+            coords[key] = first.coords[key]
     return xr.DataArray(data, dims=dims, coords=coords)
 
 

--- a/tests/math/test_contributions.py
+++ b/tests/math/test_contributions.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+import pytest
+import xarray as xr
+
+from fluxopt import Bus, Effect, Flow, Port, Sizing, Status, Storage, optimize
+from fluxopt.components import Converter
+
+
+class TestSumToTotal:
+    def test_single_source(self, timesteps_3):
+        """Single source gets 100% of effects."""
+        source = Flow(bus='elec', size=200, effects_per_flow_hour={'cost': 0.04})
+        sink = Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])
+
+        result = optimize(
+            timesteps=timesteps_3,
+            buses=[Bus('elec')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+        )
+
+        contrib = result.effect_contributions()
+        total_from_contrib = float(contrib['total'].sel(effect='cost').sum('flow').values)
+        total_from_solver = float(result.effect_totals.sel(effect='cost').values)
+        assert total_from_contrib == pytest.approx(total_from_solver, abs=1e-6)
+
+    def test_two_sources_sum_to_total(self, timesteps_3):
+        """Two sources' contributions sum to the solver total."""
+        cheap = Flow(bus='elec', size=200, effects_per_flow_hour={'cost': 0.02})
+        expensive = Flow(bus='elec', size=200, effects_per_flow_hour={'cost': 0.10})
+        sink = Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])
+
+        result = optimize(
+            timesteps=timesteps_3,
+            buses=[Bus('elec')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[
+                Port('cheap_src', imports=[cheap]),
+                Port('exp_src', imports=[expensive]),
+                Port('demand', exports=[sink]),
+            ],
+        )
+
+        contrib = result.effect_contributions()
+        total_from_contrib = float(contrib['total'].sel(effect='cost').sum('flow').values)
+        total_from_solver = float(result.effect_totals.sel(effect='cost').values)
+        assert total_from_contrib == pytest.approx(total_from_solver, abs=1e-6)
+
+    def test_per_timestep_sum_to_effect_per_timestep(self, timesteps_3):
+        """Operational contributions summed over flows match effect_per_timestep."""
+        source = Flow(bus='elec', size=200, effects_per_flow_hour={'cost': 0.04})
+        sink = Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])
+
+        result = optimize(
+            timesteps=timesteps_3,
+            buses=[Bus('elec')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+        )
+
+        contrib = result.effect_contributions()
+        op_sum = contrib['operational'].sel(effect='cost').sum('flow')
+        ept = result.effects_per_timestep.sel(effect='cost')
+        xr.testing.assert_allclose(op_sum, ept)
+
+
+class TestProportionalSplit:
+    def test_cheap_gets_all_demand(self, timesteps_3):
+        """With fixed demand, cheaper source serves everything → gets all cost."""
+        cheap = Flow(bus='elec', size=200, effects_per_flow_hour={'cost': 0.02})
+        expensive = Flow(bus='elec', size=200, effects_per_flow_hour={'cost': 0.10})
+        sink = Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])
+
+        result = optimize(
+            timesteps=timesteps_3,
+            buses=[Bus('elec')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[
+                Port('cheap_src', imports=[cheap]),
+                Port('exp_src', imports=[expensive]),
+                Port('demand', exports=[sink]),
+            ],
+        )
+
+        contrib = result.effect_contributions()
+        cheap_cost = float(contrib['total'].sel(flow='cheap_src(elec)', effect='cost').values)
+        exp_cost = float(contrib['total'].sel(flow='exp_src(elec)', effect='cost').values)
+        demand_total = 50 + 80 + 60
+        assert cheap_cost == pytest.approx(demand_total * 0.02, abs=1e-6)
+        assert exp_cost == pytest.approx(0.0, abs=1e-6)
+
+
+class TestCrossEffects:
+    def test_carbon_tax_attributed_to_emitter(self, timesteps_3):
+        """Carbon tax cost is attributed to the CO2-emitting flow."""
+        demand = [50.0, 80.0, 60.0]
+        source = Flow(bus='elec', size=200, effects_per_flow_hour={'cost': 0.04, 'co2': 0.5})
+        sink = Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])
+
+        result = optimize(
+            timesteps=timesteps_3,
+            buses=[Bus('elec')],
+            effects=[
+                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('co2', unit='kg'),
+            ],
+            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+        )
+
+        contrib = result.effect_contributions()
+        total_energy = sum(demand)
+        direct_cost = total_energy * 0.04
+        co2_total = total_energy * 0.5
+        co2_cost = co2_total * 50
+        expected_cost = direct_cost + co2_cost
+
+        grid_cost = float(contrib['total'].sel(flow='grid(elec)', effect='cost').values)
+        assert grid_cost == pytest.approx(expected_cost, abs=1e-6)
+
+        # Sum matches solver
+        total_from_contrib = float(contrib['total'].sel(effect='cost').sum('flow').values)
+        assert total_from_contrib == pytest.approx(float(result.effect_totals.sel(effect='cost').values), abs=1e-6)
+
+    def test_cross_effect_two_emitters(self, timesteps_3):
+        """Carbon tax is split proportionally between two emitting sources."""
+        dirty = Flow(bus='elec', size=200, effects_per_flow_hour={'cost': 0.02, 'co2': 1.0})
+        clean = Flow(bus='elec', size=200, effects_per_flow_hour={'cost': 0.10, 'co2': 0.0})
+        sink = Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])
+
+        co2_limit = 100.0
+        result = optimize(
+            timesteps=timesteps_3,
+            buses=[Bus('elec')],
+            effects=[
+                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('co2', maximum_total=co2_limit),
+            ],
+            ports=[
+                Port('dirty_src', imports=[dirty]),
+                Port('clean_src', imports=[clean]),
+                Port('demand', exports=[sink]),
+            ],
+        )
+
+        contrib = result.effect_contributions()
+        # Clean source has zero CO2 → zero carbon tax contribution
+        clean_co2 = float(contrib['operational'].sel(flow='clean_src(elec)', effect='co2').sum('time').values)
+        assert clean_co2 == pytest.approx(0.0, abs=1e-6)
+
+        # Totals still match
+        total_from_contrib = float(contrib['total'].sel(effect='cost').sum('flow').values)
+        assert total_from_contrib == pytest.approx(float(result.effect_totals.sel(effect='cost').values), abs=1e-6)
+
+    def test_transitive_cross_effects(self, timesteps_3):
+        """PE → CO2 → cost chain: contributions propagate transitively."""
+        demand = [50.0, 80.0, 60.0]
+        source = Flow(bus='elec', size=200, effects_per_flow_hour={'pe': 2.0})
+        sink = Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])
+
+        result = optimize(
+            timesteps=timesteps_3,
+            buses=[Bus('elec')],
+            effects=[
+                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('co2', unit='kg', contribution_from={'pe': 0.3}),
+                Effect('pe', unit='kWh'),
+            ],
+            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+        )
+
+        contrib = result.effect_contributions()
+        total_energy = sum(demand)
+        pe_total = total_energy * 2.0
+        co2_total = pe_total * 0.3
+        cost_total = co2_total * 50
+
+        grid_cost = float(contrib['total'].sel(flow='grid(elec)', effect='cost').values)
+        assert grid_cost == pytest.approx(cost_total, abs=1e-6)
+
+
+class TestSizing:
+    def test_sizing_investment_on_correct_flow(self, timesteps_3):
+        """Investment costs appear on the flow that has sizing."""
+        source = Flow(
+            bus='elec',
+            size=Sizing(min_size=50, max_size=200, mandatory=True, effects_per_size={'cost': 100}),
+            effects_per_flow_hour={'cost': 0.04},
+        )
+        sink = Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.5, 0.5])
+
+        result = optimize(
+            timesteps=timesteps_3,
+            buses=[Bus('elec')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+        )
+
+        contrib = result.effect_contributions()
+        grid_inv = float(contrib['investment'].sel(flow='grid(elec)', effect='cost').values)
+        demand_inv = float(contrib['investment'].sel(flow='demand(elec)', effect='cost').values)
+        assert grid_inv > 0
+        assert demand_inv == pytest.approx(0.0, abs=1e-6)
+
+        # Sum matches solver
+        total_from_contrib = float(contrib['total'].sel(effect='cost').sum('flow').values)
+        assert total_from_contrib == pytest.approx(float(result.effect_totals.sel(effect='cost').values), abs=1e-6)
+
+    def test_sizing_cross_effect_investment(self, timesteps_3):
+        """Sizing CO2 priced into cost via contribution_from."""
+        source = Flow(
+            bus='elec',
+            size=Sizing(min_size=50, max_size=200, mandatory=True, effects_per_size={'co2': 10}),
+            effects_per_flow_hour={'cost': 0.04, 'co2': 0.5},
+        )
+        sink = Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.5, 0.5])
+
+        result = optimize(
+            timesteps=timesteps_3,
+            buses=[Bus('elec')],
+            effects=[
+                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('co2', unit='kg'),
+            ],
+            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+        )
+
+        contrib = result.effect_contributions()
+        total_from_contrib = float(contrib['total'].sel(effect='cost').sum('flow').values)
+        assert total_from_contrib == pytest.approx(float(result.effect_totals.sel(effect='cost').values), abs=1e-6)
+
+        # Grid flow gets the investment cost (including cross-effect from CO2)
+        grid_inv_cost = float(contrib['investment'].sel(flow='grid(elec)', effect='cost').values)
+        invest_size = float(result.sizes.sel(flow='grid(elec)').values)
+        invest_co2 = invest_size * 10
+        expected_inv_cost = invest_co2 * 50
+        assert grid_inv_cost == pytest.approx(expected_inv_cost, abs=1e-6)
+
+
+class TestStatus:
+    def test_running_costs_on_correct_flow(self, timesteps_3):
+        """Running costs appear on the flow that has status."""
+        source = Flow(
+            bus='elec',
+            size=100,
+            relative_minimum=0.3,
+            effects_per_flow_hour={'cost': 0.04},
+            status=Status(effects_per_running_hour={'cost': 5.0}),
+        )
+        sink = Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])
+
+        result = optimize(
+            timesteps=timesteps_3,
+            buses=[Bus('elec')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+        )
+
+        contrib = result.effect_contributions()
+        total_from_contrib = float(contrib['total'].sel(effect='cost').sum('flow').values)
+        total_from_solver = float(result.effect_totals.sel(effect='cost').values)
+        assert total_from_contrib == pytest.approx(total_from_solver, abs=1e-6)
+
+        # Grid has running costs, demand does not
+        grid_cost = float(contrib['total'].sel(flow='grid(elec)', effect='cost').values)
+        demand_cost = float(contrib['total'].sel(flow='demand(elec)', effect='cost').values)
+        assert grid_cost > 0
+        assert demand_cost == pytest.approx(0.0, abs=1e-6)
+
+
+class TestConverter:
+    def test_converter_contributions(self, timesteps_3):
+        """Converter flows are attributed to their respective flows."""
+        fuel = Flow(bus='gas', size=200, effects_per_flow_hour={'cost': 0.03})
+        heat = Flow(bus='heat', size=200)
+        gas_supply = Flow(bus='gas', size=200)
+        heat_sink = Flow(bus='heat', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])
+
+        result = optimize(
+            timesteps=timesteps_3,
+            buses=[Bus('gas'), Bus('heat')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[Port('gas_grid', imports=[gas_supply]), Port('demand', exports=[heat_sink])],
+            converters=[Converter.boiler('boiler', thermal_efficiency=0.9, fuel_flow=fuel, thermal_flow=heat)],
+        )
+
+        contrib = result.effect_contributions()
+        # Boiler fuel flow has cost
+        boiler_fuel_cost = float(contrib['total'].sel(flow='boiler(gas)', effect='cost').values)
+        assert boiler_fuel_cost > 0
+        # Boiler heat flow has no direct cost
+        boiler_heat_cost = float(contrib['total'].sel(flow='boiler(heat)', effect='cost').values)
+        assert boiler_heat_cost == pytest.approx(0.0, abs=1e-6)
+
+        # Total matches
+        total_from_contrib = float(contrib['total'].sel(effect='cost').sum('flow').values)
+        assert total_from_contrib == pytest.approx(float(result.effect_totals.sel(effect='cost').values), abs=1e-6)
+
+
+class TestStorage:
+    def test_storage_sizing_costs(self, timesteps_4):
+        """Storage sizing investment costs appear in storage_investment."""
+        charge = Flow(bus='elec')
+        discharge = Flow(bus='elec')
+        source = Flow(bus='elec', size=100, effects_per_flow_hour={'cost': [0.02, 0.08, 0.02, 0.08]})
+        sink = Flow(bus='elec', size=50, fixed_relative_profile=[0.5, 0.5, 0.5, 0.5])
+
+        result = optimize(
+            timesteps=timesteps_4,
+            buses=[Bus('elec')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+            storages=[
+                Storage(
+                    'battery',
+                    charging=charge,
+                    discharging=discharge,
+                    capacity=Sizing(min_size=10, max_size=100, mandatory=True, effects_per_size={'cost': 50}),
+                )
+            ],
+        )
+
+        contrib = result.effect_contributions()
+        assert 'storage_investment' in contrib
+        bat_inv = float(contrib['storage_investment'].sel(storage='battery', effect='cost').values)
+        assert bat_inv > 0
+
+        # Full total: flow totals + storage investment = solver total
+        flow_total = float(contrib['total'].sel(effect='cost').sum('flow').values)
+        stor_inv_total = float(contrib['storage_investment'].sel(effect='cost').sum('storage').values)
+        solver_total = float(result.effect_totals.sel(effect='cost').values)
+        assert flow_total + stor_inv_total == pytest.approx(solver_total, abs=1e-6)
+
+
+class TestEdgeCases:
+    def test_no_cost_flows(self, timesteps_3):
+        """With no effects_per_flow_hour, contributions are zero."""
+        source = Flow(bus='elec', size=100)
+        sink = Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.5, 0.5])
+
+        result = optimize(
+            timesteps=timesteps_3,
+            buses=[Bus('elec')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+        )
+
+        contrib = result.effect_contributions()
+        assert float(contrib['total'].sum().values) == pytest.approx(0.0, abs=1e-6)
+
+    def test_data_required(self, timesteps_3):
+        """effect_contributions raises when data is missing."""
+        source = Flow(bus='elec', size=100, effects_per_flow_hour={'cost': 0.04})
+        sink = Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.5, 0.5])
+
+        result = optimize(
+            timesteps=timesteps_3,
+            buses=[Bus('elec')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+        )
+
+        result.data = None
+        with pytest.raises(ValueError, match='ModelData is required'):
+            result.effect_contributions()
+
+    def test_multiple_effects_sum_to_total(self, timesteps_3):
+        """Multiple effects tracked simultaneously all sum correctly."""
+        source = Flow(bus='elec', size=200, effects_per_flow_hour={'cost': 0.04, 'co2': 0.5})
+        sink = Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])
+
+        result = optimize(
+            timesteps=timesteps_3,
+            buses=[Bus('elec')],
+            effects=[Effect('cost', is_objective=True), Effect('co2', unit='kg')],
+            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+        )
+
+        contrib = result.effect_contributions()
+        for eff in ['cost', 'co2']:
+            total_from_contrib = float(contrib['total'].sel(effect=eff).sum('flow').values)
+            total_from_solver = float(result.effect_totals.sel(effect=eff).values)
+            assert total_from_contrib == pytest.approx(total_from_solver, abs=1e-6)
+
+    def test_caching(self, timesteps_3):
+        """Repeated calls return the same cached object."""
+        source = Flow(bus='elec', size=100, effects_per_flow_hour={'cost': 0.04})
+        sink = Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.5, 0.5])
+
+        result = optimize(
+            timesteps=timesteps_3,
+            buses=[Bus('elec')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+        )
+
+        first = result.effect_contributions()
+        second = result.effect_contributions()
+        assert first is second

--- a/tests/math/test_contributions.py
+++ b/tests/math/test_contributions.py
@@ -47,8 +47,8 @@ class TestSumToTotal:
         total_from_solver = float(result.effect_totals.sel(effect='cost').values)
         assert total_from_contrib == pytest.approx(total_from_solver, abs=1e-6)
 
-    def test_per_timestep_sum_to_effect_per_timestep(self, timesteps_3):
-        """Operational contributions summed over flows match effect_per_timestep."""
+    def test_per_timestep_sum_to_effect_temporal(self, timesteps_3):
+        """Operational contributions summed over flows match effect_temporal."""
         source = Flow(bus='elec', size=200, effects_per_flow_hour={'cost': 0.04})
         sink = Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])
 
@@ -61,7 +61,7 @@ class TestSumToTotal:
 
         contrib = result.effect_contributions()
         op_sum = contrib['operational'].sel(effect='cost').sum('flow')
-        ept = result.effects_per_timestep.sel(effect='cost')
+        ept = result.effects_temporal.sel(effect='cost')
         xr.testing.assert_allclose(op_sum, ept)
 
 

--- a/tests/math/test_contributions.py
+++ b/tests/math/test_contributions.py
@@ -210,7 +210,7 @@ class TestSizing:
         """Optional sizing with fixed costs uses binary indicator in contributions."""
         source = Flow(
             bus='elec',
-            size=Sizing(min_size=0, max_size=200, effects_fixed={'cost': 1000}),
+            size=Sizing(min_size=0, max_size=200, mandatory=False, effects_fixed={'cost': 1000}),
             effects_per_flow_hour={'cost': 0.04},
         )
         sink = Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.5, 0.5])

--- a/tests/math/test_end_to_end.py
+++ b/tests/math/test_end_to_end.py
@@ -128,6 +128,9 @@ class TestEndToEnd:
         assert 'effect' in result.effects_temporal.dims
         assert 'time' in result.effects_temporal.dims
 
+        # effects_periodic
+        assert 'effect' in result.effects_periodic.dims
+
     def test_int_timesteps(self):
         """Smoke test: int timesteps work end-to-end."""
         timesteps = [0, 1, 2, 3]

--- a/tests/math/test_end_to_end.py
+++ b/tests/math/test_end_to_end.py
@@ -124,9 +124,9 @@ class TestEndToEnd:
         # effect_totals DataArray
         assert 'effect' in result.effect_totals.dims
 
-        # effects_per_timestep
-        assert 'effect' in result.effects_per_timestep.dims
-        assert 'time' in result.effects_per_timestep.dims
+        # effects_temporal
+        assert 'effect' in result.effects_temporal.dims
+        assert 'time' in result.effects_temporal.dims
 
     def test_int_timesteps(self):
         """Smoke test: int timesteps work end-to-end."""

--- a/tests/math/test_sizing.py
+++ b/tests/math/test_sizing.py
@@ -73,7 +73,7 @@ class TestFlowSizing:
                     imports=[
                         Flow(
                             bus='Heat',
-                            size=Sizing(10, 100, effects_fixed={'costs': 200}),
+                            size=Sizing(10, 100, mandatory=False, effects_fixed={'costs': 200}),
                             effects_per_flow_hour={'costs': 1},
                         )
                     ],
@@ -104,7 +104,7 @@ class TestFlowSizing:
                     imports=[
                         Flow(
                             bus='Heat',
-                            size=Sizing(80, 80, effects_fixed={'costs': 10}),
+                            size=Sizing(80, 80, mandatory=False, effects_fixed={'costs': 10}),
                             effects_per_flow_hour={'costs': 1},
                         )
                     ],

--- a/tests/math/test_status.py
+++ b/tests/math/test_status.py
@@ -459,7 +459,7 @@ class TestStatusSizing:
                     imports=[
                         Flow(
                             bus='Heat',
-                            size=Sizing(50, 100, effects_fixed={'costs': 1000}),
+                            size=Sizing(50, 100, mandatory=False, effects_fixed={'costs': 1000}),
                             relative_minimum=0.1,
                             effects_per_flow_hour={'costs': 1},
                             status=Status(),

--- a/tests/math_port/test_flow_invest.py
+++ b/tests/math_port/test_flow_invest.py
@@ -43,7 +43,13 @@ class TestFlowInvest:
                     fuel_flow=Flow(bus='Gas', id='fuel'),
                     thermal_flow=Flow(
                         bus='Heat',
-                        size=Sizing(min_size=0, max_size=200, effects_fixed={'cost': 10}, effects_per_size={'cost': 1}),
+                        size=Sizing(
+                            min_size=0,
+                            max_size=200,
+                            mandatory=False,
+                            effects_fixed={'cost': 10},
+                            effects_per_size={'cost': 1},
+                        ),
                     ),
                 ),
             ],
@@ -88,7 +94,7 @@ class TestFlowInvest:
                     fuel_flow=Flow(bus='Gas', id='fuel'),
                     thermal_flow=Flow(
                         bus='Heat',
-                        size=Sizing(min_size=0, max_size=100, effects_fixed={'cost': 99999}),
+                        size=Sizing(min_size=0, max_size=100, mandatory=False, effects_fixed={'cost': 99999}),
                     ),
                 ),
                 Converter.boiler(
@@ -181,7 +187,7 @@ class TestFlowInvest:
                     fuel_flow=Flow(bus='Gas', id='fuel'),
                     thermal_flow=Flow(
                         bus='Heat',
-                        size=Sizing(min_size=80, max_size=80, effects_fixed={'cost': 10}),
+                        size=Sizing(min_size=80, max_size=80, mandatory=False, effects_fixed={'cost': 10}),
                     ),
                 ),
                 Converter.boiler(
@@ -333,7 +339,7 @@ class TestFlowInvest:
                     fuel_flow=Flow(bus='Gas', id='fuel'),
                     thermal_flow=Flow(
                         bus='Heat',
-                        size=Sizing(min_size=10, max_size=100, effects_fixed={'cost': 1000}),
+                        size=Sizing(min_size=10, max_size=100, mandatory=False, effects_fixed={'cost': 1000}),
                     ),
                 ),
                 Converter.boiler(
@@ -481,6 +487,7 @@ class TestFlowInvestWithStatus:
                         size=Sizing(
                             min_size=0,
                             max_size=100,
+                            mandatory=False,
                             effects_fixed={'cost': 10},
                             effects_per_size={'cost': 1},
                         ),
@@ -528,7 +535,7 @@ class TestFlowInvestWithStatus:
                     thermal_flow=Flow(
                         bus='Heat',
                         relative_minimum=0.1,
-                        size=Sizing(min_size=0, max_size=100, effects_per_size={'cost': 1}),
+                        size=Sizing(min_size=0, max_size=100, mandatory=False, effects_per_size={'cost': 1}),
                         status=Status(min_uptime=2),
                     ),
                 ),

--- a/tests/math_port/test_storage.py
+++ b/tests/math_port/test_storage.py
@@ -200,7 +200,7 @@ class TestStorage:
                     'Battery',
                     charging=Flow(bus='Elec', size=200),
                     discharging=Flow(bus='Elec', size=200),
-                    capacity=Sizing(min_size=0, max_size=200, effects_per_size={'cost': 1}),
+                    capacity=Sizing(min_size=0, max_size=200, mandatory=False, effects_per_size={'cost': 1}),
                     prior_level=0,
                     cyclic=False,
                     eta_charge=1,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -130,17 +130,17 @@ class TestRoundtripContributionFrom:
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
         assert result.data is not None
-        assert result.data.effects.cf_invest is not None
-        assert result.data.effects.cf_per_hour is not None
+        assert result.data.effects.cf_periodic is not None
+        assert result.data.effects.cf_temporal is not None
 
         result.to_netcdf(tmp_nc)
         loaded = Result.from_netcdf(tmp_nc)
 
         assert loaded.data is not None
-        assert loaded.data.effects.cf_invest is not None
-        assert loaded.data.effects.cf_per_hour is not None
-        xr.testing.assert_equal(loaded.data.effects.cf_invest, result.data.effects.cf_invest)
-        xr.testing.assert_equal(loaded.data.effects.cf_per_hour, result.data.effects.cf_per_hour)
+        assert loaded.data.effects.cf_periodic is not None
+        assert loaded.data.effects.cf_temporal is not None
+        xr.testing.assert_equal(loaded.data.effects.cf_periodic, result.data.effects.cf_periodic)
+        xr.testing.assert_equal(loaded.data.effects.cf_temporal, result.data.effects.cf_temporal)
 
         # Re-solve gives same objective
         from fluxopt import FlowSystem

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -94,8 +94,6 @@ class TestRoundtrip:
         )
         # dt preserved
         assert loaded.data.dt.values == pytest.approx(result.data.dt.values)
-        # time_extra preserved
-        assert len(loaded.data.time_extra) == len(result.data.time_extra)
 
     def test_model_data_resolve(self, tmp_nc: Path) -> None:
         """Loaded ModelData can build and solve a new model."""


### PR DESCRIPTION
## Summary

- **Per-contributor effect breakdown** — `result.effect_contributions()` decomposes solver totals into per-contributor parts on a unified `contributor` dimension (flow IDs + storage IDs), with cross-effect attribution via Leontief inverse `(I − C)⁻¹`
- **Temporal/periodic effect domains** — split effect variables into two explicit domains: `effect_temporal` (per-timestep) and `effect_periodic` (sizing, fixed costs), matching how the model separates cross-effect propagation
- **Unified contributor dimension** — flows and storages share a single `contributor` dim with `temporal`, `periodic`, and `total` variables
- **Solver validation** — contributions are validated against solver totals; raises `ValueError` on mismatch (atol=1e-6)
- **Deduplicated periodic logic** — shared `_compute_periodic` helper for flow and storage sizing/fixed costs
- **pytest-xdist** — parallel test execution

## Test plan
- [x] 16 contribution tests covering: sum-to-total, proportional split, cross-effects (1-hop, 2-emitter, transitive), sizing, status, converter, storage, caching, edge cases
- [x] Effect domain tests for temporal/periodic split
- [x] IO roundtrip tests updated
- [x] `ruff check`, `ruff format`, `mypy` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Per-contributor effect contribution breakdown with temporal (per-timestep), periodic (investment), and total components
  * New effects_periodic result view for investment and fixed-cost effects

* **Documentation**
  * Expanded effects guide clarifying temporal and periodic effect domains
  * Added per-contributor effect breakdown and cross-effect chain documentation

* **API Changes**
  * Renamed effects_per_timestep to effects_temporal for domain consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->