### PR TITLE
refac: add TimeIndex alias, tighten Timesteps, internalize helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,21 @@ uv run mypy src/         # Type check
 - **linopy**: use concise, vectorized syntax — no loops over coordinates
 - **xr.DataArray** is the primary data container; prefer broadcasting over iteration
 
+## Commit & PR Conventions
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) for **all** commit messages and PR titles:
+
+```
+<type>: <short summary>
+```
+
+Types: `feat`, `fix`, `refac`, `test`, `docs`, `chore`, `ci`, `perf`.
+Optional scope: `feat(storage): add cyclic constraint`.
+
+- **Commit messages**: `feat: add TimeIndex alias` (imperative, lowercase after colon)
+- **PR titles**: same format — `refac: clarify timestep input vs internal types`
+- No period at end, max ~70 chars
+
 ## Math Documentation
 
 Hybrid approach — plain-text formulas in code, full LaTeX in docs.

--- a/src/fluxopt/__init__.py
+++ b/src/fluxopt/__init__.py
@@ -8,11 +8,10 @@ from fluxopt.model_data import ModelData
 from fluxopt.results import Result
 from fluxopt.types import (
     IdList,
+    TimeIndex,
     TimeSeries,
     Timesteps,
     as_dataarray,
-    compute_dt,
-    normalize_timesteps,
 )
 
 
@@ -62,10 +61,9 @@ __all__ = [
     'Sizing',
     'Status',
     'Storage',
+    'TimeIndex',
     'TimeSeries',
     'Timesteps',
     'as_dataarray',
-    'compute_dt',
-    'normalize_timesteps',
     'optimize',
 ]

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -13,7 +13,7 @@ from fluxopt.types import as_dataarray, fast_concat, normalize_timesteps
 if TYPE_CHECKING:
     from fluxopt.components import Converter, Port
     from fluxopt.elements import Bus, Effect, Flow, Sizing, Status, Storage
-    from fluxopt.types import Timesteps
+    from fluxopt.types import TimeIndex, Timesteps
 
 _NC_GROUPS = {
     'flows': 'model/flows',
@@ -167,7 +167,7 @@ class _StatusArrays:
         cls,
         items: list[tuple[str, Status]],
         effect_ids: list[str],
-        time: pd.Index,
+        time: TimeIndex,
         dim: str,
         prior_rates_map: dict[str, list[float]] | None = None,
         dt: float = 1.0,
@@ -317,7 +317,7 @@ class FlowsData:
         return cls(**kwargs)
 
     @classmethod
-    def build(cls, flows: list[Flow], time: pd.Index, effects: list[Effect], dt: float = 1.0) -> Self:
+    def build(cls, flows: list[Flow], time: TimeIndex, effects: list[Effect], dt: float = 1.0) -> Self:
         """Build FlowsData from element objects.
 
         Args:
@@ -503,7 +503,7 @@ class ConvertersData:
         )
 
     @classmethod
-    def build(cls, converters: list[Converter], time: pd.Index) -> Self | None:
+    def build(cls, converters: list[Converter], time: TimeIndex) -> Self | None:
         """Build ConvertersData with sparse pair-based conversion coefficients.
 
         Args:
@@ -629,7 +629,7 @@ class EffectsData:
         return cls(**kwargs)  # type: ignore[arg-type]
 
     @classmethod
-    def build(cls, effects: list[Effect], time: pd.Index) -> Self:
+    def build(cls, effects: list[Effect], time: TimeIndex) -> Self:
         """Build EffectsData from element objects.
 
         Args:
@@ -784,7 +784,7 @@ class StoragesData:
     def build(
         cls,
         storages: list[Storage],
-        time: pd.Index,
+        time: TimeIndex,
         dt: xr.DataArray,
         effects: list[Effect] | None = None,
     ) -> Self | None:
@@ -868,7 +868,7 @@ class ModelData:
     storages: StoragesData | None  # None when no storages
     dt: xr.DataArray  # (time,)
     weights: xr.DataArray  # (time,)
-    time: pd.Index = field(repr=False)
+    time: TimeIndex = field(repr=False)
 
     def to_netcdf(self, path: str | Path, *, mode: Literal['w', 'a'] = 'a') -> None:
         """Write model data as NetCDF groups under ``/model/``.

--- a/src/fluxopt/types.py
+++ b/src/fluxopt/types.py
@@ -190,7 +190,7 @@ def normalize_timesteps(timesteps: Timesteps) -> TimeIndex:
         timesteps: Datetime objects, integers, or a DatetimeIndex.
 
     Returns:
-        pd.DatetimeIndex for datetime inputs, pd.Index (int64) for integer inputs.
+        A datetime index for datetime inputs, or an integer index for integer inputs.
     """
     if isinstance(timesteps, pd.DatetimeIndex):
         return timesteps

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -31,16 +31,43 @@ class TestNormalizeTimesteps:
         with pytest.raises(TypeError, match='Use datetime or int'):
             normalize_timesteps(['t0', 't1', 't2'])
 
+    def test_float_list_rejected(self):
+        with pytest.raises(TypeError, match='Use datetime or int'):
+            normalize_timesteps([1.0, 2.0, 3.0])
+
+    def test_bool_list_rejected(self):
+        with pytest.raises(TypeError, match='Use datetime or int'):
+            normalize_timesteps([False, True])
+
+    def test_mixed_int_float_rejected(self):
+        with pytest.raises(TypeError, match='non-integer'):
+            normalize_timesteps([1, 2.0, 3])
+
     def test_pandas_datetimeindex(self):
         idx = pd.DatetimeIndex([datetime(2024, 1, 1, h) for h in range(3)])
         result = normalize_timesteps(idx)
         assert isinstance(result, pd.DatetimeIndex)
         assert len(result) == 3
 
-    def test_empty_list(self):
-        result = normalize_timesteps([])
-        assert isinstance(result, pd.DatetimeIndex)
-        assert len(result) == 0
+    def test_empty_list_rejected(self):
+        with pytest.raises(ValueError, match='must not be empty'):
+            normalize_timesteps([])
+
+    def test_non_monotonic_datetimes_rejected(self):
+        with pytest.raises(ValueError, match='monotonically increasing'):
+            normalize_timesteps([datetime(2024, 1, 1, 2), datetime(2024, 1, 1, 0)])
+
+    def test_non_monotonic_ints_rejected(self):
+        with pytest.raises(ValueError, match='monotonically increasing'):
+            normalize_timesteps([3, 1, 2])
+
+    def test_duplicate_datetimes_rejected(self):
+        with pytest.raises(ValueError, match='duplicates'):
+            normalize_timesteps([datetime(2024, 1, 1), datetime(2024, 1, 1)])
+
+    def test_duplicate_ints_rejected(self):
+        with pytest.raises(ValueError, match='duplicates'):
+            normalize_timesteps([1, 1, 2])
 
 
 class TestComputeDt:


### PR DESCRIPTION
## Summary
- Add `TimeIndex` type alias (`pd.DatetimeIndex | pd.Index`) for the internal representation produced by `normalize_timesteps()`
- Tighten `Timesteps` by removing `np.ndarray` from the union (ambiguous dtype)
- Replace `pd.Index` annotations with `TimeIndex` in `model_data.py` signatures
- Remove `normalize_timesteps` and `compute_dt` from public API (internal helpers only)

## Test plan
- [x] `uv run pytest -v` — 294 passed
- [x] `uv run ruff check src/` — clean
- [x] `uv run mypy src/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced timestep validation with checks for empty inputs, monotonicity, and duplicates.

* **Bug Fixes**
  * Improved error handling and messages for invalid timestep inputs.

* **Refactor**
  * Refined type system for improved type consistency across the API.

* **Documentation**
  * Added commit and PR convention guidelines.

* **Tests**
  * Added comprehensive test coverage for timestep validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->