### PR TITLE
docs: streamline tutorial notebooks

### DIFF
--- a/docs/notebooks/01-quickstart.ipynb
+++ b/docs/notebooks/01-quickstart.ipynb
@@ -7,36 +7,23 @@
    "source": [
     "# Quickstart\n",
     "\n",
-    "Heat a small workshop with a gas boiler — the minimal working example.\n",
+    "Heat a workshop with a gas boiler — the simplest possible system.\n",
     "\n",
-    "This notebook introduces the **core concepts** of fluxopt:\n",
-    "\n",
-    "- **Bus**: Balance nodes where energy flows meet\n",
-    "- **Flow**: Energy transfer on a bus — with size, bounds, and cost coefficients\n",
-    "- **Effect**: Quantities to track and optimize (costs, emissions)\n",
-    "- **Port**: Sources and sinks connecting the system to the outside world\n",
-    "- **Converter**: Linear coupling between input and output flows"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1",
-   "metadata": {},
-   "source": [
-    "## Setup"
+    "**Concepts**: Bus (balance node) · Flow (energy transfer) · Effect (cost tracking) · Port (source/sink) · Converter (efficiency coupling)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
     "from datetime import datetime\n",
     "\n",
-    "import plotly.express as px\n",
+    "import plotly.graph_objects as go\n",
     "import plotly.io as pio\n",
+    "from plotly.subplots import make_subplots\n",
     "\n",
     "from fluxopt import Bus, Converter, Effect, Flow, Port, optimize\n",
     "\n",
@@ -45,33 +32,73 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "2",
    "metadata": {},
    "source": [
-    "## Define the Time Horizon\n",
+    "## System\n",
     "\n",
-    "Every optimization needs a time horizon. Here we model a simple 4-hour period:"
+    "```\n",
+    "Gas Grid ──► [gas] ──► Boiler η=90% ──► [heat] ──► Workshop\n",
+    " 0.08 €/kWh                                        30–50 kW\n",
+    "```"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
     "timesteps = [datetime(2024, 1, 15, h) for h in range(8, 12)]\n",
-    "timesteps"
+    "\n",
+    "result = optimize(\n",
+    "    timesteps=timesteps,\n",
+    "    buses=[Bus('gas'), Bus('heat')],\n",
+    "    effects=[Effect('cost', unit='EUR', is_objective=True)],\n",
+    "    ports=[\n",
+    "        Port(\n",
+    "            'gas_grid',\n",
+    "            imports=[\n",
+    "                Flow(bus='gas', size=1000, effects_per_flow_hour={'cost': 0.08}),\n",
+    "            ],\n",
+    "        ),\n",
+    "        Port(\n",
+    "            'workshop',\n",
+    "            exports=[\n",
+    "                Flow(bus='heat', size=50, fixed_relative_profile=[0.6, 1.0, 0.9, 0.5]),\n",
+    "            ],\n",
+    "        ),\n",
+    "    ],\n",
+    "    converters=[\n",
+    "        Converter.boiler(\n",
+    "            'boiler',\n",
+    "            thermal_efficiency=0.9,\n",
+    "            fuel_flow=Flow(bus='gas', size=200),\n",
+    "            thermal_flow=Flow(bus='heat', size=100),\n",
+    "        ),\n",
+    "    ],\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "4",
    "metadata": {},
    "source": [
-    "## Define the Heat Demand\n",
-    "\n",
-    "The workshop has varying heat demand throughout the morning:"
+    "## Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "demand = result.flow_rate('workshop(heat)')\n",
+    "total_heat = float(demand.sum())\n",
+    "print(f'Total cost: {result.objective:.2f} EUR  |  Avg: {result.objective / total_heat * 100:.1f} ct/kWh')"
    ]
   },
   {
@@ -81,9 +108,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "heat_demand = [30, 50, 45, 25]  # kW per hour\n",
+    "fig = make_subplots(\n",
+    "    rows=2,\n",
+    "    cols=1,\n",
+    "    shared_xaxes=True,\n",
+    "    vertical_spacing=0.15,\n",
+    "    subplot_titles=('Flow Rates', 'Cost per Timestep'),\n",
+    ")\n",
     "\n",
-    "px.bar(x=timesteps, y=heat_demand, labels={'x': 'Time', 'y': 'kW'}, title='Heat Demand')"
+    "times = result.flow_rates.coords['time'].values\n",
+    "for fid in result.flow_rates.coords['flow'].values:\n",
+    "    fig.add_trace(\n",
+    "        go.Scatter(x=times, y=result.flow_rate(str(fid)).values, name=str(fid), line_shape='hv'),\n",
+    "        row=1,\n",
+    "        col=1,\n",
+    "    )\n",
+    "\n",
+    "cost = result.effects_temporal.sel(effect='cost')\n",
+    "fig.add_trace(go.Bar(x=times, y=cost.values, name='cost', showlegend=False), row=2, col=1)\n",
+    "\n",
+    "fig.update_layout(height=450, margin={'l': 50, 'r': 20, 't': 30, 'b': 20}, template='plotly_white')\n",
+    "fig.update_yaxes(title_text='kW', row=1, col=1)\n",
+    "fig.update_yaxes(title_text='EUR', row=2, col=1)\n",
+    "fig"
    ]
   },
   {
@@ -91,174 +138,9 @@
    "id": "7",
    "metadata": {},
    "source": [
-    "## Build and Solve the Energy System\n",
+    "Flow ids are qualified as `component(bus)` — e.g. `boiler(gas)`, `workshop(heat)`.\n",
     "\n",
-    "The system has a gas grid, a boiler, and a heat demand:\n",
-    "\n",
-    "```\n",
-    "  Gas Grid ──► [gas bus] ──► Boiler ──► [heat bus] ──► Workshop\n",
-    "      €                        η=90%                    Demand\n",
-    "```\n",
-    "\n",
-    "In fluxopt, we define **Flows** (energy on a bus), group them into **Ports**\n",
-    "(sources/sinks) and **Converters** (coupled flows), then call `optimize`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Gas supply: up to 1000 kW, costs 0.08 EUR/kWh\n",
-    "gas_source = Flow(bus='gas', size=1000, effects_per_flow_hour={'cost': 0.08})\n",
-    "\n",
-    "# Boiler flows\n",
-    "fuel = Flow(bus='gas', size=200)\n",
-    "heat_out = Flow(bus='heat', size=100)\n",
-    "\n",
-    "# Heat demand: 50 kW capacity * relative profile = [30, 50, 45, 25] kW\n",
-    "demand_flow = Flow(bus='heat', size=50, fixed_relative_profile=[0.6, 1.0, 0.9, 0.5])\n",
-    "\n",
-    "result = optimize(\n",
-    "    timesteps=timesteps,\n",
-    "    buses=[Bus('gas'), Bus('heat')],\n",
-    "    effects=[Effect('cost', unit='EUR', is_objective=True)],\n",
-    "    ports=[\n",
-    "        Port('gas_grid', imports=[gas_source]),\n",
-    "        Port('workshop', exports=[demand_flow]),\n",
-    "    ],\n",
-    "    converters=[\n",
-    "        Converter.boiler('boiler', thermal_efficiency=0.9, fuel_flow=fuel, thermal_flow=heat_out),\n",
-    "    ],\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9",
-   "metadata": {},
-   "source": [
-    "## Analyze Results\n",
-    "\n",
-    "### Total Costs\n",
-    "\n",
-    "The total cost — the minimized objective:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "10",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "total_heat = sum(heat_demand)\n",
-    "gas_consumed = total_heat / 0.9\n",
-    "\n",
-    "print(f'Total heat demand: {total_heat:.0f} kWh')\n",
-    "print(f'Gas consumed:      {gas_consumed:.1f} kWh')\n",
-    "print(f'Total cost:        {result.objective:.2f} EUR')\n",
-    "print(f'Avg cost of heat:  {result.objective / total_heat:.4f} EUR/kWh')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "11",
-   "metadata": {},
-   "source": [
-    "### Flow Rates\n",
-    "\n",
-    "Visualize all flow rates over time. Flow ids are qualified as `{component}({bus})`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "12",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df = result.flow_rates.to_dataframe('kW').reset_index()\n",
-    "px.line(df, x='time', y='kW', color='flow', title='Flow Rates', line_shape='hv')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "13",
-   "metadata": {},
-   "source": [
-    "Use `flow_rate()` to get a single flow's time series:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "14",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df = result.flow_rate('boiler(gas)').to_dataframe('kW').reset_index()\n",
-    "px.line(df, x='time', y='kW', title='Boiler Gas Consumption', line_shape='hv')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "15",
-   "metadata": {},
-   "source": [
-    "### Effect Totals"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "16",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "result.effect_totals"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "17",
-   "metadata": {},
-   "source": [
-    "### Per-Timestep Effects\n",
-    "\n",
-    "Cost incurred at each timestep:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "18",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df = result.effects_temporal.to_dataframe('EUR').reset_index()\n",
-    "px.bar(df, x='time', y='EUR', color='effect', title='Effects per Timestep')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "19",
-   "metadata": {},
-   "source": [
-    "## Summary\n",
-    "\n",
-    "The basic workflow:\n",
-    "\n",
-    "1. **Define** flows with size, bounds, and cost coefficients\n",
-    "2. **Group** flows into ports (sources/sinks) and converters\n",
-    "3. **Optimize** with `optimize(timesteps, buses, effects, ports, converters)`\n",
-    "4. **Inspect** results via `result.flow_rates`, `result.effect_totals`, `result.effects_temporal`\n",
-    "\n",
-    "### Next Steps\n",
-    "\n",
-    "- [02-heat-system](02-heat-system.ipynb): Add thermal storage to shift loads with time-varying prices"
+    "**Next**: [Heat System with Storage](02-heat-system.ipynb) — time-varying prices and load shifting"
    ]
   }
  ],
@@ -276,7 +158,7 @@
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
+   "nbformat_minor": 5,
    "pygments_lexer": "ipython3",
    "version": "3.13.2"
   }

--- a/docs/notebooks/01-quickstart.ipynb
+++ b/docs/notebooks/01-quickstart.ipynb
@@ -108,6 +108,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "result.effect_totals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "fig = make_subplots(\n",
     "    rows=2,\n",
     "    cols=1,\n",
@@ -135,9 +145,11 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
+    "**Workflow**: define flows → group into ports & converters → `optimize()` → inspect results\n",
+    "\n",
     "Flow ids are qualified as `component(bus)` — e.g. `boiler(gas)`, `workshop(heat)`.\n",
     "\n",
     "**Next**: [Heat System with Storage](02-heat-system.ipynb) — time-varying prices and load shifting"
@@ -158,7 +170,7 @@
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbformat_minor": 5,
+   "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.2"
   }

--- a/docs/notebooks/02-heat-system.ipynb
+++ b/docs/notebooks/02-heat-system.ipynb
@@ -7,35 +7,24 @@
    "source": [
     "# Heat System with Storage\n",
     "\n",
-    "District heating with a thermal storage tank and time-varying gas prices.\n",
+    "Thermal storage shifts gas consumption from expensive peak to cheap off-peak hours.\n",
     "\n",
-    "This notebook introduces:\n",
-    "\n",
-    "- **Storage**: Thermal buffer with charge/discharge flows, efficiency, and self-discharge\n",
-    "- **Time-varying prices**: Cost coefficients that change per timestep\n",
-    "- **Load shifting**: The optimizer charges storage when gas is cheap and discharges when expensive"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1",
-   "metadata": {},
-   "source": [
-    "## Setup"
+    "**New concepts**: Storage (buffer with efficiency & self-discharge) · Time-varying prices · Load shifting"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
     "import math\n",
     "from datetime import datetime, timedelta\n",
     "\n",
-    "import plotly.express as px\n",
+    "import plotly.graph_objects as go\n",
     "import plotly.io as pio\n",
+    "from plotly.subplots import make_subplots\n",
     "\n",
     "from fluxopt import Bus, Converter, Effect, Flow, Port, Storage, optimize\n",
     "\n",
@@ -44,48 +33,110 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "2",
    "metadata": {},
    "source": [
-    "## Generate Time Series Data\n",
-    "\n",
-    "We model 48 hours with hourly resolution. Heat demand follows a day/night\n",
-    "pattern, and gas prices have off-peak/peak tariffs."
+    "## Input Data — 48 h with day/night price spread"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "n_hours = 48\n",
-    "timesteps = [datetime(2024, 1, 15) + timedelta(hours=h) for h in range(n_hours)]\n",
+    "n = 48\n",
+    "timesteps = [datetime(2024, 1, 15) + timedelta(hours=h) for h in range(n)]\n",
+    "demand = [50 + 40 * max(0.0, math.sin(math.pi * ((h % 24) - 6) / 12)) for h in range(n)]\n",
+    "price = [0.04 if (h % 24) < 6 or (h % 24) >= 22 else 0.08 for h in range(n)]\n",
     "\n",
-    "# Heat demand: sinusoidal pattern - peaks during business hours, low at night\n",
-    "heat_demand = [50 + 40 * max(0.0, math.sin(math.pi * ((h % 24) - 6) / 12)) for h in range(n_hours)]\n",
-    "\n",
-    "# Gas price: off-peak (22:00-06:00) at 0.04 EUR/kWh, peak at 0.08 EUR/kWh\n",
-    "gas_price = [0.04 if (h % 24) < 6 or (h % 24) >= 22 else 0.08 for h in range(n_hours)]"
+    "fig = make_subplots(\n",
+    "    rows=2,\n",
+    "    cols=1,\n",
+    "    shared_xaxes=True,\n",
+    "    vertical_spacing=0.15,\n",
+    "    subplot_titles=('Heat Demand', 'Gas Price'),\n",
+    ")\n",
+    "fig.add_trace(go.Bar(x=timesteps, y=demand, marker_color='#ef553b', showlegend=False), row=1, col=1)\n",
+    "fig.add_trace(go.Scatter(x=timesteps, y=price, line_shape='hv', line_color='#636efa', showlegend=False), row=2, col=1)\n",
+    "fig.update_layout(height=350, margin={'l': 50, 'r': 20, 't': 30, 'b': 20}, template='plotly_white')\n",
+    "fig.update_yaxes(title_text='kW', row=1, col=1)\n",
+    "fig.update_yaxes(title_text='EUR/kWh', row=2, col=1)\n",
+    "fig"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "4",
    "metadata": {},
    "source": [
-    "Visualize the demand and price profiles:"
+    "## System\n",
+    "\n",
+    "```\n",
+    "Gas Grid ──► [gas] ──► Boiler η=92% ──► [heat] ◄──► Tank 500 kWh\n",
+    " time-varying €                            │\n",
+    "                                         Office\n",
+    "```"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
-    "px.bar(x=timesteps, y=heat_demand, labels={'x': 'Time', 'y': 'kW'}, title='Heat Demand')"
+    "max_d = max(demand)\n",
+    "\n",
+    "result = optimize(\n",
+    "    timesteps=timesteps,\n",
+    "    buses=[Bus('gas'), Bus('heat')],\n",
+    "    effects=[Effect('cost', unit='EUR', is_objective=True)],\n",
+    "    ports=[\n",
+    "        Port(\n",
+    "            'gas_grid',\n",
+    "            imports=[\n",
+    "                Flow(bus='gas', size=500, effects_per_flow_hour={'cost': price}),\n",
+    "            ],\n",
+    "        ),\n",
+    "        Port(\n",
+    "            'office',\n",
+    "            exports=[\n",
+    "                Flow(bus='heat', size=max_d, fixed_relative_profile=[d / max_d for d in demand]),\n",
+    "            ],\n",
+    "        ),\n",
+    "    ],\n",
+    "    converters=[\n",
+    "        Converter.boiler(\n",
+    "            'boiler',\n",
+    "            thermal_efficiency=0.92,\n",
+    "            fuel_flow=Flow(bus='gas', size=300),\n",
+    "            thermal_flow=Flow(bus='heat', size=150),\n",
+    "        ),\n",
+    "    ],\n",
+    "    storages=[\n",
+    "        Storage(\n",
+    "            'tank',\n",
+    "            capacity=500,\n",
+    "            charging=Flow(bus='heat', size=100),\n",
+    "            discharging=Flow(bus='heat', size=100),\n",
+    "            eta_charge=0.98,\n",
+    "            eta_discharge=0.98,\n",
+    "            relative_loss_per_hour=0.005,\n",
+    "            prior_level=250.0,\n",
+    "            cyclic=False,\n",
+    "        )\n",
+    "    ],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "## Results"
    ]
   },
   {
@@ -95,24 +146,52 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "px.line(x=timesteps, y=gas_price, labels={'x': 'Time', 'y': 'EUR/kWh'}, title='Gas Price')"
+    "print(f'Total cost: {result.objective:.2f} EUR  |  Avg: {result.objective / sum(demand) * 100:.2f} ct/kWh')"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "8",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "## Build and Solve the Energy System\n",
+    "times = result.flow_rates.coords['time'].values\n",
     "\n",
-    "The system:\n",
+    "fig = make_subplots(\n",
+    "    rows=2,\n",
+    "    cols=1,\n",
+    "    shared_xaxes=True,\n",
+    "    vertical_spacing=0.12,\n",
+    "    subplot_titles=('Storage Flows', 'Storage Level'),\n",
+    ")\n",
     "\n",
-    "```\n",
-    "Gas Grid ──► [gas] ──► Boiler ──► [heat] ◄──► Storage\n",
-    "                         η=92%       │\n",
-    "                                     ▼\n",
-    "                                   Office\n",
-    "```"
+    "for fid in result.flow_rates.coords['flow'].values:\n",
+    "    if 'tank' in str(fid):\n",
+    "        fig.add_trace(\n",
+    "            go.Scatter(x=times, y=result.flow_rate(str(fid)).values, name=str(fid), line_shape='hv'),\n",
+    "            row=1,\n",
+    "            col=1,\n",
+    "        )\n",
+    "\n",
+    "level = result.storage_level('tank')\n",
+    "fig.add_trace(\n",
+    "    go.Scatter(\n",
+    "        x=level.coords['time'].values,\n",
+    "        y=level.values,\n",
+    "        name='level',\n",
+    "        fill='tozeroy',\n",
+    "        line_shape='hv',\n",
+    "        showlegend=False,\n",
+    "    ),\n",
+    "    row=2,\n",
+    "    col=1,\n",
+    ")\n",
+    "\n",
+    "fig.update_layout(height=400, margin={'l': 50, 'r': 20, 't': 30, 'b': 20}, template='plotly_white')\n",
+    "fig.update_yaxes(title_text='kW', row=1, col=1)\n",
+    "fig.update_yaxes(title_text='kWh', row=2, col=1)\n",
+    "fig"
    ]
   },
   {
@@ -122,46 +201,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Gas supply with time-varying price\n",
-    "gas_source = Flow(bus='gas', size=500, effects_per_flow_hour={'cost': gas_price})\n",
-    "\n",
-    "# Boiler: 150 kW thermal capacity, 92% efficiency\n",
-    "fuel = Flow(bus='gas', size=300)\n",
-    "heat_out = Flow(bus='heat', size=150)\n",
-    "\n",
-    "# Demand: normalize to relative profile\n",
-    "max_demand = max(heat_demand)\n",
-    "demand_profile = [d / max_demand for d in heat_demand]\n",
-    "demand_flow = Flow(bus='heat', size=max_demand, fixed_relative_profile=demand_profile)\n",
-    "\n",
-    "# Thermal storage: 500 kWh, 98% charge/discharge efficiency, 0.5%/h self-discharge\n",
-    "charge_flow = Flow(bus='heat', size=100)\n",
-    "discharge_flow = Flow(bus='heat', size=100)\n",
-    "storage = Storage(\n",
-    "    'thermal_storage',\n",
-    "    charging=charge_flow,\n",
-    "    discharging=discharge_flow,\n",
-    "    capacity=500,\n",
-    "    eta_charge=0.98,\n",
-    "    eta_discharge=0.98,\n",
-    "    relative_loss_per_hour=0.005,\n",
-    "    prior_level=250.0,  # start half-full (absolute kWh)\n",
-    "    cyclic=False,\n",
+    "fig = make_subplots(\n",
+    "    rows=2,\n",
+    "    cols=1,\n",
+    "    shared_xaxes=True,\n",
+    "    vertical_spacing=0.12,\n",
+    "    subplot_titles=('All Flow Rates', 'Hourly Cost'),\n",
     ")\n",
     "\n",
-    "result = optimize(\n",
-    "    timesteps=timesteps,\n",
-    "    buses=[Bus('gas'), Bus('heat')],\n",
-    "    effects=[Effect('cost', unit='EUR', is_objective=True)],\n",
-    "    ports=[\n",
-    "        Port('gas_grid', imports=[gas_source]),\n",
-    "        Port('office', exports=[demand_flow]),\n",
-    "    ],\n",
-    "    converters=[\n",
-    "        Converter.boiler('boiler', thermal_efficiency=0.92, fuel_flow=fuel, thermal_flow=heat_out),\n",
-    "    ],\n",
-    "    storages=[storage],\n",
-    ")"
+    "for fid in result.flow_rates.coords['flow'].values:\n",
+    "    fig.add_trace(\n",
+    "        go.Scatter(x=times, y=result.flow_rate(str(fid)).values, name=str(fid), line_shape='hv'),\n",
+    "        row=1,\n",
+    "        col=1,\n",
+    "    )\n",
+    "\n",
+    "cost = result.effects_temporal.sel(effect='cost')\n",
+    "fig.add_trace(go.Bar(x=times, y=cost.values, name='cost', showlegend=False), row=2, col=1)\n",
+    "\n",
+    "fig.update_layout(height=400, margin={'l': 50, 'r': 20, 't': 30, 'b': 20}, template='plotly_white')\n",
+    "fig.update_yaxes(title_text='kW', row=1, col=1)\n",
+    "fig.update_yaxes(title_text='EUR', row=2, col=1)\n",
+    "fig"
    ]
   },
   {
@@ -169,157 +230,11 @@
    "id": "10",
    "metadata": {},
    "source": [
-    "## Analyze Results\n",
+    "## Insights\n",
     "\n",
-    "### Cost Summary"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "11",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "total_heat = sum(heat_demand)\n",
-    "\n",
-    "print(f'Total heat delivered: {total_heat:.0f} kWh')\n",
-    "print(f'Total cost:          {result.objective:.2f} EUR')\n",
-    "print(f'Avg cost of heat:    {result.objective / total_heat * 100:.2f} ct/kWh')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "12",
-   "metadata": {},
-   "source": [
-    "### Flow Rates\n",
-    "\n",
-    "All flow rates across the horizon:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "13",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df = result.flow_rates.to_dataframe('kW').reset_index()\n",
-    "px.line(df, x='time', y='kW', color='flow', title='Flow Rates', line_shape='hv')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "14",
-   "metadata": {},
-   "source": [
-    "### Storage Operation\n",
-    "\n",
-    "Charge and discharge rates show the load-shifting behavior:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "15",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "storage_flows = [f for f in result.flow_rates.coords['flow'].values if 'thermal_storage' in f]\n",
-    "df = result.flow_rates.sel(flow=storage_flows).to_dataframe('kW').reset_index()\n",
-    "px.line(df, x='time', y='kW', color='flow', title='Storage Charge / Discharge', line_shape='hv')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "16",
-   "metadata": {},
-   "source": [
-    "### Storage Level\n",
-    "\n",
-    "The stored energy over time:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "17",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df = result.storage_level('thermal_storage').to_dataframe('kWh').reset_index()\n",
-    "px.area(df, x='time', y='kWh', title='Storage Level', line_shape='hv')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "18",
-   "metadata": {},
-   "source": [
-    "### Heat Balance\n",
-    "\n",
-    "How boiler output and storage work together to meet demand:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "19",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "heat_flow_ids = [\n",
-    "    f for f in result.flow_rates.coords['flow'].values if any(k in f for k in ('heat', 'charge', 'discharge'))\n",
-    "]\n",
-    "df = result.flow_rates.sel(flow=heat_flow_ids).to_dataframe('kW').reset_index()\n",
-    "px.line(df, x='time', y='kW', color='flow', title='Heat Bus Balance', line_shape='hv')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "20",
-   "metadata": {},
-   "source": [
-    "### Effect Totals"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "21",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df = result.effects_temporal.to_dataframe('EUR').reset_index()\n",
-    "px.bar(df, x='time', y='EUR', color='effect', title='Effects per Timestep')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "22",
-   "metadata": {},
-   "source": [
-    "## Key Insights\n",
-    "\n",
-    "The optimization reveals how storage enables **load shifting**:\n",
-    "\n",
-    "1. **Charge during off-peak**: When gas is cheap (night), the boiler runs at\n",
-    "   higher output to charge the storage\n",
-    "2. **Discharge during peak**: During expensive periods, storage supplements the\n",
-    "   boiler, reducing gas purchases\n",
-    "3. **Efficiency trade-off**: Storage has round-trip losses (0.98 x 0.98 = 96%)\n",
-    "   plus self-discharge, so shifting only happens when the price spread exceeds\n",
-    "   the loss cost\n",
-    "\n",
-    "## Summary\n",
-    "\n",
-    "You learned how to:\n",
-    "\n",
-    "- Add **Storage** with capacity, efficiency, and self-discharge\n",
-    "- Use **time-varying prices** via `effects_per_flow_hour`\n",
-    "- Inspect **storage levels** and **storage operation**\n",
-    "- Use xarray DataArrays for result analysis"
+    "- **Off-peak charging**: boiler overproduces at night (cheap gas) to fill storage\n",
+    "- **Peak discharge**: storage supplements boiler during expensive hours\n",
+    "- **Efficiency vs spread**: round-trip loss (96%) + self-discharge means shifting only pays when the price gap exceeds the loss cost"
    ]
   }
  ],
@@ -337,7 +252,7 @@
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
+   "nbformat_minor": 5,
    "pygments_lexer": "ipython3",
    "version": "3.13.2"
   }

--- a/docs/notebooks/02-heat-system.ipynb
+++ b/docs/notebooks/02-heat-system.ipynb
@@ -252,7 +252,7 @@
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbformat_minor": 5,
+   "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.2"
   }

--- a/docs/notebooks/02-heat-system.ipynb
+++ b/docs/notebooks/02-heat-system.ipynb
@@ -167,7 +167,7 @@
     ")\n",
     "\n",
     "for fid in result.flow_rates.coords['flow'].values:\n",
-    "    if 'tank' in str(fid):\n",
+    "    if str(fid).startswith('tank('):\n",
     "        fig.add_trace(\n",
     "            go.Scatter(x=times, y=result.flow_rate(str(fid)).values, name=str(fid), line_shape='hv'),\n",
     "            row=1,\n",

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,13 @@
+/* Compact plotly chart spacing */
+.js-plotly-plot {
+  margin: 0.25em 0 !important;
+}
+
+/* Tighter spacing around code blocks in notebook pages */
+.md-typeset pre {
+  margin: 0.4em 0;
+}
+
+.md-typeset .highlight {
+  margin: 0.4em 0;
+}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,13 +1,69 @@
+/* --- Notebook styling (inspired by nbsphinx / PyData theme) --- */
+
+/* Hide prompts — code vs output distinguished by background.
+   !important needed to override mkdocs-jupyter's inline high-specificity rule. */
+.jp-InputPrompt,
+.jp-OutputPrompt {
+  display: none !important;
+}
+
+/* Code input area: light gray background */
+.jp-Cell-inputWrapper {
+  display: flex;
+}
+
+.jp-InputArea {
+  display: flex;
+  width: 100%;
+}
+
+.jp-InputArea-editor {
+  flex: 1;
+  min-width: 0;
+}
+
+.jp-CodeCell .highlight-ipynb {
+  background: #f7f7f7;
+  border: 1px solid #e0e0e0;
+  border-radius: 3px;
+  margin: 0;
+}
+
+/* Output area: no background */
+.jp-Cell-outputWrapper {
+  display: flex;
+}
+
+.jp-OutputArea {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Text output */
+.jp-RenderedText pre {
+  background: none;
+  border: none;
+  padding: 0.4em 0.75em;
+  margin: 0;
+}
+
+/* Hide collapsers — not functional in static docs */
+.jp-Collapser {
+  display: none;
+}
+
+/* Cell spacing */
+.jp-Cell {
+  margin-bottom: 1em;
+}
+
 /* Compact plotly chart spacing */
 .js-plotly-plot {
   margin: 0.25em 0 !important;
 }
 
-/* Tighter spacing around code blocks in notebook pages */
-.md-typeset pre {
-  margin: 0.4em 0;
-}
-
-.md-typeset .highlight {
-  margin: 0.4em 0;
+/* Dark mode overrides */
+[data-md-color-scheme="slate"] .jp-CodeCell .highlight-ipynb {
+  background: #2b2b2b;
+  border-color: #404040;
 }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -58,7 +58,7 @@
 }
 
 /* Compact plotly chart spacing */
-.js-plotly-plot {
+.jp-OutputArea .js-plotly-plot {
   margin: 0.25em 0 !important;
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: fluxopt
-site_description: Energy system optimization with pyoframe
+site_description: Energy system optimization with linopy
 repo_url: https://github.com/FBumann/fluxopt
 repo_name: FBumann/fluxopt
 
@@ -114,6 +114,9 @@ plugins:
             line_length: 80
             modernize_annotations: true
             merge_init_into_class: true
+
+extra_css:
+  - stylesheets/extra.css
 
 extra_javascript:
   - javascripts/mathjax.js


### PR DESCRIPTION
## Summary

- Fix broken notebook metadata: restore `nbconvert_exporter: python` in `language_info` (was incorrectly replaced by `nbformat_minor`)
- Add workflow one-liner to quickstart notebook summary cell
- Add `result.effect_totals` demo cell to quickstart notebook
- Two tutorial notebooks: 01-quickstart (gas boiler) and 02-heat-system (storage + time-varying prices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Revamped quickstart and heat-system guides with simpler system descriptions, clearer concept framing, consistent identifiers, and concise Results/Insights sections
  * Consolidated visuals into combined multi-panel plots for demand, price, storage and overall flows; streamlined narratives and next-step pointers
  * Updated site description to reflect current tooling

* **Style**
  * Added Jupyter-inspired stylesheet to improve notebook appearance, spacing and dark-mode presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->