### PR TITLE
feat: prepare core for package ecosystem

### DIFF
--- a/docs/guide/effects.md
+++ b/docs/guide/effects.md
@@ -143,12 +143,12 @@ print(result.effects_periodic)
 
 ### Per-Contributor Breakdown
 
-`effect_contributions()` decomposes effect totals into per-contributor parts
+`stats.effect_contributions` decomposes effect totals into per-contributor parts
 on a unified `contributor` dimension (flow IDs + storage IDs), matching the
 model's temporal/periodic domain structure:
 
 ```python
-contrib = result.effect_contributions()
+contrib = result.stats.effect_contributions
 
 # Per-timestep contributions (contributor, effect, time) — flows only
 contrib['temporal']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,6 @@ packages = ["src/fluxopt"]
 [tool.hatch.build.targets.sdist]
 include = ["src/fluxopt/", "LICENSE", "README.md"]
 
-[project.optional-dependencies]
-viz = ["plotly>=6"]
-
 [dependency-groups]
 dev = [
     "mypy==1.19.1",
@@ -58,9 +55,6 @@ dev = [
     "pytest-cov==7.0.0",
     "pytest-xdist==3.8.0",
     "ruff==0.15.5",
-]
-viz = [
-    "plotly>=6",
 ]
 docs = [
     "plotly>=6",

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -894,20 +894,17 @@ class ModelData:
         meta.to_netcdf(p, mode=current_mode, group='model/meta', engine='netcdf4')
 
     @classmethod
-    def from_netcdf(cls, path: str | Path) -> ModelData | None:
+    def from_netcdf(cls, path: str | Path) -> ModelData:
         """Read model data from NetCDF groups.
 
         Args:
             path: Input file path.
 
-        Returns:
-            ModelData or None if no model groups found.
+        Raises:
+            OSError: If no model data groups found in the file.
         """
         p = Path(path)
-        try:
-            meta = xr.load_dataset(p, group='model/meta', engine='netcdf4')
-        except OSError:
-            return None
+        meta = xr.load_dataset(p, group='model/meta', engine='netcdf4')
 
         datasets: dict[str, xr.Dataset] = {}
         for name, group in _NC_GROUPS.items():

--- a/src/fluxopt/results.py
+++ b/src/fluxopt/results.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 @dataclass
 class Result:
     solution: xr.Dataset
-    data: ModelData | None = field(default=None, repr=False)
+    data: ModelData = field(repr=False)
 
     @property
     def objective(self) -> float:
@@ -91,11 +91,7 @@ class Result:
 
     @cached_property
     def stats(self) -> StatsAccessor:
-        """Post-processing statistics accessor.
-
-        Raises:
-            ValueError: If ``data`` is not available on this Result.
-        """
+        """Post-processing statistics accessor."""
         from fluxopt.stats import StatsAccessor
 
         return StatsAccessor(self)
@@ -108,8 +104,7 @@ class Result:
         """
         p = Path(path)
         self.solution.to_netcdf(p, mode='w', engine='netcdf4')
-        if self.data is not None:
-            self.data.to_netcdf(p)
+        self.data.to_netcdf(p)
 
     @classmethod
     def from_netcdf(cls, path: str | Path) -> Result:

--- a/src/fluxopt/results.py
+++ b/src/fluxopt/results.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import xarray as xr
+
+try:
+    from fluxopt_plot.accessor import PlotAccessor  # type: ignore[import-not-found]
+except ImportError:
+    PlotAccessor = None
 
 if TYPE_CHECKING:
     from fluxopt.model import FlowSystem
@@ -130,6 +136,13 @@ class Result:
         solution = xr.load_dataset(p, engine='netcdf4')
         data = ModelData.from_netcdf(p)
         return cls(solution=solution, data=data)
+
+    @cached_property
+    def plot(self) -> PlotAccessor:
+        """Plotting accessor (requires ``fluxopt-plot``)."""
+        if PlotAccessor is None:
+            raise ImportError('Plotting requires fluxopt-plot. Install it with: pip install fluxopt-plot')
+        return PlotAccessor(self)
 
     @classmethod
     def from_model(cls, model: FlowSystem) -> Result:

--- a/src/fluxopt/results.py
+++ b/src/fluxopt/results.py
@@ -15,13 +15,13 @@ except ImportError:
 if TYPE_CHECKING:
     from fluxopt.model import FlowSystem
     from fluxopt.model_data import ModelData
+    from fluxopt.stats import StatsAccessor
 
 
 @dataclass
 class Result:
     solution: xr.Dataset
     data: ModelData | None = field(default=None, repr=False)
-    _contributions_cache: xr.Dataset | None = field(default=None, repr=False, init=False)
 
     @property
     def objective(self) -> float:
@@ -89,28 +89,16 @@ class Result:
         """
         return self.storage_levels.sel(storage=storage_id)
 
-    def effect_contributions(self) -> xr.Dataset:
-        """Per-contributor breakdown of effect contributions.
-
-        Returns:
-            Dataset with ``temporal`` (contributor, effect, time),
-            ``periodic`` (contributor, effect), and ``total``
-            (contributor, effect). The contributor dim contains flow
-            IDs and (if present) storage IDs.
+    @cached_property
+    def stats(self) -> StatsAccessor:
+        """Post-processing statistics accessor.
 
         Raises:
             ValueError: If ``data`` is not available on this Result.
         """
-        if self._contributions_cache is not None:
-            return self._contributions_cache
+        from fluxopt.stats import StatsAccessor
 
-        if self.data is None:
-            raise ValueError('ModelData is required for effect_contributions (not available on this Result)')
-
-        from fluxopt.contributions import compute_effect_contributions
-
-        self._contributions_cache = compute_effect_contributions(self.solution, self.data)
-        return self._contributions_cache
+        return StatsAccessor(self)
 
     def to_netcdf(self, path: str | Path) -> None:
         """Write solution and model data to NetCDF.

--- a/src/fluxopt/stats.py
+++ b/src/fluxopt/stats.py
@@ -18,17 +18,14 @@ if TYPE_CHECKING:
 class StatsAccessor:
     """Post-processing statistics for a solved optimization result.
 
-    Accessed via ``result.stats``. Requires ``result.data`` (ModelData).
+    Accessed via ``result.stats``.
 
     Args:
-        result: Solved Result with ModelData attached.
+        result: Solved Result.
     """
 
     def __init__(self, result: Result) -> None:
-        if result.data is None:
-            raise ValueError('Stats requires ModelData (not available on this Result)')
         self._result = result
-        self._data = result.data
 
     @cached_property
     def flow_hours(self) -> xr.DataArray:
@@ -37,7 +34,7 @@ class StatsAccessor:
         Returns:
             DataArray (flow, time) in energy units (e.g. MWh).
         """
-        return self._result.flow_rates * self._data.dt
+        return self._result.flow_rates * self._result.data.dt
 
     @cached_property
     def total_flow_hours(self) -> xr.DataArray:
@@ -46,7 +43,7 @@ class StatsAccessor:
         Returns:
             DataArray (flow,) — weighted sum of flow_hours over time.
         """
-        return (self.flow_hours * self._data.weights).sum('time')
+        return (self.flow_hours * self._result.data.weights).sum('time')
 
     @cached_property
     def effect_contributions(self) -> xr.Dataset:
@@ -59,4 +56,4 @@ class StatsAccessor:
         """
         from fluxopt.contributions import compute_effect_contributions
 
-        return compute_effect_contributions(self._result.solution, self._data)
+        return compute_effect_contributions(self._result.solution, self._result.data)

--- a/src/fluxopt/stats.py
+++ b/src/fluxopt/stats.py
@@ -1,0 +1,62 @@
+"""Derived statistics from optimization results.
+
+Computes post-processing quantities that require ModelData (dt, weights)
+— energy totals, effect contributions, solver metadata.
+"""
+
+from __future__ import annotations
+
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import xarray as xr
+
+    from fluxopt.results import Result
+
+
+class StatsAccessor:
+    """Post-processing statistics for a solved optimization result.
+
+    Accessed via ``result.stats``. Requires ``result.data`` (ModelData).
+
+    Args:
+        result: Solved Result with ModelData attached.
+    """
+
+    def __init__(self, result: Result) -> None:
+        if result.data is None:
+            raise ValueError('Stats requires ModelData (not available on this Result)')
+        self._result = result
+        self._data = result.data
+
+    @cached_property
+    def flow_hours(self) -> xr.DataArray:
+        """Energy per flow per timestep: P_{f,t} * dt_t.
+
+        Returns:
+            DataArray (flow, time) in energy units (e.g. MWh).
+        """
+        return self._result.flow_rates * self._data.dt
+
+    @cached_property
+    def total_flow_hours(self) -> xr.DataArray:
+        """Total energy per flow over the horizon, weighted.
+
+        Returns:
+            DataArray (flow,) — weighted sum of flow_hours over time.
+        """
+        return (self.flow_hours * self._data.weights).sum('time')
+
+    @cached_property
+    def effect_contributions(self) -> xr.Dataset:
+        """Per-contributor breakdown of effect contributions.
+
+        Returns:
+            Dataset with ``temporal`` (contributor, effect, time),
+            ``periodic`` (contributor, effect), and ``total``
+            (contributor, effect).
+        """
+        from fluxopt.contributions import compute_effect_contributions
+
+        return compute_effect_contributions(self._result.solution, self._data)

--- a/tests/math/test_contributions.py
+++ b/tests/math/test_contributions.py
@@ -414,22 +414,6 @@ class TestEdgeCases:
         contrib = result.stats.effect_contributions
         assert float(contrib['total'].sum().values) == pytest.approx(0.0, abs=1e-6)
 
-    def test_data_required(self):
-        """Stats raises when data is missing."""
-        source = Flow(bus='elec', size=100, effects_per_flow_hour={'cost': 0.04})
-        sink = Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.5, 0.5])
-
-        result = optimize(
-            timesteps=ts(3),
-            buses=[Bus('elec')],
-            effects=[Effect('cost', is_objective=True)],
-            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
-        )
-
-        result.data = None
-        with pytest.raises(ValueError, match='Stats requires ModelData'):
-            result.stats  # noqa: B018
-
     def test_multiple_effects_sum_to_total(self):
         """Multiple effects tracked simultaneously all sum correctly."""
         source = Flow(bus='elec', size=200, effects_per_flow_hour={'cost': 0.04, 'co2': 0.5})

--- a/tests/math/test_contributions.py
+++ b/tests/math/test_contributions.py
@@ -21,7 +21,7 @@ class TestSumToTotal:
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
-        contrib = result.effect_contributions()
+        contrib = result.stats.effect_contributions
         total_from_contrib = float(contrib['total'].sel(effect='cost').sum('contributor').values)
         total_from_solver = float(result.effect_totals.sel(effect='cost').values)
         assert total_from_contrib == pytest.approx(total_from_solver, abs=1e-6)
@@ -43,7 +43,7 @@ class TestSumToTotal:
             ],
         )
 
-        contrib = result.effect_contributions()
+        contrib = result.stats.effect_contributions
         total_from_contrib = float(contrib['total'].sel(effect='cost').sum('contributor').values)
         total_from_solver = float(result.effect_totals.sel(effect='cost').values)
         assert total_from_contrib == pytest.approx(total_from_solver, abs=1e-6)
@@ -60,7 +60,7 @@ class TestSumToTotal:
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
-        contrib = result.effect_contributions()
+        contrib = result.stats.effect_contributions
         temporal_sum = contrib['temporal'].sel(effect='cost').sum('contributor')
         ept = result.effects_temporal.sel(effect='cost')
         xr.testing.assert_allclose(temporal_sum, ept)
@@ -84,7 +84,7 @@ class TestProportionalSplit:
             ],
         )
 
-        contrib = result.effect_contributions()
+        contrib = result.stats.effect_contributions
         cheap_cost = float(contrib['total'].sel(contributor='cheap_src(elec)', effect='cost').values)
         exp_cost = float(contrib['total'].sel(contributor='exp_src(elec)', effect='cost').values)
         demand_total = 50 + 80 + 60
@@ -109,7 +109,7 @@ class TestCrossEffects:
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
-        contrib = result.effect_contributions()
+        contrib = result.stats.effect_contributions
         total_energy = sum(demand)
         direct_cost = total_energy * 0.04
         co2_total = total_energy * 0.5
@@ -144,7 +144,7 @@ class TestCrossEffects:
             ],
         )
 
-        contrib = result.effect_contributions()
+        contrib = result.stats.effect_contributions
         # Clean source has zero CO2 -> zero carbon tax contribution
         clean_co2 = float(contrib['temporal'].sel(contributor='clean_src(elec)', effect='co2').sum('time').values)
         assert clean_co2 == pytest.approx(0.0, abs=1e-6)
@@ -170,7 +170,7 @@ class TestCrossEffects:
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
-        contrib = result.effect_contributions()
+        contrib = result.stats.effect_contributions
         total_energy = sum(demand)
         pe_total = total_energy * 2.0
         co2_total = pe_total * 0.3
@@ -197,7 +197,7 @@ class TestSizing:
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
-        contrib = result.effect_contributions()
+        contrib = result.stats.effect_contributions
         grid_inv = float(contrib['periodic'].sel(contributor='grid(elec)', effect='cost').values)
         demand_inv = float(contrib['periodic'].sel(contributor='demand(elec)', effect='cost').values)
         # size=50 (min to meet demand) * effects_per_size=100
@@ -225,7 +225,7 @@ class TestSizing:
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
-        contrib = result.effect_contributions()
+        contrib = result.stats.effect_contributions
         total_from_contrib = float(contrib['total'].sel(effect='cost').sum('contributor').values)
         assert total_from_contrib == pytest.approx(float(result.effect_totals.sel(effect='cost').values), abs=1e-6)
 
@@ -252,7 +252,7 @@ class TestSizing:
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
-        contrib = result.effect_contributions()
+        contrib = result.stats.effect_contributions
         total_from_contrib = float(contrib['total'].sel(effect='cost').sum('contributor').values)
         assert total_from_contrib == pytest.approx(float(result.effect_totals.sel(effect='cost').values), abs=1e-6)
 
@@ -283,7 +283,7 @@ class TestStatus:
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
-        contrib = result.effect_contributions()
+        contrib = result.stats.effect_contributions
         total_from_contrib = float(contrib['total'].sel(effect='cost').sum('contributor').values)
         total_from_solver = float(result.effect_totals.sel(effect='cost').values)
         assert total_from_contrib == pytest.approx(total_from_solver, abs=1e-6)
@@ -313,7 +313,7 @@ class TestConverter:
             converters=[Converter.boiler('boiler', thermal_efficiency=0.9, fuel_flow=fuel, thermal_flow=heat)],
         )
 
-        contrib = result.effect_contributions()
+        contrib = result.stats.effect_contributions
         # Boiler fuel flow has cost
         boiler_fuel_cost = float(contrib['total'].sel(contributor='boiler(gas)', effect='cost').values)
         assert boiler_fuel_cost == pytest.approx(sum([50, 80, 60]) / 0.9 * 0.03, abs=1e-5)
@@ -349,7 +349,7 @@ class TestStorage:
             ],
         )
 
-        contrib = result.effect_contributions()
+        contrib = result.stats.effect_contributions
         # Storage appears as a contributor in periodic
         bat_inv = float(contrib['periodic'].sel(contributor='battery', effect='cost').values)
         bat_capacity = float(result.storage_capacities.sel(storage='battery').values)
@@ -385,7 +385,7 @@ class TestStorage:
             ],
         )
 
-        contrib = result.effect_contributions()
+        contrib = result.stats.effect_contributions
         total_from_contrib = float(contrib['total'].sel(effect='cost').sum('contributor').values)
         solver_total = float(result.effect_totals.sel(effect='cost').values)
         assert total_from_contrib == pytest.approx(solver_total, abs=1e-6)
@@ -411,11 +411,11 @@ class TestEdgeCases:
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
-        contrib = result.effect_contributions()
+        contrib = result.stats.effect_contributions
         assert float(contrib['total'].sum().values) == pytest.approx(0.0, abs=1e-6)
 
     def test_data_required(self):
-        """effect_contributions raises when data is missing."""
+        """Stats raises when data is missing."""
         source = Flow(bus='elec', size=100, effects_per_flow_hour={'cost': 0.04})
         sink = Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.5, 0.5])
 
@@ -427,8 +427,8 @@ class TestEdgeCases:
         )
 
         result.data = None
-        with pytest.raises(ValueError, match='ModelData is required'):
-            result.effect_contributions()
+        with pytest.raises(ValueError, match='Stats requires ModelData'):
+            result.stats  # noqa: B018
 
     def test_multiple_effects_sum_to_total(self):
         """Multiple effects tracked simultaneously all sum correctly."""
@@ -442,14 +442,14 @@ class TestEdgeCases:
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
-        contrib = result.effect_contributions()
+        contrib = result.stats.effect_contributions
         for eff in ['cost', 'co2']:
             total_from_contrib = float(contrib['total'].sel(effect=eff).sum('contributor').values)
             total_from_solver = float(result.effect_totals.sel(effect=eff).values)
             assert total_from_contrib == pytest.approx(total_from_solver, abs=1e-6)
 
     def test_caching(self):
-        """Repeated calls return the same cached object."""
+        """Stats accessor and its properties are cached."""
         source = Flow(bus='elec', size=100, effects_per_flow_hour={'cost': 0.04})
         sink = Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.5, 0.5])
 
@@ -460,6 +460,5 @@ class TestEdgeCases:
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
-        first = result.effect_contributions()
-        second = result.effect_contributions()
-        assert first is second
+        assert result.stats is result.stats
+        assert result.stats.effect_contributions is result.stats.effect_contributions

--- a/tests/math/test_stats.py
+++ b/tests/math/test_stats.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+from conftest import ts
+
+from fluxopt import Bus, Effect, Flow, Port, optimize
+
+
+class TestFlowHours:
+    def test_flow_hours_nonnegative(self):
+        result = optimize(
+            timesteps=ts(3),
+            buses=[Bus('elec')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[
+                Port('grid', imports=[Flow(bus='elec', size=200, effects_per_flow_hour={'cost': 0.04})]),
+                Port('demand', exports=[Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])]),
+            ],
+        )
+        assert (result.stats.flow_hours >= 0).all()
+
+    def test_total_flow_hours_matches_manual(self):
+        demand = [50.0, 80.0, 60.0]
+        result = optimize(
+            timesteps=ts(3),
+            buses=[Bus('elec')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[
+                Port('grid', imports=[Flow(bus='elec', size=200, effects_per_flow_hour={'cost': 0.04})]),
+                Port('demand', exports=[Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])]),
+            ],
+        )
+        grid_total = float(result.stats.total_flow_hours.sel(flow='grid(elec)').values)
+        assert grid_total == pytest.approx(sum(demand), abs=1e-6)
+
+
+class TestCaching:
+    def test_stats_accessor_cached(self):
+        result = optimize(
+            timesteps=ts(3),
+            buses=[Bus('elec')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[
+                Port('grid', imports=[Flow(bus='elec', size=100, effects_per_flow_hour={'cost': 0.04})]),
+                Port('demand', exports=[Flow(bus='elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])]),
+            ],
+        )
+        assert result.stats is result.stats
+        assert result.stats.flow_hours is result.stats.flow_hours

--- a/tests/math_port/conftest.py
+++ b/tests/math_port/conftest.py
@@ -58,7 +58,7 @@ def optimize(request, tmp_path):
         path = tmp_path / 'result.nc'
         result.to_netcdf(path)
         loaded = Result.from_netcdf(path)
-        loaded.effect_contributions()  # validate contributions survive IO roundtrip
+        _ = loaded.stats.effect_contributions  # validate contributions survive IO roundtrip
         return loaded
 
     return _optimize

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -161,16 +161,3 @@ class TestSolutionDataset:
         assert isinstance(ds, xr.Dataset)
         assert 'flow--rate' in ds
         assert ds.attrs['objective'] == pytest.approx(result.objective)
-
-
-class TestEdgeCases:
-    def test_no_data_field(self, tmp_nc: Path) -> None:
-        """Result without data field still serializes solution."""
-        ts = [datetime(2024, 1, 1, h) for h in range(3)]
-        result = _solve_simple(ts)
-        result.data = None
-
-        result.to_netcdf(tmp_nc)
-        loaded = Result.from_netcdf(tmp_nc)
-
-        assert loaded.objective == pytest.approx(result.objective, abs=1e-6)


### PR DESCRIPTION
## Summary

- Add `Result.stats` accessor with `flow_hours`, `total_flow_hours`, and `effect_contributions` (#49)
- Add `Result.plot` stub for optional `fluxopt-plot` companion package (#50)
- Remove plotly from core dependencies (#54)
- Make `Result.data` non-optional (always `ModelData`, never `None`)

## Test plan

- [x] All 302 tests pass
- [x] mypy clean
- [x] ruff clean
- [x] IO roundtrip tests verify stats survive save/reload

Closes #49, closes #50, closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)