### PR TITLE
docs: add companion package links to README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Companion packages depend on core — core has no knowledge of companions.
 |-----------|-------------|--------|-------|
 | `Result.stats` accessor | Cached xarray properties for post-processing | Planned | [#49](https://github.com/FBumann/fluxopt/issues/49) |
 | `.plot` stub on `Result` | Discoverable property, helpful error if plot package absent | Planned | [#50](https://github.com/FBumann/fluxopt/issues/50) |
-| `fluxopt-plot` package | Interactive plotly visualization as companion package | Planned | [#51](https://github.com/FBumann/fluxopt/issues/51) |
-| `fluxopt-yaml` package | Declarative model definition via YAML + CSV | Planned | [#52](https://github.com/FBumann/fluxopt/issues/52) |
+| `fluxopt-plot` package | Interactive plotly visualization as companion package | [Scaffolded](https://fbumann.github.io/fluxopt-plot/latest/) | [#51](https://github.com/FBumann/fluxopt/issues/51) |
+| `fluxopt-yaml` package | Declarative model definition via YAML + CSV | [Scaffolded](https://fbumann.github.io/fluxopt-yaml/latest/) | [#52](https://github.com/FBumann/fluxopt/issues/52) |
 | `fluxopt-tsam` package | Time series aggregation preprocessing | Planned | — |
 | ReadTheDocs migration | Automatic versioned docs from git tags | Planned | [#53](https://github.com/FBumann/fluxopt/issues/53) |
 | Remove plotly from core | Keep core lean — plotting deps in `fluxopt-plot` only | Planned | [#54](https://github.com/FBumann/fluxopt/issues/54) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,11 @@ print(f"Total cost: {result.objective:.2f}")
 print(result.flow_rates)
 ```
 
+## Companion Packages
+
+- **[fluxopt-plot](https://fbumann.github.io/fluxopt-plot/latest/)** — interactive plotly visualization for optimization results
+- **[fluxopt-yaml](https://fbumann.github.io/fluxopt-yaml/latest/)** — declarative model definition via YAML + CSV
+
 ## Next Steps
 
 - **[Guide](guide/getting-started.md)** — walkthrough of the full API, from flows to storage


### PR DESCRIPTION
## Summary
- Update milestones table in README: fluxopt-plot and fluxopt-yaml status → "Scaffolded" with links to deployed docs
- Add "Companion Packages" section to docs/index.md with links to both companion doc sites

Docs are live at:
- https://fbumann.github.io/fluxopt-plot/latest/
- https://fbumann.github.io/fluxopt-yaml/latest/

## Test plan
- [ ] Verify docs links resolve correctly
- [ ] Verify README renders properly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated milestone status for fluxopt-plot and fluxopt-yaml companion packages
  * Added Companion Packages section documenting two new tools: fluxopt-plot for interactive Plotly visualization and fluxopt-yaml for declarative YAML+CSV model definition

<!-- end of auto-generated comment: release notes by coderabbit.ai -->