### PR TITLE
chore: configure release-please for alpha pre-releases

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -7,7 +7,9 @@
       "release-type": "simple",
       "package-name": "fluxopt",
       "bump-patch-for-minor-pre-major": true,
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "prerelease": true,
+      "prerelease-type": "alpha"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds `"prerelease": true` and `"prerelease-type": "alpha"` to the Release Please package config
- All releases will now be tagged as alpha pre-releases (e.g. `0.1.0-alpha.1`) until the project is ready for stable releases
- When we're ready for stable releases, simply remove the `prerelease` and `prerelease-type` fields from `.release-please-config.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration to enable prerelease version management and alpha release support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->