### PR TITLE
chore: prevent major version bump while pre-v1

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -6,6 +6,7 @@
     ".": {
       "release-type": "simple",
       "package-name": "fluxopt",
+      "bump-minor-for-major-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "changelog-path": "CHANGELOG.md",
       "prerelease": true,


### PR DESCRIPTION
## Summary
- Add `"bump-minor-for-major-pre-major": true` to the Release Please package config
- This demotes breaking-change bumps from major to minor while the version is at 0.x, so we get e.g. `0.2.0-alpha.1` instead of `1.0.0`
- Combined with the existing `bump-patch-for-minor-pre-major`, all pre-v1 bumps stay within the 0.x range

## After merging
Close PR #68 (the release PR currently showing 1.0.0) so that Release Please recreates it with the correct version.

## Test plan
- [ ] Verify the release PR is recreated with a 0.x version after merging this and closing #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release versioning configuration to improve version management practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->