### PR TITLE
chore: set initial version to prevent 1.0.0 bump

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -10,7 +10,8 @@
       "bump-patch-for-minor-pre-major": true,
       "changelog-path": "CHANGELOG.md",
       "prerelease": true,
-      "prerelease-type": "alpha"
+      "prerelease-type": "alpha",
+      "initial-version": "0.0.1-alpha.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Release Please was ignoring bump demotion settings because `0.0.0` in the manifest is treated as "no prior release", defaulting to 1.0.0
- Setting `initial-version` to `0.0.1-alpha.0` ensures the first release starts at the right level
- Close PR #70 after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)