### PR TITLE
ci: use GitHub App token for release-please

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,11 +16,18 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+          token: ${{ steps.app-token.outputs.token }}
 
   publish:
     name: Build & publish to PyPI


### PR DESCRIPTION
## Summary
- Use `actions/create-github-app-token` to generate an app token for release-please
- App token pushes trigger workflow events (unlike GITHUB_TOKEN), so CI runs on release-please PRs
- No PAT needed — tokens auto-expire and commits are attributed to the app, not a person

## Test plan
- [ ] Merge and verify next release-please PR gets CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow automation to enhance security and reliability of the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->