### PR TITLE
refac: extract Dims class from ModelData

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "highspy>=1.13.1",
-    "linopy @ git+https://github.com/PyPSA/linopy.git@fix/add-variables-dataarray-coords",
+    "linopy @ git+https://github.com/PyPSA/linopy.git@f53d1968e53d70962eb208b01c3f938f693f0083",
     "netcdf4>=1.6.0",
     "numpy>=1.26",
     "pandas>=2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "highspy>=1.13.1",
-    "linopy>=0.6",
+    "linopy @ git+https://github.com/PyPSA/linopy.git@fix/add-variables-dataarray-coords",
     "netcdf4>=1.6.0",
     "numpy>=1.26",
     "pandas>=2.1",
@@ -36,6 +36,9 @@ dependencies = [
 
 [project.urls]
 repository = "https://github.com/FBumann/fluxopt"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"

--- a/src/fluxopt/__init__.py
+++ b/src/fluxopt/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 from fluxopt.components import Converter, Port
 from fluxopt.elements import PENALTY_EFFECT_ID, Carrier, Effect, Flow, Sizing, Status, Storage
 from fluxopt.model import FlowSystem
-from fluxopt.model_data import ModelData
+from fluxopt.model_data import Dims, ModelData
 from fluxopt.results import Result
 from fluxopt.types import (
     IdList,
@@ -51,6 +51,7 @@ __all__ = [
     'PENALTY_EFFECT_ID',
     'Carrier',
     'Converter',
+    'Dims',
     'Effect',
     'Flow',
     'FlowSystem',

--- a/src/fluxopt/contributions.py
+++ b/src/fluxopt/contributions.py
@@ -132,7 +132,7 @@ def compute_effect_contributions(solution: xr.Dataset, data: ModelData) -> xr.Da
     all_ids = flow_ids + stor_ids
 
     rate = solution['flow--rate']  # (flow, time)
-    dt = data.dt  # (time,)
+    dt = data.dims.dt  # (time,)
 
     # --- Temporal: per-flow contributions (flow, effect, time) ---
     temporal_flow = data.flows.effect_coeff * rate * dt
@@ -191,7 +191,7 @@ def compute_effect_contributions(solution: xr.Dataset, data: ModelData) -> xr.Da
         periodic = _apply_leontief(_leontief(data.effects.cf_periodic), periodic)
 
     # --- Total: temporal (weighted sum over time) + periodic ---
-    total = (temporal * data.weights).sum('time').reindex(contributor=all_ids, fill_value=0.0) + periodic.reindex(
+    total = (temporal * data.dims.weights).sum('time').reindex(contributor=all_ids, fill_value=0.0) + periodic.reindex(
         contributor=all_ids, fill_value=0.0
     )
 

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -445,7 +445,7 @@ class FlowSystem:
             previous_state=previous_state,
         )
 
-        dt = self.data.dt
+        dt = self.data.dims.dt
 
         # Uptime tracking
         has_any_up = min_up.notnull().any() | max_up.notnull().any()
@@ -532,7 +532,7 @@ class FlowSystem:
 
         temporal_rhs: Any = 0
         if has_any_coeff:
-            coeff_dt = effect_coeff * d.dt
+            coeff_dt = effect_coeff * d.dims.dt
             temporal_rhs = sparse_weighted_sum(self.flow_rate, coeff_dt, sum_dim='flow', group_dim='effect')
 
         # Status running costs: sum_f(running_coeff[f,k,t] * on[f,t] * dt[t])
@@ -540,7 +540,7 @@ class FlowSystem:
             assert self.flow_on is not None
             er = d.flows.status_effects_running.rename({'status_flow': 'flow'})
             if (er != 0).any():
-                temporal_rhs = temporal_rhs + (er * self.flow_on * d.dt).sum('flow')
+                temporal_rhs = temporal_rhs + (er * self.flow_on * d.dims.dt).sum('flow')
 
         # Status startup costs: sum_f(startup_coeff[f,k,t] * startup[f,t]) — per event, no dt
         if d.flows.status_effects_startup is not None:
@@ -643,7 +643,7 @@ class FlowSystem:
 
         # --- Total: effect_total[effect] = sum_t(temporal * w) + periodic ---
         self.effect_total = self.m.add_variables(coords=[effect_ids], name='effect--total')
-        rhs = (self.effect_temporal * d.weights).sum('time') + self.effect_periodic
+        rhs = (self.effect_temporal * d.dims.weights).sum('time') + self.effect_periodic
         self.m.add_constraints(self.effect_total == rhs, name='effect_total_eq')
 
         # Bounds on effect_total
@@ -666,7 +666,7 @@ class FlowSystem:
         ds = d.storages
 
         stor_ids = ds.capacity.coords['storage']
-        time = d.dt.coords['time']
+        time = d.dims.dt.coords['time']
 
         # storage_level[storage, time] >= 0  (end-of-period convention)
         self.storage_level = self.m.add_variables(lower=0, coords=[stor_ids, time], name='storage--level')
@@ -743,9 +743,9 @@ class FlowSystem:
         discharge_rates = discharge_rates.assign_coords({'storage': stor_vals})
 
         # Precompute pure-xarray coefficients (no linopy overhead)
-        loss_factor = (1 - ds.loss) ** d.dt  # (storage, time)
-        charge_factor = ds.eta_c * d.dt  # (storage, time)
-        discharge_factor = d.dt / ds.eta_d  # (storage, time)
+        loss_factor = (1 - ds.loss) ** d.dims.dt  # (storage, time)
+        charge_factor = ds.eta_c * d.dims.dt  # (storage, time)
+        discharge_factor = d.dims.dt / ds.eta_d  # (storage, time)
 
         inflow = charge_rates * charge_factor
         outflow = discharge_rates * discharge_factor

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -48,7 +48,7 @@ class FlowSystem:
         *,
         lower: Any = None,
         upper: Any = None,
-        coords: list[xr.DataArray],
+        coords: dict[str, xr.DataArray],
         name: str,
         binary: bool = False,
     ) -> Variable:
@@ -57,11 +57,11 @@ class FlowSystem:
         Args:
             lower: Lower bound (scalar, array, or DataArray).
             upper: Upper bound (scalar, array, or DataArray).
-            coords: Coordinate arrays defining the variable dimensions.
+            coords: Coordinate dict mapping dim names to DataArrays.
             name: Variable name.
             binary: Create a binary variable instead.
         """
-        coord_dict = {str(c.dims[0]): c.values for c in coords}
+        coord_dict = {k: v.values for k, v in coords.items()}
         kwargs: dict[str, Any] = {'coords': coords, 'name': name, 'binary': binary}
         if not binary:
             if lower is not None:
@@ -126,7 +126,7 @@ class FlowSystem:
         """Create flow rate decision variables P_{f,t} >= 0."""
         ds = self.data.flows
         self.flow_rate = self.m.add_variables(
-            lower=0, coords=[ds.rel_lb.coords['flow'], ds.rel_lb.coords['time']], name='flow--rate'
+            lower=0, coords={'flow': ds.rel_lb.coords['flow'], **self.data.dims.coords(time=True)}, name='flow--rate'
         )
 
     def _create_sizing_variables(self) -> None:
@@ -139,13 +139,13 @@ class FlowSystem:
             sizing_ids = fds.sizing_min.coords['sizing_flow'].values
             flow_coord = xr.DataArray(sizing_ids, dims=['flow'])
             upper = fds.sizing_max.rename({'sizing_flow': 'flow'})
-            self.flow_size = self._add_variables(lower=0, upper=upper, coords=[flow_coord], name='flow--size')
+            self.flow_size = self._add_variables(lower=0, upper=upper, coords={'flow': flow_coord}, name='flow--size')
             mandatory = fds.sizing_mandatory
             optional_ids = sizing_ids[~mandatory.values]
             if len(optional_ids):
                 self.flow_size_indicator = self._add_variables(
                     binary=True,
-                    coords=[xr.DataArray(optional_ids, dims=['flow'])],
+                    coords={'flow': xr.DataArray(optional_ids, dims=['flow'])},
                     name='flow--size_indicator',
                 )
 
@@ -158,14 +158,14 @@ class FlowSystem:
             stor_coord = xr.DataArray(sizing_ids, dims=['storage'])
             upper = sds.sizing_max.rename({'sizing_storage': 'storage'})
             self.storage_capacity = self._add_variables(
-                lower=0, upper=upper, coords=[stor_coord], name='storage--capacity'
+                lower=0, upper=upper, coords={'storage': stor_coord}, name='storage--capacity'
             )
             mandatory = sds.sizing_mandatory
             optional_ids = sizing_ids[~mandatory.values]
             if len(optional_ids):
                 self.storage_capacity_indicator = self._add_variables(
                     binary=True,
-                    coords=[xr.DataArray(optional_ids, dims=['storage'])],
+                    coords={'storage': xr.DataArray(optional_ids, dims=['storage'])},
                     name='storage--size_indicator',
                 )
 
@@ -177,11 +177,11 @@ class FlowSystem:
 
         status_ids = ds.status_min_uptime.coords['status_flow'].values
         flow_coord = xr.DataArray(status_ids, dims=['flow'])
-        time_coord = ds.rel_lb.coords['time']
+        tp = {'flow': flow_coord, **self.data.dims.coords(time=True)}
 
-        self.flow_on = self._add_variables(binary=True, coords=[flow_coord, time_coord], name='flow--on')
-        self.flow_startup = self._add_variables(binary=True, coords=[flow_coord, time_coord], name='flow--startup')
-        self.flow_shutdown = self._add_variables(binary=True, coords=[flow_coord, time_coord], name='flow--shutdown')
+        self.flow_on = self._add_variables(binary=True, coords=tp, name='flow--on')
+        self.flow_startup = self._add_variables(binary=True, coords=tp, name='flow--startup')
+        self.flow_shutdown = self._add_variables(binary=True, coords=tp, name='flow--shutdown')
 
     def _status_flow_ids(self) -> set[str]:
         """Return ids of flows with Status, or empty set."""
@@ -518,13 +518,14 @@ class FlowSystem:
         ds = d.effects
 
         effect_ids = ds.min_total.coords['effect']
-        time = ds.min_per_hour.coords['time']
 
         if len(effect_ids) == 0:
             return
 
         # --- Temporal domain: effect_temporal[effect, time] ---
-        self.effect_temporal = self.m.add_variables(coords=[effect_ids, time], name='effect--temporal')
+        self.effect_temporal = self.m.add_variables(
+            coords={'effect': effect_ids, **self.data.dims.coords(time=True)}, name='effect--temporal'
+        )
 
         # Flow contributions: sum_f(coeff_{f,k,t} * P_{f,t} * dt_t)
         effect_coeff = d.flows.effect_coeff  # (flow, effect, time)
@@ -568,7 +569,7 @@ class FlowSystem:
             self.m.add_constraints(self.effect_temporal <= max_ph, name='effect_max_ph', mask=has_max_ph)
 
         # --- Periodic domain: effect_periodic[effect] ---
-        self.effect_periodic = self.m.add_variables(coords=[effect_ids], name='effect--periodic')
+        self.effect_periodic = self.m.add_variables(coords={'effect': effect_ids}, name='effect--periodic')
 
         # Accumulate direct investment contributions per effect
         periodic_direct: Any = 0
@@ -642,7 +643,7 @@ class FlowSystem:
         self.m.add_constraints(self.effect_periodic == periodic_rhs, name='effect_periodic_eq')
 
         # --- Total: effect_total[effect] = sum_t(temporal * w) + periodic ---
-        self.effect_total = self.m.add_variables(coords=[effect_ids], name='effect--total')
+        self.effect_total = self.m.add_variables(coords={'effect': effect_ids}, name='effect--total')
         rhs = (self.effect_temporal * d.dims.weights).sum('time') + self.effect_periodic
         self.m.add_constraints(self.effect_total == rhs, name='effect_total_eq')
 
@@ -666,10 +667,11 @@ class FlowSystem:
         ds = d.storages
 
         stor_ids = ds.capacity.coords['storage']
-        time = d.dims.dt.coords['time']
 
         # storage_level[storage, time] >= 0  (end-of-period convention)
-        self.storage_level = self.m.add_variables(lower=0, coords=[stor_ids, time], name='storage--level')
+        self.storage_level = self.m.add_variables(
+            lower=0, coords={'storage': stor_ids, **self.data.dims.coords(time=True)}, name='storage--level'
+        )
 
         # --- Capacity bounds on storage_level ---
         cap = ds.capacity  # (storage,) — NaN for uncapped/investable
@@ -678,7 +680,7 @@ class FlowSystem:
 
         # Fixed-capacity storages: level <= capacity (parameter)
         if has_fixed_cap.any():
-            cap_2d = cap.broadcast_like(xr.DataArray(np.nan, dims=['storage', 'time'], coords=[stor_ids, time]))
+            cap_2d = cap.broadcast_like(xr.DataArray(np.nan, dims=['storage', 'time'], coords=[stor_ids, d.dims.time]))
             mask_cap = has_fixed_cap.broadcast_like(cap_2d)
             self.m.add_constraints(self.storage_level <= cap_2d, name='level_cap', mask=mask_cap)
 
@@ -753,7 +755,7 @@ class FlowSystem:
         # --- Prior variable + single balance for ALL storages ---
         # prior[storage] is a free variable representing the state before period 0.
         # Cyclic and fixed-prior constraints pin it; otherwise it's free.
-        self.prior_storage_level = self.m.add_variables(lower=0, coords=[stor_ids], name='storage--prior')
+        self.prior_storage_level = self.m.add_variables(lower=0, coords={'storage': stor_ids}, name='storage--prior')
 
         add_accumulation_constraints(
             self.m,

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -914,8 +914,8 @@ class Dims:
 
     def __post_init__(self) -> None:
         for name, arr in [('dt', self.dt), ('weights', self.weights)]:
-            if 'time' not in arr.dims:
-                raise ValueError(f'Dims.{name} must have a "time" dimension, got {arr.dims}')
+            if arr.dims != ('time',):
+                raise ValueError(f"Dims.{name} must be 1D with dims=('time',), got {arr.dims}")
             if not arr.coords['time'].equals(self.time):
                 raise ValueError(f'Dims.{name} time coordinate does not match Dims.time')
 

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -935,7 +935,7 @@ class Dims:
         return xr.Dataset({'dt': self.dt, 'weights': self.weights})
 
     @classmethod
-    def from_dataset(cls, ds: xr.Dataset) -> Dims:
+    def from_dataset(cls, ds: xr.Dataset) -> Self:
         """Deserialize from xr.Dataset.
 
         Args:
@@ -946,7 +946,7 @@ class Dims:
         return cls(time=time_idx, dt=dt, weights=ds['weights'])
 
     @classmethod
-    def build(cls, time: TimeIndex, dt: xr.DataArray) -> Dims:
+    def build(cls, time: TimeIndex, dt: xr.DataArray) -> Self:
         """Build Dims from a time index.
 
         Args:

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field, fields
+from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Self
 
@@ -902,15 +902,52 @@ class StoragesData:
 
 
 @dataclass
+class Dims:
+    """Shared model coordinates and temporal metadata.
+
+    Owns the time dimension, timestep durations, and weights.
+    """
+
+    time: xr.DataArray  # (time,) — coordinate labels
+    dt: xr.DataArray  # (time,) — timestep durations [h]
+    weights: xr.DataArray  # (time,) — timestep weights
+
+    def to_dataset(self) -> xr.Dataset:
+        """Serialize to xr.Dataset."""
+        return xr.Dataset({'dt': self.dt, 'weights': self.weights})
+
+    @classmethod
+    def from_dataset(cls, ds: xr.Dataset) -> Dims:
+        """Deserialize from xr.Dataset.
+
+        Args:
+            ds: Dataset with dt and weights.
+        """
+        dt = ds['dt']
+        time_idx = dt.coords['time']
+        return cls(time=time_idx, dt=dt, weights=ds['weights'])
+
+    @classmethod
+    def build(cls, time: TimeIndex, dt: xr.DataArray) -> Dims:
+        """Build Dims from a time index.
+
+        Args:
+            time: Normalized time index.
+            dt: Timestep durations.
+        """
+        time_coord = xr.DataArray(time, dims=['time'], coords={'time': time})
+        weights = xr.DataArray(np.ones(len(time)), dims=['time'], coords={'time': time}, name='weight')
+        return cls(time=time_coord, dt=dt, weights=weights)
+
+
+@dataclass
 class ModelData:
     flows: FlowsData
     carriers: CarriersData
     converters: ConvertersData | None  # None when no converters
     effects: EffectsData
     storages: StoragesData | None  # None when no storages
-    dt: xr.DataArray  # (time,)
-    weights: xr.DataArray  # (time,)
-    time: TimeIndex = field(repr=False)
+    dims: Dims
 
     def to_netcdf(self, path: str | Path, *, mode: Literal['w', 'a'] = 'a') -> None:
         """Write model data as NetCDF groups under ``/model/``.
@@ -932,8 +969,7 @@ class ModelData:
             if obj is not None:
                 obj.to_dataset().to_netcdf(p, mode=current_mode, group=_NC_GROUPS[name], engine='netcdf4')
                 current_mode = 'a'
-        meta = xr.Dataset({'dt': self.dt, 'weights': self.weights})
-        meta.to_netcdf(p, mode=current_mode, group='model/meta', engine='netcdf4')
+        self.dims.to_dataset().to_netcdf(p, mode=current_mode, group='model/meta', engine='netcdf4')
 
     @classmethod
     def from_netcdf(cls, path: str | Path) -> ModelData:
@@ -955,9 +991,6 @@ class ModelData:
             except OSError:
                 datasets[name] = xr.Dataset()
 
-        dt = meta['dt']
-        time = pd.Index(dt.coords['time'].values)
-
         flows = FlowsData.from_dataset(datasets['flows'])
         carriers = CarriersData.from_dataset(datasets['carriers'])
         converters = ConvertersData.from_dataset(datasets['converters']) if datasets['converters'].data_vars else None
@@ -970,9 +1003,7 @@ class ModelData:
             converters=converters,
             effects=effects,
             storages=storages,
-            dt=dt,
-            weights=meta['weights'],
-            time=time,
+            dims=Dims.from_dataset(meta),
         )
 
     @classmethod
@@ -1011,7 +1042,7 @@ class ModelData:
         flows, carrier_coeff = _collect_flows(ports, converters, stor_list)
         _validate_system(effects, ports, converters, stor_list, flows, carriers)
 
-        weights = xr.DataArray(np.ones(len(time)), dims=['time'], coords={'time': time}, name='weight')
+        dims = Dims.build(time, dt_da)
 
         # Scalar dt for prior duration computation (use first timestep)
         dt_scalar = float(dt_da.values[0])
@@ -1027,9 +1058,7 @@ class ModelData:
             converters=converters_data,
             effects=effects_data,
             storages=storages_data,
-            dt=dt_da,
-            weights=weights,
-            time=time,
+            dims=dims,
         )
 
 

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -919,6 +919,17 @@ class Dims:
             if not arr.coords['time'].equals(self.time):
                 raise ValueError(f'Dims.{name} time coordinate does not match Dims.time')
 
+    def coords(self, *, time: bool = False) -> dict[str, xr.DataArray]:
+        """Return shared coordinates for variable/DataArray creation.
+
+        Args:
+            time: Include the time coordinate.
+        """
+        result: dict[str, xr.DataArray] = {}
+        if time:
+            result['time'] = self.time
+        return result
+
     def to_dataset(self) -> xr.Dataset:
         """Serialize to xr.Dataset."""
         return xr.Dataset({'dt': self.dt, 'weights': self.weights})

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -912,6 +912,13 @@ class Dims:
     dt: xr.DataArray  # (time,) — timestep durations [h]
     weights: xr.DataArray  # (time,) — timestep weights
 
+    def __post_init__(self) -> None:
+        for name, arr in [('dt', self.dt), ('weights', self.weights)]:
+            if 'time' not in arr.dims:
+                raise ValueError(f'Dims.{name} must have a "time" dimension, got {arr.dims}')
+            if not arr.coords['time'].equals(self.time):
+                raise ValueError(f'Dims.{name} time coordinate does not match Dims.time')
+
     def to_dataset(self) -> xr.Dataset:
         """Serialize to xr.Dataset."""
         return xr.Dataset({'dt': self.dt, 'weights': self.weights})
@@ -1045,12 +1052,12 @@ class ModelData:
         dims = Dims.build(time, dt_da)
 
         # Scalar dt for prior duration computation (use first timestep)
-        dt_scalar = float(dt_da.values[0])
+        dt_scalar = float(dims.dt.values[0])
         flows_data = FlowsData.build(flows, time, effects, dt=dt_scalar)
         carriers_data = CarriersData.build(carriers, flows, carrier_coeff)
         converters_data = ConvertersData.build(converters, time)
         effects_data = EffectsData.build(effects, time)
-        storages_data = StoragesData.build(stor_list, time, dt_da, effects)
+        storages_data = StoragesData.build(stor_list, time, dims.dt, effects)
 
         return cls(
             flows=flows_data,

--- a/src/fluxopt/stats.py
+++ b/src/fluxopt/stats.py
@@ -34,7 +34,7 @@ class StatsAccessor:
         Returns:
             DataArray (flow, time) in energy units (e.g. MWh).
         """
-        return self._result.flow_rates * self._result.data.dt
+        return self._result.flow_rates * self._result.data.dims.dt
 
     @cached_property
     def total_flow_hours(self) -> xr.DataArray:
@@ -43,7 +43,7 @@ class StatsAccessor:
         Returns:
             DataArray (flow,) — weighted sum of flow_hours over time.
         """
-        return (self.flow_hours * self._result.data.weights).sum('time')
+        return (self.flow_hours * self._result.data.dims.weights).sum('time')
 
     @cached_property
     def carrier_balance(self) -> xr.DataArray:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -288,10 +288,10 @@ class TestMultiNodeCarrier:
 
 class TestDimsValidation:
     def test_mismatched_dim_raises(self):
-        """Dims rejects arrays without a 'time' dimension."""
+        """Dims rejects arrays that are not 1D with dims=('time',)."""
         time = xr.DataArray([0, 1], dims=['time'], coords={'time': [0, 1]})
         bad_dt = xr.DataArray([1.0, 1.0], dims=['other'])
-        with pytest.raises(ValueError, match='must have a "time" dimension'):
+        with pytest.raises(ValueError, match='must be 1D'):
             Dims(time=time, dt=bad_dt, weights=time)
 
     def test_mismatched_coords_raises(self):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import numpy as np
 import pytest
+import xarray as xr
 from conftest import ts
 
-from fluxopt import Carrier, Converter, Effect, Flow, ModelData, Port, Storage, optimize
+from fluxopt import Carrier, Converter, Dims, Effect, Flow, ModelData, Port, Storage, optimize
 
 
 class TestFlowsTable:
@@ -282,3 +284,20 @@ class TestMultiNodeCarrier:
         assert 'heat:A' in carrier_ids
         assert 'heat:B' in carrier_ids
         assert len(carrier_ids) == 2
+
+
+class TestDimsValidation:
+    def test_mismatched_dim_raises(self):
+        """Dims rejects arrays without a 'time' dimension."""
+        time = xr.DataArray([0, 1], dims=['time'], coords={'time': [0, 1]})
+        bad_dt = xr.DataArray([1.0, 1.0], dims=['other'])
+        with pytest.raises(ValueError, match='must have a "time" dimension'):
+            Dims(time=time, dt=bad_dt, weights=time)
+
+    def test_mismatched_coords_raises(self):
+        """Dims rejects arrays with different time coordinates."""
+        time = xr.DataArray([0, 1], dims=['time'], coords={'time': [0, 1]})
+        dt = xr.DataArray([1.0, 1.0], dims=['time'], coords={'time': [0, 1]})
+        bad_weights = xr.DataArray(np.ones(3), dims=['time'], coords={'time': [0, 1, 2]})
+        with pytest.raises(ValueError, match='does not match'):
+            Dims(time=time, dt=dt, weights=bad_weights)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -104,10 +104,10 @@ class TestConvertersTable:
         ds = data.converters
         assert ds is not None
         fuel_coeff = float(
-            ds.flow_coeff.sel(converter='boiler', eq_idx=0, flow='boiler(gas)', time=data.time[0]).values
+            ds.flow_coeff.sel(converter='boiler', eq_idx=0, flow='boiler(gas)', time=data.dims.time[0]).values
         )
         heat_coeff = float(
-            ds.flow_coeff.sel(converter='boiler', eq_idx=0, flow='boiler(heat)', time=data.time[0]).values
+            ds.flow_coeff.sel(converter='boiler', eq_idx=0, flow='boiler(heat)', time=data.dims.time[0]).values
         )
         assert fuel_coeff == 0.9
         assert heat_coeff == -1.0

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -93,7 +93,7 @@ class TestRoundtrip:
             result.data.storages.capacity.coords['storage'].values
         )
         # dt preserved
-        assert loaded.data.dt.values == pytest.approx(result.data.dt.values)
+        assert loaded.data.dims.dt.values == pytest.approx(result.data.dims.dt.values)
 
     def test_model_data_resolve(self, tmp_nc: Path) -> None:
         """Loaded ModelData can build and solve a new model."""

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -92,8 +92,10 @@ class TestRoundtrip:
         assert list(loaded.data.storages.capacity.coords['storage'].values) == list(
             result.data.storages.capacity.coords['storage'].values
         )
-        # dt preserved
-        assert loaded.data.dims.dt.values == pytest.approx(result.data.dims.dt.values)
+        # Dims roundtrip: dt, time, and weights preserved with coordinates
+        xr.testing.assert_equal(loaded.data.dims.dt, result.data.dims.dt)
+        xr.testing.assert_equal(loaded.data.dims.time, result.data.dims.time)
+        xr.testing.assert_equal(loaded.data.dims.weights, result.data.dims.weights)
 
     def test_model_data_resolve(self, tmp_nc: Path) -> None:
         """Loaded ModelData can build and solve a new model."""


### PR DESCRIPTION
## Summary
- Extracts a `Dims` dataclass from `ModelData` to centralize time, dt, and weights
- `Dims` has `build()`, `to_dataset()`, and `from_dataset()` for construction and serialization
- All consumers (`model.py`, `contributions.py`, `stats.py`, tests) now access temporal metadata via `data.dims`
- Prepares the ground for multi-period optimization (#27) by having a single place to add period coordinates

## Test plan
- [x] All 322 tests pass
- [x] ruff check clean
- [x] mypy strict clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed Dims at package root: unified container for time, dt, and weights.

* **Refactor**
  * Unified temporal metadata behind a single dims attribute; code now uses named dimension mappings for variable coordinates and time-related computations.

* **Tests**
  * Updated tests to validate dims roundtrip and to reference dims for time, dt, and weights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->