### PR TITLE
feat: add multi-period optimization

### DIFF
--- a/docs/math/effects.md
+++ b/docs/math/effects.md
@@ -6,12 +6,16 @@ Effects represent quantities that are tracked across the optimization horizon (e
 cost, CO₂ emissions, primary energy). One effect is designated as the objective to
 minimize.
 
-Effects are split into two **domains**:
+Effects are split into three **domains**:
 
 - **Temporal** (with time dimension): per-timestep flow contributions, status costs
-- **Periodic** (without time dimension): sizing costs, fixed yearly costs
+- **Periodic** (without time dimension): recurring costs like sizing, fixed yearly costs
+- **Once** (without time dimension): one-time costs that are not scaled by period weights
 
-Both domains support cross-effect chains via `contribution_from`.
+All domains support cross-effect chains via `contribution_from`.
+
+In multi-period mode, all variables gain an optional `period` dimension. Period
+weights \(\omega_p\) scale the total effect in the objective (see [Objective](objective.md)).
 
 ## Temporal Domain
 
@@ -63,12 +67,22 @@ temporal factor only.
 Self-references (\(\alpha_{k,k}\)) and circular dependencies
 (\(k \to j \to \cdots \to k\)) are rejected at build time to prevent singular systems.
 
-## Total Aggregation
+## Once Domain
 
-The total effect combines both domains:
+One-time costs that should not be scaled by period weights (e.g., investment CAPEX,
+decommissioning costs). Currently constrained to zero — a placeholder for future
+investment modelling:
 
 \[
-\Phi_k = \sum_{t \in \mathcal{T}} \Phi_{k,t}^{\text{temporal}} \cdot w_t + \Phi_k^{\text{periodic}} \quad \forall \, k \in \mathcal{K}
+\Phi_{k(,p)}^{\text{once}} = 0 \quad \forall \, k
+\]
+
+## Total Aggregation
+
+The total effect combines all three domains:
+
+\[
+\Phi_{k(,p)} = \sum_{t \in \mathcal{T}} \Phi_{k,t(,p)}^{\text{temporal}} \cdot w_t + \Phi_{k(,p)}^{\text{periodic}} + \Phi_{k(,p)}^{\text{once}} \quad \forall \, k \in \mathcal{K}
 \]
 
 Weights \(w_t\) allow scaling timesteps (e.g., a representative week scaled to a year).
@@ -97,9 +111,10 @@ This enforces per-hour limits (e.g., maximum hourly emissions).
 
 | Symbol | Description | Reference |
 |---|---|---|
-| \(\Phi_{k,t}^{\text{temporal}}\) | Per-timestep effect variable | `effect_temporal[effect, time]` |
-| \(\Phi_k^{\text{periodic}}\) | Periodic effect variable (sizing, fixed costs) | `effect_periodic[effect]` |
-| \(\Phi_k\) | Total effect variable | `effect_total[effect]` |
+| \(\Phi_{k,t(,p)}^{\text{temporal}}\) | Per-timestep effect variable | `effect_temporal[effect, time(, period)]` |
+| \(\Phi_{k(,p)}^{\text{periodic}}\) | Periodic effect variable (recurring costs) | `effect_periodic[effect(, period)]` |
+| \(\Phi_{k(,p)}^{\text{once}}\) | One-time effect variable | `effect_once[effect(, period)]` |
+| \(\Phi_{k(,p)}\) | Total effect variable | `effect_total[effect(, period)]` |
 | \(c_{f,k,t}\) | Effect coefficient per flow-hour | `Flow.effects_per_flow_hour` |
 | \(\alpha_{k,j,t}\) | Cross-effect contribution factor (per hour) | `Effect.contribution_from_per_hour` |
 | \(\alpha_{k,j}\) | Cross-effect contribution factor (scalar) | `Effect.contribution_from` |

--- a/docs/math/effects.md
+++ b/docs/math/effects.md
@@ -6,16 +6,25 @@ Effects represent quantities that are tracked across the optimization horizon (e
 cost, CO₂ emissions, primary energy). One effect is designated as the objective to
 minimize.
 
-Effects are split into three **domains**:
+Effects are split into three **domains** based on how they vary over time and
+how they are weighted in multi-period optimization:
 
-- **Temporal** (with time dimension): per-timestep flow contributions, status costs
-- **Periodic** (without time dimension): recurring costs like sizing, fixed yearly costs
-- **Once** (without time dimension): one-time costs that are not scaled by period weights
+| Domain | Dims | What goes here | Multi-period weighting |
+|---|---|---|---|
+| **Temporal** | `(effect, time)` | Flow costs, running costs, startup costs — anything that varies per timestep | Summed over time (× \(w_t\)), then weighted like periodic |
+| **Periodic** | `(effect,)` | Recurring costs that repeat each period — sizing costs, fixed annual O&M | Weighted by \(\omega^{\text{periodic}}_{k,p}\) (defaults to global `period_weights`) |
+| **Once** | `(effect,)` | One-time costs at a point in time — CAPEX, decommissioning | Weighted by \(\omega^{\text{once}}_{k,p}\) (defaults to 1, no scaling) |
+
+The key distinction: **periodic** costs are assumed to recur across the gap between
+periods (e.g., annual O&M for 5 years), while **once** costs happen at a specific point
+(e.g., an investment decision in 2025). This matters because their period weights
+differ — recurring costs scale with duration, one-time costs typically don't
+(or use discount factors instead).
 
 All domains support cross-effect chains via `contribution_from`.
 
-In multi-period mode, all variables gain an optional `period` dimension. Period
-weights \(\omega_p\) scale the total effect in the objective (see [Objective](objective.md)).
+In multi-period mode, all variables gain an optional `period` dimension.
+See [Objective](objective.md) for how the domains are weighted in the objective.
 
 ## Temporal Domain
 

--- a/docs/math/notation.md
+++ b/docs/math/notation.md
@@ -8,6 +8,7 @@ Each symbol maps to a specific field or variable in the code.
 | Symbol | Description | Code |
 |---|---|---|
 | \(t \in \mathcal{T}\) | Timesteps | `time` dimension |
+| \(p \in \mathcal{P}\) | Periods (multi-period only) | `period` dimension |
 | \(f \in \mathcal{F}\) | Flows | `flow` dimension |
 | \(b \in \mathcal{B}\) | Buses | `bus` dimension |
 | \(s \in \mathcal{S}\) | Storages | `storage` dimension |
@@ -18,20 +19,21 @@ Each symbol maps to a specific field or variable in the code.
 
 | Symbol | Code | Domain | Unit | Description |
 |---|---|---|---|---|
-| \(P_{f,t}\) | `flow--rate[flow, time]` | \(\geq 0\) | MW | Flow rate |
-| \(E_{s,t}\) | `storage--level[storage, time]` | \(\geq 0\) | MWh | Stored energy |
-| \(\Phi_{k,t}^{\text{temporal}}\) | `effect--temporal[effect, time]` | \(\mathbb{R}\) | varies | Temporal (per-timestep) effect |
-| \(\Phi_k^{\text{periodic}}\) | `effect--periodic[effect]` | \(\mathbb{R}\) | varies | Periodic (investment) effect |
-| \(\Phi_k\) | `effect--total[effect]` | \(\mathbb{R}\) | varies | Total effect over horizon |
-| \(S_f\) | `flow--size[flow]` | \(\geq 0\) | MW | Invested flow capacity |
-| \(y_f\) | `flow--size_indicator[flow]` | \(\{0, 1\}\) | — | Binary invest indicator (flow) |
-| \(S_s\) | `storage--capacity[storage]` | \(\geq 0\) | MWh | Invested storage capacity |
-| \(y_s\) | `storage--size_indicator[storage]` | \(\{0, 1\}\) | — | Binary invest indicator (storage) |
-| \(\sigma_{f,t}\) | `flow--on[flow, time]` | \(\{0, 1\}\) | — | On/off indicator |
-| \(\tau^+_{f,t}\) | `flow--startup[flow, time]` | \(\{0, 1\}\) | — | Startup event indicator |
-| \(\tau^-_{f,t}\) | `flow--shutdown[flow, time]` | \(\{0, 1\}\) | — | Shutdown event indicator |
-| \(D^{\text{up}}_{f,t}\) | `uptime[flow, time]` | \(\geq 0\) | h | Consecutive uptime |
-| \(D^{\text{down}}_{f,t}\) | `downtime[flow, time]` | \(\geq 0\) | h | Consecutive downtime |
+| \(P_{f,t(,p)}\) | `flow--rate[flow, time(, period)]` | \(\geq 0\) | MW | Flow rate |
+| \(E_{s,t(,p)}\) | `storage--level[storage, time(, period)]` | \(\geq 0\) | MWh | Stored energy |
+| \(\Phi_{k,t(,p)}^{\text{temporal}}\) | `effect--temporal[effect, time(, period)]` | \(\mathbb{R}\) | varies | Temporal (per-timestep) effect |
+| \(\Phi_{k(,p)}^{\text{periodic}}\) | `effect--periodic[effect(, period)]` | \(\mathbb{R}\) | varies | Periodic (recurring) effect |
+| \(\Phi_{k(,p)}^{\text{once}}\) | `effect--once[effect(, period)]` | \(\mathbb{R}\) | varies | One-time effect |
+| \(\Phi_{k(,p)}\) | `effect--total[effect(, period)]` | \(\mathbb{R}\) | varies | Total effect per period |
+| \(S_{f(,p)}\) | `flow--size[flow(, period)]` | \(\geq 0\) | MW | Flow capacity |
+| \(y_{f(,p)}\) | `flow--size_indicator[flow(, period)]` | \(\{0, 1\}\) | — | Binary invest indicator (flow) |
+| \(S_{s(,p)}\) | `storage--capacity[storage(, period)]` | \(\geq 0\) | MWh | Storage capacity |
+| \(y_{s(,p)}\) | `storage--size_indicator[storage(, period)]` | \(\{0, 1\}\) | — | Binary invest indicator (storage) |
+| \(\sigma_{f,t(,p)}\) | `flow--on[flow, time(, period)]` | \(\{0, 1\}\) | — | On/off indicator |
+| \(\tau^+_{f,t(,p)}\) | `flow--startup[flow, time(, period)]` | \(\{0, 1\}\) | — | Startup event indicator |
+| \(\tau^-_{f,t(,p)}\) | `flow--shutdown[flow, time(, period)]` | \(\{0, 1\}\) | — | Shutdown event indicator |
+| \(D^{\text{up}}_{f,t(,p)}\) | `uptime[flow, time(, period)]` | \(\geq 0\) | h | Consecutive uptime |
+| \(D^{\text{down}}_{f,t(,p)}\) | `downtime[flow, time(, period)]` | \(\geq 0\) | h | Consecutive downtime |
 
 ## Parameters
 
@@ -63,6 +65,9 @@ Each symbol maps to a specific field or variable in the code.
 | \(u_{f,k,t}\) | `Status.effects_per_startup` | \(\mathbb{R}\) | varies | Startup cost coefficient |
 | \(w_t\) | weights | \(> 0\) | — | Timestep weight |
 | \(\Delta t_t\) | dt | \(> 0\) | h | Timestep duration |
+| \(\omega_p\) | `Dims.period_weights` | \(> 0\) | — | Global period weight (multi-period only) |
+| \(\omega^{\text{periodic}}_{k,p}\) | `Effect.period_weights_periodic` | \(> 0\) | — | Per-effect weight for recurring domain |
+| \(\omega^{\text{once}}_{k,p}\) | `Effect.period_weights_once` | \(> 0\) | — | Per-effect weight for one-time domain |
 
 ## Naming Conventions
 

--- a/docs/math/objective.md
+++ b/docs/math/objective.md
@@ -3,16 +3,39 @@
 ## Formulation
 
 The model minimizes the total value of the designated objective effect \(k^*\)
-(the one with `is_objective=True`):
+(the one with `is_objective=True`).
+
+### Single-period
+
+Without periods, the objective is simply:
 
 \[
 \min \; \Phi_{k^*}
 \]
 
-The total effect combines the temporal and periodic domains:
+### Multi-period
+
+With periods \(p \in \mathcal{P}\), the objective separates recurring and one-time
+domains with independent per-effect weights:
 
 \[
-\Phi_k = \sum_{t \in \mathcal{T}} \Phi_{k,t}^{\text{temporal}} \cdot w_t + \Phi_k^{\text{periodic}}
+\min \; \sum_{p \in \mathcal{P}} \omega^{\text{periodic}}_{k^*,p} \cdot \left(\sum_t \Phi_{k^*,t,p}^{\text{temporal}} \cdot w_t + \Phi_{k^*,p}^{\text{periodic}}\right) + \omega^{\text{once}}_{k^*,p} \cdot \Phi_{k^*,p}^{\text{once}}
+\]
+
+- \(\omega^{\text{periodic}}_{k,p}\) defaults to the global `period_weights` (inferred from
+  gaps between period labels, or explicit). Override per effect via `Effect.period_weights_periodic`.
+- \(\omega^{\text{once}}_{k,p}\) defaults to 1 (no scaling). Override per effect via
+  `Effect.period_weights_once`.
+
+This allows different weighting strategies per effect (e.g., NPV discounting for costs,
+flat weights for emissions).
+
+### Total effect
+
+The total effect per period combines all three domains:
+
+\[
+\Phi_{k(,p)} = \sum_{t \in \mathcal{T}} \Phi_{k,t(,p)}^{\text{temporal}} \cdot w_t + \Phi_{k(,p)}^{\text{periodic}} + \Phi_{k(,p)}^{\text{once}}
 \]
 
 The **temporal** domain accumulates flow contributions, running costs,
@@ -22,11 +45,14 @@ startup costs, and cross-effect contributions per timestep:
 \Phi_{k,t}^{\text{temporal}} = \underbrace{\sum_{f} c_{f,k,t} \cdot P_{f,t} \cdot \Delta t_t}_{\text{flow}} + \underbrace{\sum_{f} r_{f,k,t} \cdot \sigma_{f,t} \cdot \Delta t_t}_{\text{running}} + \underbrace{\sum_{f} u_{f,k,t} \cdot \tau^+_{f,t}}_{\text{startup}} + \underbrace{\sum_{j} \alpha_{k,j,t} \cdot \Phi_{j,t}^{\text{temporal}}}_{\text{cross-effect}}
 \]
 
-The **periodic** domain accumulates sizing costs, fixed costs, and cross-effect contributions:
+The **periodic** domain accumulates recurring sizing costs, fixed costs, and cross-effect contributions:
 
 \[
 \Phi_k^{\text{periodic}} = \underbrace{\sum_{f} \gamma_{f,k} \cdot S_f + \sum_{f} \phi_{f,k} \cdot y_f + \sum_{s} \gamma_{s,k} \cdot S_s + \sum_{s} \phi_{s,k} \cdot y_s}_{\text{direct sizing costs}} + \underbrace{\sum_{j} \alpha_{k,j} \cdot \Phi_j^{\text{periodic}}}_{\text{cross-effect}}
 \]
+
+The **once** domain is reserved for one-time costs (e.g., investment CAPEX)
+that should not be scaled by period weights. Currently constrained to zero.
 
 See [Sizing](sizing.md), [Status](status.md), and [Effects](effects.md) for
 full formulations of each term.
@@ -40,13 +66,18 @@ full formulations of each term.
 | \(P_{f,t}\) | Flow rate variable | `flow--rate[flow, time]` |
 | \(\Delta t_t\) | Timestep duration | dt |
 | \(w_t\) | Timestep weight | weights |
-| \(\Phi_{k,t}^{\text{temporal}}\) | Temporal (per-timestep) effect variable | `effect--temporal[effect, time]` |
-| \(\Phi_k^{\text{periodic}}\) | Periodic effect variable (sizing, fixed costs) | `effect--periodic[effect]` |
-| \(\Phi_k\) | Total effect variable | `effect--total[effect]` |
+| \(\omega^{\text{periodic}}_{k,p}\) | Period weight for recurring domain | `Effect.period_weights_periodic` (fallback: `Dims.period_weights`) |
+| \(\omega^{\text{once}}_{k,p}\) | Period weight for one-time domain | `Effect.period_weights_once` (default: 1) |
+| \(\Phi_{k,t(,p)}^{\text{temporal}}\) | Temporal (per-timestep) effect variable | `effect--temporal[effect, time(, period)]` |
+| \(\Phi_{k(,p)}^{\text{periodic}}\) | Periodic effect variable (recurring costs) | `effect--periodic[effect(, period)]` |
+| \(\Phi_{k(,p)}^{\text{once}}\) | One-time effect variable | `effect--once[effect(, period)]` |
+| \(\Phi_{k(,p)}\) | Total effect variable | `effect--total[effect(, period)]` |
 
 See [Notation](notation.md) for the full symbol table.
 
-## Example
+## Examples
+
+### Single-period
 
 Consider a gas boiler over 3 timesteps (\(\Delta t = 1\,\text{h}\), \(w = 1\)):
 
@@ -58,5 +89,15 @@ Consider a gas boiler over 3 timesteps (\(\Delta t = 1\,\text{h}\), \(w = 1\)):
 
 Total cost: \(\Phi_{\text{cost}} = \sum_t \Phi_{\text{cost},t}^{\text{temporal}} = 60 + 90 + 45 = 195\,\text{€}\)
 
-The optimizer finds the \(P_{f,t}\) values that minimize \(\Phi_{k^*}\) subject to all
-constraints (bus balance, flow bounds, conversion, storage dynamics).
+### Multi-period
+
+Same system with `periods=[2020, 2025]`, `period_weights=[5, 5]`.
+
+Each period has the same 3 timesteps with per-period cost = 30 €. The objective becomes:
+
+\[
+\sum_p \omega_p \cdot \Phi_{\text{cost},p} = 5 \times 30 + 5 \times 30 = 300\,\text{€}
+\]
+
+The optimizer finds the \(P_{f,t(,p)}\) values that minimize the (period-weighted)
+\(\Phi_{k^*}\) subject to all constraints.

--- a/docs/notebooks/04-multi-period.ipynb
+++ b/docs/notebooks/04-multi-period.ipynb
@@ -1,0 +1,362 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Multi-Period Optimization\n",
+    "\n",
+    "Multi-period optimization models systems across multiple planning periods\n",
+    "(e.g. 2025, 2030, 2035). Each period shares the same timestep structure\n",
+    "but can have independent sizing and dispatch decisions.\n",
+    "\n",
+    "This notebook demonstrates:\n",
+    "\n",
+    "1. A gas boiler system with cost **and** CO₂ tracking across 3 periods\n",
+    "2. NPV discounting on costs via `period_weights_periodic` (CO₂ stays flat)\n",
+    "3. Which costs land in **temporal** vs **periodic** vs **once**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "from fluxopt import Carrier, Converter, Effect, Flow, Port, Sizing, optimize"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "## System\n",
+    "\n",
+    "A factory needs heat. A gas boiler is the only supply option,\n",
+    "with capacity to be optimized (sizing).\n",
+    "\n",
+    "```\n",
+    "Gas Grid ──► [gas] ──► Boiler η=90% ──► [heat] ──► Factory\n",
+    " 0.05 €/kWh                                       50–100 kW\n",
+    " 0.2 kg CO₂/kWh\n",
+    "```\n",
+    "\n",
+    "We plan across **3 periods** (2025, 2030, 2035), each representing 5 years.\n",
+    "The representative day has 4 timesteps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "timesteps = [datetime(2025, 1, 15, h) for h in range(6, 10)]\n",
+    "periods = [2025, 2030, 2035]\n",
+    "demand_profile = [0.6, 1.0, 0.8, 0.5]  # relative to size=100 kW"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "## 1. Baseline: global period weights\n",
+    "\n",
+    "With `periods=[2025, 2030, 2035]` the weights are inferred as `[5, 5, 5]`\n",
+    "(gap between labels, last gap repeated) — just like `dt` is inferred from timesteps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = optimize(\n",
+    "    timesteps=timesteps,\n",
+    "    carriers=[Carrier('gas'), Carrier('heat')],\n",
+    "    effects=[\n",
+    "        Effect('cost', unit='EUR', is_objective=True),\n",
+    "        Effect('CO2', unit='kg'),\n",
+    "    ],\n",
+    "    ports=[\n",
+    "        Port(\n",
+    "            'gas_grid',\n",
+    "            imports=[\n",
+    "                Flow('gas', size=1000, effects_per_flow_hour={'cost': 0.05, 'CO2': 0.2}),\n",
+    "            ],\n",
+    "        ),\n",
+    "        Port(\n",
+    "            'factory',\n",
+    "            exports=[\n",
+    "                Flow('heat', size=100, fixed_relative_profile=demand_profile),\n",
+    "            ],\n",
+    "        ),\n",
+    "    ],\n",
+    "    converters=[\n",
+    "        Converter.boiler(\n",
+    "            'boiler',\n",
+    "            thermal_efficiency=0.9,\n",
+    "            fuel_flow=Flow('gas', size=Sizing(50, 200, effects_per_size={'cost': 10})),\n",
+    "            thermal_flow=Flow('heat', size=200),\n",
+    "        ),\n",
+    "    ],\n",
+    "    periods=periods,\n",
+    ")\n",
+    "\n",
+    "result.objective"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "### Where do costs end up?\n",
+    "\n",
+    "Effects are split into three **domains**. Each captures a different kind of cost:\n",
+    "\n",
+    "| Domain | What goes here | This example |\n",
+    "|---|---|---|\n",
+    "| **Temporal** | `effects_per_flow_hour` × flow × dt | Gas fuel cost (0.05 €/kWh), CO₂ (0.2 kg/kWh) |\n",
+    "| **Periodic** | `Sizing.effects_per_size` × size | Boiler sizing cost (10 €/kW) |\n",
+    "| **Once** | *(future: investment CAPEX)* | Currently zero — placeholder |\n",
+    "\n",
+    "**Temporal** — per-timestep fuel costs (vary with dispatch):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result.effects_temporal.sel(effect='cost').to_pandas()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "**Periodic** — recurring sizing costs (boiler size × 10 €/kW):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result.effects_periodic.sel(effect='cost').to_pandas()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "**Once** — one-time costs (zero for now, future CAPEX placeholder):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result.effects_once.sel(effect='cost').to_pandas()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12",
+   "metadata": {},
+   "source": [
+    "**Total** = temporal_sum + periodic + once, per period.\n",
+    "The objective is `sum(period_weight[p] * total[p])` = 5 × total + 5 × total + 5 × total:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result.effect_totals.sel(effect='cost').to_pandas()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "## 2. NPV discounting on cost (CO₂ stays flat)\n",
+    "\n",
+    "Future costs are worth less today. We apply NPV discount factors to the\n",
+    "cost effect via `Effect.period_weights_periodic`, while CO₂ keeps the\n",
+    "global period weights (physical quantity, no discounting).\n",
+    "\n",
+    "With a 5% discount rate and 5-year periods, the annuity sum for each\n",
+    "period is `sum(1/(1+r)^y for y in range(5))` discounted to year 0:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = 0.05\n",
+    "period_years = [0, 5, 10]\n",
+    "\n",
+    "npv_weights = [round(sum(1 / (1 + r) ** (y0 + y) for y in range(5)), 2) for y0 in period_years]\n",
+    "\n",
+    "pd.DataFrame(\n",
+    "    {\n",
+    "        'global (duration)': [5, 5, 5],\n",
+    "        'cost (NPV)': npv_weights,\n",
+    "        'CO2 (no override)': [5, 5, 5],\n",
+    "    },\n",
+    "    index=pd.Index(periods, name='period'),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result_npv = optimize(\n",
+    "    timesteps=timesteps,\n",
+    "    carriers=[Carrier('gas'), Carrier('heat')],\n",
+    "    effects=[\n",
+    "        Effect('cost', unit='EUR', is_objective=True, period_weights_periodic=npv_weights),\n",
+    "        Effect('CO2', unit='kg'),\n",
+    "    ],\n",
+    "    ports=[\n",
+    "        Port(\n",
+    "            'gas_grid',\n",
+    "            imports=[\n",
+    "                Flow('gas', size=1000, effects_per_flow_hour={'cost': 0.05, 'CO2': 0.2}),\n",
+    "            ],\n",
+    "        ),\n",
+    "        Port(\n",
+    "            'factory',\n",
+    "            exports=[\n",
+    "                Flow('heat', size=100, fixed_relative_profile=demand_profile),\n",
+    "            ],\n",
+    "        ),\n",
+    "    ],\n",
+    "    converters=[\n",
+    "        Converter.boiler(\n",
+    "            'boiler',\n",
+    "            thermal_efficiency=0.9,\n",
+    "            fuel_flow=Flow('gas', size=Sizing(50, 200, effects_per_size={'cost': 10})),\n",
+    "            thermal_flow=Flow('heat', size=200),\n",
+    "        ),\n",
+    "    ],\n",
+    "    periods=periods,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17",
+   "metadata": {},
+   "source": [
+    "Same per-period costs, different objective contributions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cost_flat = result.effect_totals.sel(effect='cost').values\n",
+    "cost_npv = result_npv.effect_totals.sel(effect='cost').values\n",
+    "\n",
+    "pd.DataFrame(\n",
+    "    {\n",
+    "        'cost/period': cost_flat.round(2),\n",
+    "        'weight (flat)': [5, 5, 5],\n",
+    "        'contribution (flat)': (cost_flat * 5).round(2),\n",
+    "        'weight (NPV)': npv_weights,\n",
+    "        'contribution (NPV)': (cost_npv * npv_weights).round(2),\n",
+    "    },\n",
+    "    index=pd.Index(periods, name='period'),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.Series(\n",
+    "    {\n",
+    "        'Baseline (flat weights)': round(result.objective, 2),\n",
+    "        'NPV (discounted)': round(result_npv.objective, 2),\n",
+    "    },\n",
+    "    name='objective (EUR)',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20",
+   "metadata": {},
+   "source": [
+    "## Recap: the three domains\n",
+    "\n",
+    "56424\\Phi_{k,p} = \\underbrace{\\sum_t \\Phi^{\\text{temporal}}_{k,t,p} \\cdot w_t}_{\\text{fuel, running, startup}} + \\underbrace{\\Phi^{\\text{periodic}}_{k,p}}_{\\text{sizing, O\\&M}} + \\underbrace{\\Phi^{\\text{once}}_{k,p}}_{\\text{CAPEX (future)}}56424\n",
+    "\n",
+    "The objective weights recurring and one-time costs **separately**:\n",
+    "\n",
+    "56424\\min \\sum_p \\omega^{\\text{periodic}}_{k^*,p} \\cdot (\\text{temporal\\_sum} + \\text{periodic}) + \\omega^{\\text{once}}_{k^*,p} \\cdot \\text{once}56424\n",
+    "\n",
+    "| Weight | Default | Override via | Use case |\n",
+    "|---|---|---|---|\n",
+    "| $\\omega^{\\text{periodic}}_{k,p}$ | Global `period_weights` | `Effect.period_weights_periodic` | NPV, annuity factors |\n",
+    "| $\\omega^{\\text{once}}_{k,p}$ | 1 (no scaling) | `Effect.period_weights_once` | Discount one-time investments |\n",
+    "\n",
+    "The library doesn’t implement NPV — it provides **weight slots**.\n",
+    "You compute the discount factors and pass them in."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/notebooks/04-multi-period.ipynb
+++ b/docs/notebooks/04-multi-period.ipynb
@@ -119,7 +119,7 @@
     "                thermal_efficiency=0.9,\n",
     "                fuel_flow=Flow('gas', size=Sizing(50, 200, effects_per_size={'cost': 10})),\n",
     "                thermal_flow=Flow('heat', size=200),\n",
-    "            ),\n",
+    "            )\n",
     "        ],\n",
     "        'periods': periods,\n",
     "    }\n",

--- a/docs/notebooks/04-multi-period.ipynb
+++ b/docs/notebooks/04-multi-period.ipynb
@@ -7,15 +7,23 @@
    "source": [
     "# Multi-Period Optimization\n",
     "\n",
-    "Multi-period optimization models systems across multiple planning periods\n",
+    "Multi-period optimization extends the model with a **period** dimension\n",
     "(e.g. 2025, 2030, 2035). Each period shares the same timestep structure\n",
-    "but can have independent sizing and dispatch decisions.\n",
+    "but can have independent dispatch and sizing decisions.\n",
     "\n",
-    "This notebook demonstrates:\n",
+    "Period weights scale the objective — they control how much each period\n",
+    "\"counts\". The library provides **weight slots**; you decide the numbers.\n",
     "\n",
-    "1. A gas boiler system with cost **and** CO₂ tracking across 3 periods\n",
-    "2. NPV discounting on costs via `period_weights_periodic` (CO₂ stays flat)\n",
-    "3. Which costs land in **temporal** vs **periodic** vs **once**"
+    "Common choices:\n",
+    "\n",
+    "| Strategy | Weights for `[2025, 2030, 2035]` | Use case |\n",
+    "|---|---|---|\n",
+    "| **Flat (default)** | `[5, 5, 5]` (inferred from gaps) | Equal importance per year |\n",
+    "| **NPV** | `[4.55, 3.56, 2.79]` (discounted) | Present-value costing |\n",
+    "| **Custom** | any `list[float]` | Scenario-specific |\n",
+    "\n",
+    "This notebook shows how to use `period_weights_periodic` on an `Effect`\n",
+    "to apply NPV discounting to costs while keeping CO₂ on flat weights."
    ]
   },
   {
@@ -27,6 +35,7 @@
    "source": [
     "from datetime import datetime\n",
     "\n",
+    "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
     "from fluxopt import Carrier, Converter, Effect, Flow, Port, Sizing, optimize"
@@ -39,17 +48,16 @@
    "source": [
     "## System\n",
     "\n",
-    "A factory needs heat. A gas boiler is the only supply option,\n",
-    "with capacity to be optimized (sizing).\n",
+    "A factory needs heat supplied by a gas boiler whose capacity is optimized.\n",
     "\n",
     "```\n",
     "Gas Grid ──► [gas] ──► Boiler η=90% ──► [heat] ──► Factory\n",
-    " 0.05 €/kWh                                       50–100 kW\n",
+    " 0.05 €/kWh                                       demand profile\n",
     " 0.2 kg CO₂/kWh\n",
     "```\n",
     "\n",
-    "We plan across **3 periods** (2025, 2030, 2035), each representing 5 years.\n",
-    "The representative day has 4 timesteps."
+    "Three planning periods (2025, 2030, 2035), each representing 5 years.\n",
+    "Four representative timesteps per period."
    ]
   },
   {
@@ -69,10 +77,10 @@
    "id": "4",
    "metadata": {},
    "source": [
-    "## 1. Baseline: global period weights\n",
+    "## Flat weights (default)\n",
     "\n",
-    "With `periods=[2025, 2030, 2035]` the weights are inferred as `[5, 5, 5]`\n",
-    "(gap between labels, last gap repeated) — just like `dt` is inferred from timesteps."
+    "When no weights are specified, they are inferred from the gaps between\n",
+    "period labels — here `[5, 5, 5]`. This treats every year equally."
    ]
   },
   {
@@ -82,39 +90,43 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = optimize(\n",
-    "    timesteps=timesteps,\n",
-    "    carriers=[Carrier('gas'), Carrier('heat')],\n",
-    "    effects=[\n",
-    "        Effect('cost', unit='EUR', is_objective=True),\n",
-    "        Effect('CO2', unit='kg'),\n",
-    "    ],\n",
-    "    ports=[\n",
-    "        Port(\n",
-    "            'gas_grid',\n",
-    "            imports=[\n",
-    "                Flow('gas', size=1000, effects_per_flow_hour={'cost': 0.05, 'CO2': 0.2}),\n",
-    "            ],\n",
-    "        ),\n",
-    "        Port(\n",
-    "            'factory',\n",
-    "            exports=[\n",
-    "                Flow('heat', size=100, fixed_relative_profile=demand_profile),\n",
-    "            ],\n",
-    "        ),\n",
-    "    ],\n",
-    "    converters=[\n",
-    "        Converter.boiler(\n",
-    "            'boiler',\n",
-    "            thermal_efficiency=0.9,\n",
-    "            fuel_flow=Flow('gas', size=Sizing(50, 200, effects_per_size={'cost': 10})),\n",
-    "            thermal_flow=Flow('heat', size=200),\n",
-    "        ),\n",
-    "    ],\n",
-    "    periods=periods,\n",
-    ")\n",
+    "def build_system(**effect_kw):\n",
+    "    \"\"\"Build the system with configurable Effect parameters.\"\"\"\n",
+    "    return {\n",
+    "        'timesteps': timesteps,\n",
+    "        'carriers': [Carrier('gas'), Carrier('heat')],\n",
+    "        'effects': [\n",
+    "            Effect('cost', unit='EUR', is_objective=True, **effect_kw),\n",
+    "            Effect('CO2', unit='kg'),\n",
+    "        ],\n",
+    "        'ports': [\n",
+    "            Port(\n",
+    "                'gas_grid',\n",
+    "                imports=[\n",
+    "                    Flow('gas', size=1000, effects_per_flow_hour={'cost': 0.05, 'CO2': 0.2}),\n",
+    "                ],\n",
+    "            ),\n",
+    "            Port(\n",
+    "                'factory',\n",
+    "                exports=[\n",
+    "                    Flow('heat', size=100, fixed_relative_profile=demand_profile),\n",
+    "                ],\n",
+    "            ),\n",
+    "        ],\n",
+    "        'converters': [\n",
+    "            Converter.boiler(\n",
+    "                'boiler',\n",
+    "                thermal_efficiency=0.9,\n",
+    "                fuel_flow=Flow('gas', size=Sizing(50, 200, effects_per_size={'cost': 10})),\n",
+    "                thermal_flow=Flow('heat', size=200),\n",
+    "            ),\n",
+    "        ],\n",
+    "        'periods': periods,\n",
+    "    }\n",
     "\n",
-    "result.objective"
+    "\n",
+    "result_flat = optimize(**build_system())\n",
+    "result_flat.effect_totals.sel(effect='cost').to_pandas()"
    ]
   },
   {
@@ -122,17 +134,8 @@
    "id": "6",
    "metadata": {},
    "source": [
-    "### Where do costs end up?\n",
-    "\n",
-    "Effects are split into three **domains**. Each captures a different kind of cost:\n",
-    "\n",
-    "| Domain | What goes here | This example |\n",
-    "|---|---|---|\n",
-    "| **Temporal** | `effects_per_flow_hour` × flow × dt | Gas fuel cost (0.05 €/kWh), CO₂ (0.2 kg/kWh) |\n",
-    "| **Periodic** | `Sizing.effects_per_size` × size | Boiler sizing cost (10 €/kW) |\n",
-    "| **Once** | *(future: investment CAPEX)* | Currently zero — placeholder |\n",
-    "\n",
-    "**Temporal** — per-timestep fuel costs (vary with dispatch):"
+    "Each period has the same cost (same demand, same system). The objective\n",
+    "sums `weight × total` across periods:"
    ]
   },
   {
@@ -142,7 +145,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result.effects_temporal.sel(effect='cost').to_pandas()"
+    "result_flat.objective  # 5 * total + 5 * total + 5 * total"
    ]
   },
   {
@@ -150,7 +153,12 @@
    "id": "8",
    "metadata": {},
    "source": [
-    "**Periodic** — recurring sizing costs (boiler size × 10 €/kW):"
+    "## NPV weights\n",
+    "\n",
+    "Future costs are worth less today. To discount them, compute your own\n",
+    "weight factors and pass them via `Effect.period_weights_periodic`.\n",
+    "\n",
+    "With a 5% discount rate and 5-year periods:"
    ]
   },
   {
@@ -160,7 +168,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result.effects_periodic.sel(effect='cost').to_pandas()"
+    "r = 0.05\n",
+    "period_offsets = [0, 5, 10]\n",
+    "\n",
+    "# annuity sum for each 5-year block, discounted to year 0\n",
+    "npv_weights = [round(sum(1 / (1 + r) ** (y0 + y) for y in range(5)), 2) for y0 in period_offsets]\n",
+    "\n",
+    "pd.DataFrame(\n",
+    "    {\n",
+    "        'period': periods,\n",
+    "        'flat (default)': [5, 5, 5],\n",
+    "        'NPV (r=5%)': npv_weights,\n",
+    "    }\n",
+    ").set_index('period')"
    ]
   },
   {
@@ -168,7 +188,9 @@
    "id": "10",
    "metadata": {},
    "source": [
-    "**Once** — one-time costs (zero for now, future CAPEX placeholder):"
+    "Now optimize with NPV weights on cost. CO₂ has no override, so it\n",
+    "keeps the global flat weights — physical quantities should not be\n",
+    "discounted."
    ]
   },
   {
@@ -178,7 +200,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result.effects_once.sel(effect='cost').to_pandas()"
+    "result_npv = optimize(**build_system(period_weights_periodic=npv_weights))"
    ]
   },
   {
@@ -186,8 +208,9 @@
    "id": "12",
    "metadata": {},
    "source": [
-    "**Total** = temporal_sum + periodic + once, per period.\n",
-    "The objective is `sum(period_weight[p] * total[p])` = 5 × total + 5 × total + 5 × total:"
+    "## Comparison\n",
+    "\n",
+    "The per-period costs are identical — only the weighting differs:"
    ]
   },
   {
@@ -197,111 +220,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result.effect_totals.sel(effect='cost').to_pandas()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "14",
-   "metadata": {},
-   "source": [
-    "## 2. NPV discounting on cost (CO₂ stays flat)\n",
-    "\n",
-    "Future costs are worth less today. We apply NPV discount factors to the\n",
-    "cost effect via `Effect.period_weights_periodic`, while CO₂ keeps the\n",
-    "global period weights (physical quantity, no discounting).\n",
-    "\n",
-    "With a 5% discount rate and 5-year periods, the annuity sum for each\n",
-    "period is `sum(1/(1+r)^y for y in range(5))` discounted to year 0:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "15",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "r = 0.05\n",
-    "period_years = [0, 5, 10]\n",
-    "\n",
-    "npv_weights = [round(sum(1 / (1 + r) ** (y0 + y) for y in range(5)), 2) for y0 in period_years]\n",
+    "totals_flat = result_flat.effect_totals.sel(effect='cost').values\n",
+    "totals_npv = result_npv.effect_totals.sel(effect='cost').values\n",
     "\n",
     "pd.DataFrame(\n",
     "    {\n",
-    "        'global (duration)': [5, 5, 5],\n",
-    "        'cost (NPV)': npv_weights,\n",
-    "        'CO2 (no override)': [5, 5, 5],\n",
-    "    },\n",
-    "    index=pd.Index(periods, name='period'),\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "16",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "result_npv = optimize(\n",
-    "    timesteps=timesteps,\n",
-    "    carriers=[Carrier('gas'), Carrier('heat')],\n",
-    "    effects=[\n",
-    "        Effect('cost', unit='EUR', is_objective=True, period_weights_periodic=npv_weights),\n",
-    "        Effect('CO2', unit='kg'),\n",
-    "    ],\n",
-    "    ports=[\n",
-    "        Port(\n",
-    "            'gas_grid',\n",
-    "            imports=[\n",
-    "                Flow('gas', size=1000, effects_per_flow_hour={'cost': 0.05, 'CO2': 0.2}),\n",
-    "            ],\n",
-    "        ),\n",
-    "        Port(\n",
-    "            'factory',\n",
-    "            exports=[\n",
-    "                Flow('heat', size=100, fixed_relative_profile=demand_profile),\n",
-    "            ],\n",
-    "        ),\n",
-    "    ],\n",
-    "    converters=[\n",
-    "        Converter.boiler(\n",
-    "            'boiler',\n",
-    "            thermal_efficiency=0.9,\n",
-    "            fuel_flow=Flow('gas', size=Sizing(50, 200, effects_per_size={'cost': 10})),\n",
-    "            thermal_flow=Flow('heat', size=200),\n",
-    "        ),\n",
-    "    ],\n",
-    "    periods=periods,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "17",
-   "metadata": {},
-   "source": [
-    "Same per-period costs, different objective contributions:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "18",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cost_flat = result.effect_totals.sel(effect='cost').values\n",
-    "cost_npv = result_npv.effect_totals.sel(effect='cost').values\n",
-    "\n",
-    "pd.DataFrame(\n",
-    "    {\n",
-    "        'cost/period': cost_flat.round(2),\n",
+    "        'cost/period': totals_flat.round(2),\n",
     "        'weight (flat)': [5, 5, 5],\n",
-    "        'contribution (flat)': (cost_flat * 5).round(2),\n",
+    "        'objective contribution (flat)': (totals_flat * 5).round(2),\n",
     "        'weight (NPV)': npv_weights,\n",
-    "        'contribution (NPV)': (cost_npv * npv_weights).round(2),\n",
+    "        'objective contribution (NPV)': (totals_npv * np.array(npv_weights)).round(2),\n",
     "    },\n",
     "    index=pd.Index(periods, name='period'),\n",
     ")"
@@ -310,14 +238,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
     "pd.Series(\n",
     "    {\n",
-    "        'Baseline (flat weights)': round(result.objective, 2),\n",
-    "        'NPV (discounted)': round(result_npv.objective, 2),\n",
+    "        'Flat (default)': round(result_flat.objective, 2),\n",
+    "        'NPV (r=5%)': round(result_npv.objective, 2),\n",
     "    },\n",
     "    name='objective (EUR)',\n",
     ")"
@@ -325,24 +253,27 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "15",
    "metadata": {},
    "source": [
-    "## Recap: the three domains\n",
+    "## How it works\n",
     "\n",
-    "56424\\Phi_{k,p} = \\underbrace{\\sum_t \\Phi^{\\text{temporal}}_{k,t,p} \\cdot w_t}_{\\text{fuel, running, startup}} + \\underbrace{\\Phi^{\\text{periodic}}_{k,p}}_{\\text{sizing, O\\&M}} + \\underbrace{\\Phi^{\\text{once}}_{k,p}}_{\\text{CAPEX (future)}}56424\n",
+    "The objective function weights each period's total effect:\n",
     "\n",
-    "The objective weights recurring and one-time costs **separately**:\n",
+    "$$\n",
+    "\\min \\sum_p \\omega^{\\text{periodic}}_{k^*,p} \\cdot \\Phi_{k^*,p}\n",
+    "$$\n",
     "\n",
-    "56424\\min \\sum_p \\omega^{\\text{periodic}}_{k^*,p} \\cdot (\\text{temporal\\_sum} + \\text{periodic}) + \\omega^{\\text{once}}_{k^*,p} \\cdot \\text{once}56424\n",
+    "where $\\Phi_{k,p}$ combines temporal (dispatch) and periodic (sizing) costs.\n",
     "\n",
-    "| Weight | Default | Override via | Use case |\n",
+    "| Parameter | Default | Override | Purpose |\n",
     "|---|---|---|---|\n",
-    "| $\\omega^{\\text{periodic}}_{k,p}$ | Global `period_weights` | `Effect.period_weights_periodic` | NPV, annuity factors |\n",
-    "| $\\omega^{\\text{once}}_{k,p}$ | 1 (no scaling) | `Effect.period_weights_once` | Discount one-time investments |\n",
+    "| `period_weights` | Inferred from gaps | `optimize(period_weights=...)` | Global weights for all effects |\n",
+    "| `period_weights_periodic` | Global weights | `Effect(period_weights_periodic=...)` | Per-effect override (e.g. NPV on cost only) |\n",
+    "| `period_weights_once` | `1` (no scaling) | `Effect(period_weights_once=...)` | One-time cost weighting |\n",
     "\n",
-    "The library doesn’t implement NPV — it provides **weight slots**.\n",
-    "You compute the discount factors and pass them in."
+    "The library provides the weight slots — **you** decide the factors.\n",
+    "Flat, NPV, annuity, or any custom scheme."
    ]
   }
  ],
@@ -354,9 +285,9 @@
   },
   "language_info": {
    "name": "python",
-   "version": "3.12.0"
+   "version": "3.13.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
     - Quickstart: notebooks/01-quickstart.ipynb
     - Heat System: notebooks/02-heat-system.ipynb
     - Multi-Node Heat: notebooks/03-multi-node-heat.ipynb
+    - Multi-Period: notebooks/04-multi-period.ipynb
   - Math:
     - Notation: math/notation.md
     - Objective: math/objective.md

--- a/src/fluxopt/__init__.py
+++ b/src/fluxopt/__init__.py
@@ -23,6 +23,8 @@ def optimize(
     converters: list[Converter] | None = None,
     storages: list[Storage] | None = None,
     dt: float | list[float] | None = None,
+    periods: list[int] | None = None,
+    weight_of_last_period: int | float | None = None,
     solver: str = 'highs',
     customize: Callable[[FlowSystem], None] | None = None,
     **kwargs: Any,
@@ -37,12 +39,25 @@ def optimize(
         converters: Linear converters between carriers.
         storages: Energy storages.
         dt: Timestep duration in hours. Auto-derived if None.
+        periods: Integer period labels for multi-period optimization.
+        weight_of_last_period: Duration of the last period. Required when
+            only one period is given; otherwise inferred from the last gap.
         solver: Solver backend name.
         customize: Optional callback to modify the linopy model between build and solve.
             Receives the built FlowSystem; use ``model.m`` to add variables/constraints.
         **kwargs: Passed through to ``linopy.Model.solve()``.
     """
-    data = ModelData.build(timesteps, carriers, effects, ports, converters, storages, dt)
+    data = ModelData.build(
+        timesteps,
+        carriers,
+        effects,
+        ports,
+        converters,
+        storages,
+        dt,
+        periods=periods,
+        weight_of_last_period=weight_of_last_period,
+    )
     model = FlowSystem(data)
     return model.optimize(customize=customize, solver=solver, **kwargs)
 

--- a/src/fluxopt/__init__.py
+++ b/src/fluxopt/__init__.py
@@ -24,7 +24,7 @@ def optimize(
     storages: list[Storage] | None = None,
     dt: float | list[float] | None = None,
     periods: list[int] | None = None,
-    weight_of_last_period: int | float | None = None,
+    period_weights: list[float] | None = None,
     solver: str = 'highs',
     customize: Callable[[FlowSystem], None] | None = None,
     **kwargs: Any,
@@ -40,8 +40,7 @@ def optimize(
         storages: Energy storages.
         dt: Timestep duration in hours. Auto-derived if None.
         periods: Integer period labels for multi-period optimization.
-        weight_of_last_period: Duration of the last period. Required when
-            only one period is given; otherwise inferred from the last gap.
+        period_weights: Explicit weights per period. Inferred from gaps if None.
         solver: Solver backend name.
         customize: Optional callback to modify the linopy model between build and solve.
             Receives the built FlowSystem; use ``model.m`` to add variables/constraints.
@@ -56,7 +55,7 @@ def optimize(
         storages,
         dt,
         periods=periods,
-        weight_of_last_period=weight_of_last_period,
+        period_weights=period_weights,
     )
     model = FlowSystem(data)
     return model.optimize(customize=customize, solver=solver, **kwargs)

--- a/src/fluxopt/elements.py
+++ b/src/fluxopt/elements.py
@@ -129,6 +129,8 @@ class Effect:
     minimum_per_hour: TimeSeries | None = None  # Φ̲_{k,t}  [unit]
     contribution_from: dict[str, float] = field(default_factory=dict)
     contribution_from_per_hour: dict[str, TimeSeries] = field(default_factory=dict)
+    period_weights_periodic: list[float] | None = None  # ω_periodic[p] — scales temporal+periodic
+    period_weights_once: list[float] | None = None  # ω_once[p] — scales once
 
 
 @dataclass

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -29,6 +29,9 @@ class FlowSystem:
     storage_level: Variable | None = None
     prior_storage_level: Variable | None = None
 
+    # Effect variables — set during build
+    effect_once: Variable | None = None
+
     # Status variables — None when no status is configured
     flow_on: Variable | None = None
     flow_startup: Variable | None = None
@@ -126,7 +129,9 @@ class FlowSystem:
         """Create flow rate decision variables P_{f,t} >= 0."""
         ds = self.data.flows
         self.flow_rate = self.m.add_variables(
-            lower=0, coords={'flow': ds.rel_lb.coords['flow'], **self.data.dims.coords(time=True)}, name='flow--rate'
+            lower=0,
+            coords={'flow': ds.rel_lb.coords['flow'], **self.data.dims.coords(time=True, period=True)},
+            name='flow--rate',
         )
 
     def _create_sizing_variables(self) -> None:
@@ -139,13 +144,16 @@ class FlowSystem:
             sizing_ids = fds.sizing_min.coords['sizing_flow'].values
             flow_coord = xr.DataArray(sizing_ids, dims=['flow'])
             upper = fds.sizing_max.rename({'sizing_flow': 'flow'})
-            self.flow_size = self._add_variables(lower=0, upper=upper, coords={'flow': flow_coord}, name='flow--size')
+            pc = self.data.dims.coords(period=True)
+            self.flow_size = self._add_variables(
+                lower=0, upper=upper, coords={'flow': flow_coord, **pc}, name='flow--size'
+            )
             mandatory = fds.sizing_mandatory
             optional_ids = sizing_ids[~mandatory.values]
             if len(optional_ids):
                 self.flow_size_indicator = self._add_variables(
                     binary=True,
-                    coords={'flow': xr.DataArray(optional_ids, dims=['flow'])},
+                    coords={'flow': xr.DataArray(optional_ids, dims=['flow']), **pc},
                     name='flow--size_indicator',
                 )
 
@@ -157,15 +165,16 @@ class FlowSystem:
             sizing_ids = sds.sizing_min.coords['sizing_storage'].values
             stor_coord = xr.DataArray(sizing_ids, dims=['storage'])
             upper = sds.sizing_max.rename({'sizing_storage': 'storage'})
+            pc = self.data.dims.coords(period=True)
             self.storage_capacity = self._add_variables(
-                lower=0, upper=upper, coords={'storage': stor_coord}, name='storage--capacity'
+                lower=0, upper=upper, coords={'storage': stor_coord, **pc}, name='storage--capacity'
             )
             mandatory = sds.sizing_mandatory
             optional_ids = sizing_ids[~mandatory.values]
             if len(optional_ids):
                 self.storage_capacity_indicator = self._add_variables(
                     binary=True,
-                    coords={'storage': xr.DataArray(optional_ids, dims=['storage'])},
+                    coords={'storage': xr.DataArray(optional_ids, dims=['storage']), **pc},
                     name='storage--size_indicator',
                 )
 
@@ -177,7 +186,7 @@ class FlowSystem:
 
         status_ids = ds.status_min_uptime.coords['status_flow'].values
         flow_coord = xr.DataArray(status_ids, dims=['flow'])
-        tp = {'flow': flow_coord, **self.data.dims.coords(time=True)}
+        tp = {'flow': flow_coord, **self.data.dims.coords(time=True, period=True)}
 
         self.flow_on = self._add_variables(binary=True, coords=tp, name='flow--on')
         self.flow_startup = self._add_variables(binary=True, coords=tp, name='flow--startup')
@@ -513,7 +522,7 @@ class FlowSystem:
         self.m.add_constraints(lhs == 0, name='conversion', mask=mask_3d)
 
     def _create_effects(self) -> None:
-        """Effect tracking: temporal (per-timestep) and periodic (investment) domains."""
+        """Effect tracking: temporal, periodic, and one-time domains."""
         d = self.data
         ds = d.effects
 
@@ -522,9 +531,10 @@ class FlowSystem:
         if len(effect_ids) == 0:
             return
 
-        # --- Temporal domain: effect_temporal[effect, time] ---
+        # --- Temporal domain: effect_temporal[effect, time(, period)] ---
         self.effect_temporal = self.m.add_variables(
-            coords={'effect': effect_ids, **self.data.dims.coords(time=True)}, name='effect--temporal'
+            coords={'effect': effect_ids, **self.data.dims.coords(time=True, period=True)},
+            name='effect--temporal',
         )
 
         # Flow contributions: sum_f(coeff_{f,k,t} * P_{f,t} * dt_t)
@@ -568,8 +578,9 @@ class FlowSystem:
         if has_max_ph.any():
             self.m.add_constraints(self.effect_temporal <= max_ph, name='effect_max_ph', mask=has_max_ph)
 
-        # --- Periodic domain: effect_periodic[effect] ---
-        self.effect_periodic = self.m.add_variables(coords={'effect': effect_ids}, name='effect--periodic')
+        # --- Periodic domain: effect_periodic[effect(, period)] ---
+        pc = self.data.dims.coords(period=True)
+        self.effect_periodic = self.m.add_variables(coords={'effect': effect_ids, **pc}, name='effect--periodic')
 
         # Accumulate direct investment contributions per effect
         periodic_direct: Any = 0
@@ -642,12 +653,19 @@ class FlowSystem:
 
         self.m.add_constraints(self.effect_periodic == periodic_rhs, name='effect_periodic_eq')
 
-        # --- Total: effect_total[effect] = sum_t(temporal * w) + periodic ---
-        self.effect_total = self.m.add_variables(coords={'effect': effect_ids}, name='effect--total')
-        rhs = (self.effect_temporal * d.dims.weights).sum('time') + self.effect_periodic
+        # --- One-time domain: effect_once[effect(, period)] ---
+        # Costs that occur once per period, not scaled by period_weight.
+        # Currently no inputs — placeholder for future investment costs.
+        self.effect_once = self.m.add_variables(coords={'effect': effect_ids, **pc}, name='effect--once')
+        self.m.add_constraints(self.effect_once == 0, name='effect_once_eq')
+
+        # --- Total: effect_total[effect(, period)] ---
+        self.effect_total = self.m.add_variables(coords={'effect': effect_ids, **pc}, name='effect--total')
+        temporal_sum = (self.effect_temporal * d.dims.weights).sum('time')
+        rhs = temporal_sum + self.effect_periodic + self.effect_once
         self.m.add_constraints(self.effect_total == rhs, name='effect_total_eq')
 
-        # Bounds on effect_total
+        # Bounds on effect_total (per-period when multi-period)
         min_total = ds.min_total  # (effect,) — NaN = unbounded
         max_total = ds.max_total
 
@@ -668,9 +686,11 @@ class FlowSystem:
 
         stor_ids = ds.capacity.coords['storage']
 
-        # storage_level[storage, time] >= 0  (end-of-period convention)
+        # storage_level[storage, time(, period)] >= 0  (end-of-period convention)
         self.storage_level = self.m.add_variables(
-            lower=0, coords={'storage': stor_ids, **self.data.dims.coords(time=True)}, name='storage--level'
+            lower=0,
+            coords={'storage': stor_ids, **self.data.dims.coords(time=True, period=True)},
+            name='storage--level',
         )
 
         # --- Capacity bounds on storage_level ---
@@ -755,7 +775,9 @@ class FlowSystem:
         # --- Prior variable + single balance for ALL storages ---
         # prior[storage] is a free variable representing the state before period 0.
         # Cyclic and fixed-prior constraints pin it; otherwise it's free.
-        self.prior_storage_level = self.m.add_variables(lower=0, coords={'storage': stor_ids}, name='storage--prior')
+        self.prior_storage_level = self.m.add_variables(
+            lower=0, coords={'storage': stor_ids, **self.data.dims.coords(period=True)}, name='storage--prior'
+        )
 
         add_accumulation_constraints(
             self.m,
@@ -786,7 +808,9 @@ class FlowSystem:
             )
 
     def _set_objective(self) -> None:
-        """Set objective: minimize the objective effect total."""
+        """Set objective: minimize the (period-weighted) objective effect total."""
         obj_effect = self.data.effects.objective_effect
-        obj = self.effect_total.sel(effect=obj_effect).sum()
+        obj_total = self.effect_total.sel(effect=obj_effect)
+        pw = self.data.dims.period_weights
+        obj = (obj_total * pw).sum() if pw is not None else obj_total.sum()
         self.m.add_objective(obj)

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -808,9 +808,22 @@ class FlowSystem:
             )
 
     def _set_objective(self) -> None:
-        """Set objective: minimize the (period-weighted) objective effect total."""
-        obj_effect = self.data.effects.objective_effect
-        obj_total = self.effect_total.sel(effect=obj_effect)
-        pw = self.data.dims.period_weights
-        obj = (obj_total * pw).sum() if pw is not None else obj_total.sum()
-        self.m.add_objective(obj)
+        """Set objective: minimize the (period-weighted) objective effect total.
+
+        Objective = sum_p( ω_periodic[k*,p] * (temporal_sum + periodic) + ω_once[k*,p] * once )
+
+        ω_periodic defaults to global period_weights (or 1 in single-period).
+        ω_once defaults to 1.
+        """
+        k = self.data.effects.objective_effect
+        w_periodic, w_once = self.data.effects.objective_weights(self.data.dims.period_weights)
+
+        assert self.effect_temporal is not None
+        assert self.effect_periodic is not None
+        assert self.effect_once is not None
+
+        temporal_sum = (self.effect_temporal.sel(effect=k) * self.data.dims.weights).sum('time')
+        recurring = temporal_sum + self.effect_periodic.sel(effect=k)
+        once = self.effect_once.sel(effect=k)
+
+        self.m.add_objective((w_periodic * recurring + w_once * once).sum())

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -812,7 +812,11 @@ class EffectsData:
                         if len(e.period_weights_periodic) != n_periods:
                             msg = f'Effect {e.id!r}: period_weights_periodic has {len(e.period_weights_periodic)} entries, expected {n_periods}'
                             raise ValueError(msg)
-                        mat[i] = e.period_weights_periodic
+                        vals = np.asarray(e.period_weights_periodic, dtype=float)
+                        if not np.all(np.isfinite(vals)) or not np.all(vals > 0):
+                            msg = f'Effect {e.id!r}: period_weights_periodic must be positive and finite, got {vals}'
+                            raise ValueError(msg)
+                        mat[i] = vals
                 pw_periodic = xr.DataArray(
                     mat, dims=['effect', 'period'], coords={'effect': effect_ids, 'period': period}
                 )
@@ -823,7 +827,11 @@ class EffectsData:
                         if len(e.period_weights_once) != n_periods:
                             msg = f'Effect {e.id!r}: period_weights_once has {len(e.period_weights_once)} entries, expected {n_periods}'
                             raise ValueError(msg)
-                        mat[i] = e.period_weights_once
+                        vals = np.asarray(e.period_weights_once, dtype=float)
+                        if not np.all(np.isfinite(vals)) or not np.all(vals > 0):
+                            msg = f'Effect {e.id!r}: period_weights_once must be positive and finite, got {vals}'
+                            raise ValueError(msg)
+                        mat[i] = vals
                 pw_once = xr.DataArray(mat, dims=['effect', 'period'], coords={'effect': effect_ids, 'period': period})
 
         return cls(
@@ -998,6 +1006,9 @@ def _compute_period_weights(
     else:
         gaps = np.diff(idx.to_numpy().astype(int))
         w = np.append(gaps, gaps[-1])
+
+    if not np.all(np.isfinite(w)) or not np.all(w > 0):
+        raise ValueError(f'period_weights must be positive and finite, got {w}')
 
     return idx, xr.DataArray(w, dims=['period'], coords={'period': idx}, name='period_weight')
 

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -639,6 +639,8 @@ class EffectsData:
     objective_effect: str
     cf_periodic: xr.DataArray | None = None  # (effect, source_effect)
     cf_temporal: xr.DataArray | None = None  # (effect, source_effect, time)
+    period_weights_periodic: xr.DataArray | None = None  # (effect, period)
+    period_weights_once: xr.DataArray | None = None  # (effect, period)
 
     def __post_init__(self) -> None:
         """Validate exactly one objective effect exists."""
@@ -649,6 +651,35 @@ class EffectsData:
             raise ValueError(
                 f'Multiple objective effects: {list(self.is_objective.coords["effect"][self.is_objective].values)}. Only one is allowed.'
             )
+
+    def objective_weights(
+        self,
+        global_period_weights: xr.DataArray | None,
+    ) -> tuple[xr.DataArray | int, xr.DataArray | int]:
+        """Resolve period weights for the objective effect's two domains.
+
+        Args:
+            global_period_weights: Default period weights from Dims (or None).
+
+        Returns:
+            (w_periodic, w_once) — weights for recurring and one-time domains.
+            Falls back to global_period_weights / 1 when no per-effect override.
+        """
+        k = self.objective_effect
+
+        if self.period_weights_periodic is not None and not self.period_weights_periodic.sel(effect=k).isnull().all():
+            w_periodic: xr.DataArray | int = self.period_weights_periodic.sel(effect=k)
+        elif global_period_weights is not None:
+            w_periodic = global_period_weights
+        else:
+            w_periodic = 1
+
+        if self.period_weights_once is not None and not self.period_weights_once.sel(effect=k).isnull().all():
+            w_once: xr.DataArray | int = self.period_weights_once.sel(effect=k)
+        else:
+            w_once = 1
+
+        return w_periodic, w_once
 
     def to_dataset(self) -> xr.Dataset:
         """Serialize to xr.Dataset."""
@@ -671,12 +702,18 @@ class EffectsData:
         return cls(**kwargs)  # type: ignore[arg-type]
 
     @classmethod
-    def build(cls, effects: list[Effect], time: TimeIndex) -> Self:
+    def build(
+        cls,
+        effects: list[Effect],
+        time: TimeIndex,
+        period: pd.Index | None = None,
+    ) -> Self:
         """Build EffectsData from element objects.
 
         Args:
             effects: Effect definitions.
             time: Time index.
+            period: Period index (multi-period only).
         """
         effect_ids = [e.id for e in effects]
         effect_set = set(effect_ids)
@@ -761,6 +798,34 @@ class EffectsData:
 
         effect_idx = pd.Index(effect_ids, name='effect')
 
+        # Per-effect period weights
+        pw_periodic: xr.DataArray | None = None
+        pw_once: xr.DataArray | None = None
+        if period is not None:
+            has_pw_periodic = any(e.period_weights_periodic is not None for e in effects)
+            has_pw_once = any(e.period_weights_once is not None for e in effects)
+            n_periods = len(period)
+            if has_pw_periodic:
+                mat = np.full((n, n_periods), np.nan)
+                for i, e in enumerate(effects):
+                    if e.period_weights_periodic is not None:
+                        if len(e.period_weights_periodic) != n_periods:
+                            msg = f'Effect {e.id!r}: period_weights_periodic has {len(e.period_weights_periodic)} entries, expected {n_periods}'
+                            raise ValueError(msg)
+                        mat[i] = e.period_weights_periodic
+                pw_periodic = xr.DataArray(
+                    mat, dims=['effect', 'period'], coords={'effect': effect_ids, 'period': period}
+                )
+            if has_pw_once:
+                mat = np.full((n, n_periods), np.nan)
+                for i, e in enumerate(effects):
+                    if e.period_weights_once is not None:
+                        if len(e.period_weights_once) != n_periods:
+                            msg = f'Effect {e.id!r}: period_weights_once has {len(e.period_weights_once)} entries, expected {n_periods}'
+                            raise ValueError(msg)
+                        mat[i] = e.period_weights_once
+                pw_once = xr.DataArray(mat, dims=['effect', 'period'], coords={'effect': effect_ids, 'period': period})
+
         return cls(
             min_total=xr.DataArray(min_total, dims=['effect'], coords={'effect': effect_ids}),
             max_total=xr.DataArray(max_total, dims=['effect'], coords={'effect': effect_ids}),
@@ -770,6 +835,8 @@ class EffectsData:
             objective_effect=objective_effect,
             cf_periodic=cf_periodic,
             cf_temporal=cf_temporal,
+            period_weights_periodic=pw_periodic,
+            period_weights_once=pw_once,
         )
 
 
@@ -903,18 +970,14 @@ class StoragesData:
 
 def _compute_period_weights(
     periods: list[int] | pd.Index,
-    weight_of_last_period: int | float | None = None,
+    period_weights: list[float] | None = None,
 ) -> tuple[pd.Index, xr.DataArray]:
     """Compute period weights from a period index.
 
-    Weights are the duration of each period, i.e. the gap to the next period.
-    For the last period, ``weight_of_last_period`` is used (inferred from the
-    last interval when omitted).
-
     Args:
         periods: Integer period labels (e.g. [2020, 2025, 2030]).
-        weight_of_last_period: Duration of the last period. Required when
-            only one period is given; otherwise inferred from the last gap.
+        period_weights: Explicit weights per period. If None, inferred from
+            ``np.diff(periods)`` with the last gap repeated.
 
     Returns:
         Tuple of (period_index, period_weights DataArray).
@@ -924,13 +987,19 @@ def _compute_period_weights(
         raise TypeError(f'periods must be integer, got {idx.dtype}')
     if not idx.is_monotonic_increasing or not idx.is_unique:
         raise ValueError('periods must be monotonically increasing and unique')
-    if weight_of_last_period is None:
-        if len(idx) < 2:
-            raise ValueError('weight_of_last_period is required when only one period is given')
-        weight_of_last_period = int(idx[-1]) - int(idx[-2])
-    extra = idx.append(pd.Index([int(idx[-1]) + weight_of_last_period], name='period'))
-    weights = np.diff(extra.to_numpy().astype(int))
-    return idx, xr.DataArray(weights, dims=['period'], coords={'period': idx}, name='period_weight')
+
+    if period_weights is not None:
+        if len(period_weights) != len(idx):
+            msg = f'period_weights has {len(period_weights)} entries, expected {len(idx)}'
+            raise ValueError(msg)
+        w = np.asarray(period_weights, dtype=float)
+    elif len(idx) < 2:
+        raise ValueError('period_weights is required when only one period is given')
+    else:
+        gaps = np.diff(idx.to_numpy().astype(int))
+        w = np.append(gaps, gaps[-1])
+
+    return idx, xr.DataArray(w, dims=['period'], coords={'period': idx}, name='period_weight')
 
 
 @dataclass
@@ -999,7 +1068,7 @@ class Dims:
         time: TimeIndex,
         dt: xr.DataArray,
         periods: list[int] | pd.Index | None = None,
-        weight_of_last_period: int | float | None = None,
+        period_weights: list[float] | None = None,
     ) -> Self:
         """Build Dims from a time index and optional periods.
 
@@ -1007,7 +1076,7 @@ class Dims:
             time: Normalized time index.
             dt: Timestep durations.
             periods: Integer period labels for multi-period optimization.
-            weight_of_last_period: Duration of the last period.
+            period_weights: Explicit weights per period. Inferred from gaps if None.
         """
         time_coord = xr.DataArray(time, dims=['time'], coords={'time': time})
         weights = xr.DataArray(np.ones(len(time)), dims=['time'], coords={'time': time}, name='weight')
@@ -1015,7 +1084,7 @@ class Dims:
         period_da: xr.DataArray | None = None
         period_weights_da: xr.DataArray | None = None
         if periods is not None:
-            period_idx, period_weights_da = _compute_period_weights(periods, weight_of_last_period)
+            period_idx, period_weights_da = _compute_period_weights(periods, period_weights)
             period_da = xr.DataArray(period_idx.values, dims=['period'], coords={'period': period_idx})
 
         return cls(
@@ -1104,7 +1173,7 @@ class ModelData:
         storages: list[Storage] | None = None,
         dt: float | list[float] | None = None,
         periods: list[int] | pd.Index | None = None,
-        weight_of_last_period: int | float | None = None,
+        period_weights: list[float] | None = None,
     ) -> Self:
         """Build ModelData from element objects.
 
@@ -1117,8 +1186,7 @@ class ModelData:
             storages: Energy storages.
             dt: Timestep duration in hours. Auto-derived if None.
             periods: Integer period labels for multi-period optimization.
-            weight_of_last_period: Duration of the last period. Required when
-                only one period is given; otherwise inferred from the last gap.
+            period_weights: Explicit weights per period. Inferred from gaps if None.
         """
         from fluxopt.elements import PENALTY_EFFECT_ID, Effect
         from fluxopt.types import compute_dt as _compute_dt
@@ -1134,14 +1202,15 @@ class ModelData:
         flows, carrier_coeff = _collect_flows(ports, converters, stor_list)
         _validate_system(effects, ports, converters, stor_list, flows, carriers)
 
-        dims = Dims.build(time, dt_da, periods=periods, weight_of_last_period=weight_of_last_period)
+        dims = Dims.build(time, dt_da, periods=periods, period_weights=period_weights)
 
         # Scalar dt for prior duration computation (use first timestep)
         dt_scalar = float(dims.dt.values[0])
         flows_data = FlowsData.build(flows, time, effects, dt=dt_scalar)
         carriers_data = CarriersData.build(carriers, flows, carrier_coeff)
         converters_data = ConvertersData.build(converters, time)
-        effects_data = EffectsData.build(effects, time)
+        period_idx = pd.Index(dims.period.values) if dims.period is not None else None
+        effects_data = EffectsData.build(effects, time, period=period_idx)
         storages_data = StoragesData.build(stor_list, time, dims.dt, effects)
 
         return cls(

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -901,16 +901,50 @@ class StoragesData:
         )
 
 
+def _compute_period_weights(
+    periods: list[int] | pd.Index,
+    weight_of_last_period: int | float | None = None,
+) -> tuple[pd.Index, xr.DataArray]:
+    """Compute period weights from a period index.
+
+    Weights are the duration of each period, i.e. the gap to the next period.
+    For the last period, ``weight_of_last_period`` is used (inferred from the
+    last interval when omitted).
+
+    Args:
+        periods: Integer period labels (e.g. [2020, 2025, 2030]).
+        weight_of_last_period: Duration of the last period. Required when
+            only one period is given; otherwise inferred from the last gap.
+
+    Returns:
+        Tuple of (period_index, period_weights DataArray).
+    """
+    idx = pd.Index(periods, name='period')
+    if not np.issubdtype(idx.dtype, np.integer):  # type: ignore[arg-type]
+        raise TypeError(f'periods must be integer, got {idx.dtype}')
+    if not idx.is_monotonic_increasing or not idx.is_unique:
+        raise ValueError('periods must be monotonically increasing and unique')
+    if weight_of_last_period is None:
+        if len(idx) < 2:
+            raise ValueError('weight_of_last_period is required when only one period is given')
+        weight_of_last_period = int(idx[-1]) - int(idx[-2])
+    extra = idx.append(pd.Index([int(idx[-1]) + weight_of_last_period], name='period'))
+    weights = np.diff(extra.to_numpy().astype(int))
+    return idx, xr.DataArray(weights, dims=['period'], coords={'period': idx}, name='period_weight')
+
+
 @dataclass
 class Dims:
     """Shared model coordinates and temporal metadata.
 
-    Owns the time dimension, timestep durations, and weights.
+    Owns the time and period dimensions, timestep durations, and weights.
     """
 
     time: xr.DataArray  # (time,) — coordinate labels
     dt: xr.DataArray  # (time,) — timestep durations [h]
     weights: xr.DataArray  # (time,) — timestep weights
+    period: xr.DataArray | None = None  # (period,) — coordinate labels
+    period_weights: xr.DataArray | None = None  # (period,) — duration weights
 
     def __post_init__(self) -> None:
         for name, arr in [('dt', self.dt), ('weights', self.weights)]:
@@ -919,43 +953,78 @@ class Dims:
             if not arr.coords['time'].equals(self.time):
                 raise ValueError(f'Dims.{name} time coordinate does not match Dims.time')
 
-    def coords(self, *, time: bool = False) -> dict[str, xr.DataArray]:
+    def coords(self, *, time: bool = False, period: bool = False) -> dict[str, xr.DataArray]:
         """Return shared coordinates for variable/DataArray creation.
 
         Args:
             time: Include the time coordinate.
+            period: Include the period coordinate (no-op in single-period mode).
         """
         result: dict[str, xr.DataArray] = {}
         if time:
             result['time'] = self.time
+        if period and self.period is not None:
+            result['period'] = self.period
         return result
 
     def to_dataset(self) -> xr.Dataset:
         """Serialize to xr.Dataset."""
-        return xr.Dataset({'dt': self.dt, 'weights': self.weights})
+        data_vars: dict[str, xr.DataArray] = {'dt': self.dt, 'weights': self.weights}
+        if self.period is not None:
+            data_vars['period'] = self.period
+        if self.period_weights is not None:
+            data_vars['period_weights'] = self.period_weights
+        return xr.Dataset(data_vars)
 
     @classmethod
     def from_dataset(cls, ds: xr.Dataset) -> Self:
         """Deserialize from xr.Dataset.
 
         Args:
-            ds: Dataset with dt and weights.
+            ds: Dataset with dt, weights, and optional period fields.
         """
         dt = ds['dt']
         time_idx = dt.coords['time']
-        return cls(time=time_idx, dt=dt, weights=ds['weights'])
+        return cls(
+            time=time_idx,
+            dt=dt,
+            weights=ds['weights'],
+            period=ds.get('period', None),
+            period_weights=ds.get('period_weights', None),
+        )
 
     @classmethod
-    def build(cls, time: TimeIndex, dt: xr.DataArray) -> Self:
-        """Build Dims from a time index.
+    def build(
+        cls,
+        time: TimeIndex,
+        dt: xr.DataArray,
+        periods: list[int] | pd.Index | None = None,
+        weight_of_last_period: int | float | None = None,
+    ) -> Self:
+        """Build Dims from a time index and optional periods.
 
         Args:
             time: Normalized time index.
             dt: Timestep durations.
+            periods: Integer period labels for multi-period optimization.
+            weight_of_last_period: Duration of the last period.
         """
         time_coord = xr.DataArray(time, dims=['time'], coords={'time': time})
         weights = xr.DataArray(np.ones(len(time)), dims=['time'], coords={'time': time}, name='weight')
-        return cls(time=time_coord, dt=dt, weights=weights)
+
+        period_da: xr.DataArray | None = None
+        period_weights_da: xr.DataArray | None = None
+        if periods is not None:
+            period_idx, period_weights_da = _compute_period_weights(periods, weight_of_last_period)
+            period_da = xr.DataArray(period_idx.values, dims=['period'], coords={'period': period_idx})
+
+        return cls(
+            time=time_coord,
+            dt=dt,
+            weights=weights,
+            period=period_da,
+            period_weights=period_weights_da,
+        )
 
 
 @dataclass
@@ -1034,6 +1103,8 @@ class ModelData:
         converters: list[Converter] | None = None,
         storages: list[Storage] | None = None,
         dt: float | list[float] | None = None,
+        periods: list[int] | pd.Index | None = None,
+        weight_of_last_period: int | float | None = None,
     ) -> Self:
         """Build ModelData from element objects.
 
@@ -1045,6 +1116,9 @@ class ModelData:
             converters: Linear converters.
             storages: Energy storages.
             dt: Timestep duration in hours. Auto-derived if None.
+            periods: Integer period labels for multi-period optimization.
+            weight_of_last_period: Duration of the last period. Required when
+                only one period is given; otherwise inferred from the last gap.
         """
         from fluxopt.elements import PENALTY_EFFECT_ID, Effect
         from fluxopt.types import compute_dt as _compute_dt
@@ -1060,7 +1134,7 @@ class ModelData:
         flows, carrier_coeff = _collect_flows(ports, converters, stor_list)
         _validate_system(effects, ports, converters, stor_list, flows, carriers)
 
-        dims = Dims.build(time, dt_da)
+        dims = Dims.build(time, dt_da, periods=periods, weight_of_last_period=weight_of_last_period)
 
         # Scalar dt for prior duration computation (use first timestep)
         dt_scalar = float(dims.dt.values[0])

--- a/src/fluxopt/results.py
+++ b/src/fluxopt/results.py
@@ -64,6 +64,11 @@ class Result:
         """Per-period (investment) effect values as (effect,) DataArray."""
         return self.solution['effect--periodic']
 
+    @property
+    def effects_once(self) -> xr.DataArray:
+        """One-time effect values as (effect,) DataArray."""
+        return self.solution['effect--once']
+
     def flow_rate(self, flow_id: str) -> xr.DataArray:
         """Get flow rate time series for a single flow.
 
@@ -169,6 +174,8 @@ class Result:
             'effect--temporal': model.effect_temporal.solution,
             'effect--periodic': model.effect_periodic.solution,
         }
+        if model.effect_once is not None:
+            sol_vars['effect--once'] = model.effect_once.solution
 
         if model.storage_level is not None:
             sol_vars['storage--level'] = model.storage_level.solution

--- a/tests/math_port/conftest.py
+++ b/tests/math_port/conftest.py
@@ -49,7 +49,7 @@ def optimize(request, tmp_path):
                 kwargs.get('storages'),
                 kwargs.get('dt'),
                 periods=kwargs.get('periods'),
-                weight_of_last_period=kwargs.get('weight_of_last_period'),
+                period_weights=kwargs.get('period_weights'),
             )
             path = tmp_path / 'data.nc'
             data.to_netcdf(path, mode='w')

--- a/tests/math_port/conftest.py
+++ b/tests/math_port/conftest.py
@@ -48,6 +48,8 @@ def optimize(request, tmp_path):
                 kwargs.get('converters'),
                 kwargs.get('storages'),
                 kwargs.get('dt'),
+                periods=kwargs.get('periods'),
+                weight_of_last_period=kwargs.get('weight_of_last_period'),
             )
             path = tmp_path / 'data.nc'
             data.to_netcdf(path, mode='w')

--- a/tests/math_port/test_multi_period.py
+++ b/tests/math_port/test_multi_period.py
@@ -1,36 +1,73 @@
-"""Mathematical correctness tests for multi-period optimization.
+"""Mathematical correctness tests for multi-period optimization."""
 
-All tests skipped — multi-period optimization is not supported in fluxopt.
-"""
-
+import numpy as np
 import pytest
+from conftest import ts
+from numpy.testing import assert_allclose
+
+from fluxopt import Carrier, Effect, Flow, Port
 
 
-@pytest.mark.skip(reason='multi-period optimization not supported in fluxopt')
 class TestMultiPeriod:
     def test_period_weights_affect_objective(self, optimize):
-        """Proves: period weights scale per-period costs in the objective."""
+        """Proves: period weights scale per-period costs in the objective.
 
+        3 timesteps, periods=[2020, 2025], weight_of_last_period=5.
+        Weights = [5, 5] (2025-2020=5, last=5).
+        Grid @1 cost/MWh, Demand=[10, 10, 10]. Per-period cost=30.
+        Objective = 5*30 + 5*30 = 300.
+        """
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([10, 10, 10])),
+                    ],
+                ),
+                Port(
+                    'Grid',
+                    imports=[
+                        Flow('Heat', effects_per_flow_hour={'cost': 1}),
+                    ],
+                ),
+            ],
+            periods=[2020, 2025],
+            weight_of_last_period=5,
+        )
+        assert_allclose(result.objective, 300.0, rtol=1e-5)
+
+    @pytest.mark.skip(reason='multi-period over-period constraints not yet implemented')
     def test_flow_hours_max_over_periods(self, optimize):
         """Proves: flow_hours_max_over_periods caps the weighted total flow-hours."""
 
+    @pytest.mark.skip(reason='multi-period over-period constraints not yet implemented')
     def test_flow_hours_min_over_periods(self, optimize):
         """Proves: flow_hours_min_over_periods forces a minimum weighted total."""
 
+    @pytest.mark.skip(reason='multi-period over-period constraints not yet implemented')
     def test_effect_maximum_over_periods(self, optimize):
         """Proves: Effect.maximum_over_periods caps weighted total of an effect."""
 
+    @pytest.mark.skip(reason='multi-period over-period constraints not yet implemented')
     def test_effect_minimum_over_periods(self, optimize):
         """Proves: Effect.minimum_over_periods forces minimum weighted total."""
 
+    @pytest.mark.skip(reason='multi-period linked periods not yet implemented')
     def test_invest_linked_periods(self, optimize):
         """Proves: InvestParameters.linked_periods forces equal sizes across periods."""
 
+    @pytest.mark.skip(reason='multi-period per-effect period weights not yet implemented')
     def test_effect_period_weights(self, optimize):
         """Proves: Effect.period_weights overrides default period weights."""
 
+    @pytest.mark.skip(reason='multi-period storage constraints not yet implemented')
     def test_storage_relative_minimum_final_level_scalar(self, optimize):
         """Proves: scalar relative_minimum_final_level works in multi-period."""
 
+    @pytest.mark.skip(reason='multi-period storage constraints not yet implemented')
     def test_storage_relative_maximum_final_level_scalar(self, optimize):
         """Proves: scalar relative_maximum_final_level works in multi-period."""

--- a/tests/math_port/test_multi_period.py
+++ b/tests/math_port/test_multi_period.py
@@ -12,8 +12,7 @@ class TestMultiPeriod:
     def test_period_weights_affect_objective(self, optimize):
         """Proves: period weights scale per-period costs in the objective.
 
-        3 timesteps, periods=[2020, 2025], weight_of_last_period=5.
-        Weights = [5, 5] (2025-2020=5, last=5).
+        3 timesteps, periods=[2020, 2025], period_weights=[5, 5].
         Grid @1 cost/MWh, Demand=[10, 10, 10]. Per-period cost=30.
         Objective = 5*30 + 5*30 = 300.
         """
@@ -36,7 +35,7 @@ class TestMultiPeriod:
                 ),
             ],
             periods=[2020, 2025],
-            weight_of_last_period=5,
+            period_weights=[5, 5],
         )
         assert_allclose(result.objective, 300.0, rtol=1e-5)
 
@@ -60,9 +59,37 @@ class TestMultiPeriod:
     def test_invest_linked_periods(self, optimize):
         """Proves: InvestParameters.linked_periods forces equal sizes across periods."""
 
-    @pytest.mark.skip(reason='multi-period per-effect period weights not yet implemented')
-    def test_effect_period_weights(self, optimize):
-        """Proves: Effect.period_weights overrides default period weights."""
+    def test_effect_period_weights_periodic(self, optimize):
+        """Proves: Effect.period_weights_periodic overrides global period weights.
+
+        3 timesteps, periods=[2020, 2025], global weights=[5, 5].
+        Per-period cost = 30. With custom periodic weights [1, 2]:
+        Objective = 1*30 + 2*30 = 90  (instead of 5*30 + 5*30 = 300).
+        """
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[
+                Effect('cost', is_objective=True, period_weights_periodic=[1, 2]),
+            ],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([10, 10, 10])),
+                    ],
+                ),
+                Port(
+                    'Grid',
+                    imports=[
+                        Flow('Heat', effects_per_flow_hour={'cost': 1}),
+                    ],
+                ),
+            ],
+            periods=[2020, 2025],
+            period_weights=[5, 5],
+        )
+        assert_allclose(result.objective, 90.0, rtol=1e-5)
 
     @pytest.mark.skip(reason='multi-period storage constraints not yet implemented')
     def test_storage_relative_minimum_final_level_scalar(self, optimize):


### PR DESCRIPTION
## Summary
- Add `period` dimension to all model variables (flow rates, sizing, status, effects, storage)
- Introduce two effect accumulators: `effect_periodic` (recurring, scaled by period_weight) and `effect_once` (one-time, not scaled)
- Period-weighted objective: `sum_p(period_weight[p] * effect_total[p])`
- New `periods` and `weight_of_last_period` parameters on `optimize()` and `ModelData.build()`
- Single-period mode (no `periods` arg) remains unchanged

## Design decisions
- **effect_periodic** — costs that repeat each period (O&M, fuel). Forward-fillable across period gaps. Multiplied by period_weight.
- **effect_once** — costs that occur once (CAPEX, decommissioning). Not forward-filled. Not multiplied by period_weight. Currently a placeholder (== 0), ready for investment cost inputs.
- **Size vs Investment** — size is `[flow, period]` (available capacity per period). Investment will be a separate global build decision with lifetime (future work).

Closes #27

## Test plan
- [x] `test_period_weights_affect_objective` — 3 timesteps, 2 periods, verifies weighted objective = 300
- [x] All 3 pipeline variants pass (optimize, save→reload→optimize, optimize→save→reload→validate)
- [x] All 327 existing tests pass (no regressions)
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-period optimization with configurable period definitions and global/per-effect period weights
  * Added a distinct "once" (one-time-per-period) cost domain and per-effect periodic/once weight overrides
  * Results now expose one-time effect values for inspection

* **Documentation**
  * Expanded math/notation and examples to describe temporal, periodic, and once domains and the period-weighted objective

* **Tests**
  * Added and updated tests to validate multi-period behavior and period-weighted objectives
<!-- end of auto-generated comment: release notes by coderabbit.ai -->