### PR TITLE
ci: set mike default to dev so root URL redirects

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -68,7 +68,11 @@ jobs:
 
       - name: Deploy dev docs
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !inputs.deploy
-        run: uv run mike deploy --push dev
+        run: |
+          uv run mike deploy --push dev
+          if ! uv run mike get-default 2>/dev/null; then
+            uv run mike set-default --push dev
+          fi
 
       - name: Deploy versioned docs
         if: inputs.deploy && inputs.version != ''


### PR DESCRIPTION
## Summary

- `mike deploy` places docs in subdirectories (`dev/`, versioned paths) on gh-pages, but without `mike set-default` the root of gh-pages has no `index.html`, causing a 404 at `fbumann.github.io/fluxopt/`
- This adds `mike set-default --push dev` after deploying dev docs, so the root URL redirects to the `dev/` subdirectory
- Versioned stable releases already call `mike set-default --push latest`, so once a stable release is deployed the default will switch from `dev` to `latest`

## Test plan

- [ ] Merge and verify that the docs workflow deploys successfully
- [ ] Confirm `fbumann.github.io/fluxopt/` no longer 404s and redirects to dev docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)