### PR TITLE
ci: allow tag push to trigger release publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+    tags: ['v*']
 
 permissions:
   contents: write
@@ -11,6 +12,7 @@ permissions:
 jobs:
   release-please:
     name: Release Please
+    if: "!startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-24.04
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -32,7 +34,7 @@ jobs:
   publish:
     name: Build & publish to PyPI
     needs: [release-please]
-    if: needs.release-please.outputs.release_created
+    if: needs.release-please.outputs.release_created || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     environment:
@@ -62,7 +64,7 @@ jobs:
   deploy-docs:
     name: Deploy docs
     needs: [release-please, publish]
-    if: needs.release-please.outputs.release_created
+    if: needs.release-please.outputs.release_created || startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
     uses: ./.github/workflows/docs.yaml


### PR DESCRIPTION
## Summary
- Adds `tags: ['v*']` trigger to the release workflow so failed publishes can be retried by deleting and re-pushing the release tag
- Release-please is skipped on tag pushes since it only applies to branch pushes
- Publish and deploy-docs jobs now also trigger on `v*` tag pushes

## Test plan
- [ ] Verify workflow syntax is valid (CI check)
- [ ] Confirm release-please still runs on pushes to `main`
- [ ] Confirm publish + deploy-docs trigger on `v*` tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)