### PR TITLE
ci: extract reusable publish workflow for manual retry

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,54 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g. v0.0.4-alpha.0)'
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+
+jobs:
+  publish:
+    name: Build & publish to PyPI
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment:
+      name: pypi
+      url: https://pypi.org/project/fluxopt
+    permissions:
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Build
+        run: uv build
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  deploy-docs:
+    name: Deploy docs
+    needs: [publish]
+    permissions:
+      contents: write
+    uses: ./.github/workflows/docs.yaml
+    with:
+      deploy: true
+      version: ${{ inputs.tag }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,42 +32,12 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
   publish:
-    name: Build & publish to PyPI
     needs: [release-please]
-    if: needs.release-please.outputs.release_created || startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    environment:
-      name: pypi
-      url: https://pypi.org/project/fluxopt
+    if: needs.release-please.outputs.release_created
     permissions:
       id-token: write
       attestations: write
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Build
-        run: uv build
-
-      - uses: pypa/gh-action-pypi-publish@release/v1
-
-  deploy-docs:
-    name: Deploy docs
-    needs: [release-please, publish]
-    if: needs.release-please.outputs.release_created || startsWith(github.ref, 'refs/tags/v')
-    permissions:
       contents: write
-    uses: ./.github/workflows/docs.yaml
+    uses: ./.github/workflows/publish.yaml
     with:
-      deploy: true
-      version: ${{ needs.release-please.outputs.tag_name }}
+      tag: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
## Summary
- Extract the inline `publish` and `deploy-docs` jobs from `release.yaml` into a new reusable `publish.yaml` workflow
- `publish.yaml` supports both `workflow_call` (used by release.yaml) and `workflow_dispatch` (manual trigger via GitHub Actions UI)
- `release.yaml` now calls `publish.yaml` with the release tag, keeping the release-please logic minimal

## Test plan
- [ ] Verify `release.yaml` syntax is valid (CI will check)
- [ ] Verify `publish.yaml` syntax is valid (CI will check)
- [ ] After merge, trigger a release to confirm the workflow_call path works end-to-end
- [ ] Manually test workflow_dispatch by running publish.yaml from the Actions tab with a known tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)