### PR TITLE
feat: make all effect parameters period-aware

### DIFF
--- a/src/fluxopt/elements.py
+++ b/src/fluxopt/elements.py
@@ -55,8 +55,8 @@ class Sizing:
     min_size: float
     max_size: float
     mandatory: bool = True
-    effects_per_size: dict[str, float] = field(default_factory=dict)
-    effects_fixed: dict[str, float] = field(default_factory=dict)
+    effects_per_size: dict[str, TimeSeries] = field(default_factory=dict)
+    effects_fixed: dict[str, TimeSeries] = field(default_factory=dict)
 
 
 @dataclass
@@ -84,10 +84,10 @@ class Investment:
     mandatory: bool = True
     lifetime: int | None = None
     prior_size: float = 0.0
-    effects_per_size: dict[str, float] = field(default_factory=dict)
-    effects_fixed: dict[str, float] = field(default_factory=dict)
-    effects_per_size_periodic: dict[str, float] = field(default_factory=dict)
-    effects_fixed_periodic: dict[str, float] = field(default_factory=dict)
+    effects_per_size: dict[str, TimeSeries] = field(default_factory=dict)
+    effects_fixed: dict[str, TimeSeries] = field(default_factory=dict)
+    effects_per_size_periodic: dict[str, TimeSeries] = field(default_factory=dict)
+    effects_fixed_periodic: dict[str, TimeSeries] = field(default_factory=dict)
 
 
 @dataclass
@@ -158,7 +158,7 @@ class Effect:
     minimum_total: float | None = None  # Φ̲_k  [unit]
     maximum_per_hour: TimeSeries | None = None  # Φ̄_{k,t}  [unit]
     minimum_per_hour: TimeSeries | None = None  # Φ̲_{k,t}  [unit]
-    contribution_from: dict[str, float] = field(default_factory=dict)
+    contribution_from: dict[str, TimeSeries] = field(default_factory=dict)
     contribution_from_per_hour: dict[str, TimeSeries] = field(default_factory=dict)
     period_weights_periodic: list[float] | None = None  # ω_periodic[p] — scales temporal+periodic
     period_weights_once: list[float] | None = None  # ω_once[p] — scales once

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -15,6 +15,50 @@ if TYPE_CHECKING:
     from fluxopt.elements import Carrier, Effect, Flow, Investment, Sizing, Status, Storage
     from fluxopt.types import TimeIndex, Timesteps
 
+
+@dataclass(frozen=True)
+class _EffectTemplate:
+    """Pre-computed shape/dims/coords for an effect-dimensioned zero array."""
+
+    shape: tuple[int, ...]
+    dims: tuple[str, ...]
+    coords: dict[str, Any]
+    as_da_coords: dict[str, Any]
+
+    def zeros(self) -> xr.DataArray:
+        """Create a zero-filled DataArray with this template's shape."""
+        return xr.DataArray(np.zeros(self.shape), dims=list(self.dims), coords=self.coords)
+
+
+def _effect_template(
+    base_dims: dict[str, Any],
+    period: pd.Index | None = None,
+) -> _EffectTemplate:
+    """Build template shape/dims/coords for effect arrays with optional period.
+
+    Args:
+        base_dims: Ordered mapping of dim_name -> coord_values.
+        period: Period index to append as trailing dimension.
+    """
+    dims = list(base_dims.keys())
+    coords = dict(base_dims)
+    shape = [len(v) for v in base_dims.values()]
+    as_da_coords: dict[str, Any] = {k: v for k, v in base_dims.items() if k not in ('effect', 'source_effect')}
+
+    if period is not None:
+        dims.append('period')
+        coords['period'] = period
+        shape.append(len(period))
+        as_da_coords['period'] = period
+
+    return _EffectTemplate(
+        shape=tuple(shape),
+        dims=tuple(dims),
+        coords=coords,
+        as_da_coords=as_da_coords,
+    )
+
+
 _NC_GROUPS = {
     'flows': 'model/flows',
     'carriers': 'model/carriers',
@@ -85,7 +129,7 @@ class _SizingArrays:
             return cls()
 
         effect_set = set(effect_ids)
-        n_effects = len(effect_ids)
+        tmpl = _effect_template({'effect': effect_ids}, period)
 
         ids: list[str] = []
         mins: list[float] = []
@@ -94,33 +138,22 @@ class _SizingArrays:
         eps_slices: list[xr.DataArray] = []
         ef_slices: list[xr.DataArray] = []
 
-        # Template shape: (effect,) or (effect, period)
-        tmpl_coords: dict[str, Any] = {'effect': effect_ids}
-        tmpl_shape: list[int] = [n_effects]
-        tmpl_dims: list[str] = ['effect']
-        da_coords: dict[str, Any] = {}
-        if period is not None:
-            tmpl_coords['period'] = period
-            tmpl_shape.append(len(period))
-            tmpl_dims.append('period')
-            da_coords['period'] = period
-
         for item_id, s in items:
             ids.append(item_id)
             mins.append(s.min_size)
             maxs.append(s.max_size)
             mandatories.append(s.mandatory)
 
-            eps = xr.DataArray(np.zeros(tmpl_shape), dims=tmpl_dims, coords=tmpl_coords)
-            ef = xr.DataArray(np.zeros(tmpl_shape), dims=tmpl_dims, coords=tmpl_coords)
+            eps = tmpl.zeros()
+            ef = tmpl.zeros()
             for ek, ev in s.effects_per_size.items():
                 if ek not in effect_set:
                     raise ValueError(f'Unknown effect {ek!r} in Sizing.effects_per_size on {item_id!r}')
-                eps.loc[ek] = as_dataarray(ev, da_coords)
+                eps.loc[ek] = as_dataarray(ev, tmpl.as_da_coords)
             for ek, ev in s.effects_fixed.items():
                 if ek not in effect_set:
                     raise ValueError(f'Unknown effect {ek!r} in Sizing.effects_fixed on {item_id!r}')
-                ef.loc[ek] = as_dataarray(ev, da_coords)
+                ef.loc[ek] = as_dataarray(ev, tmpl.as_da_coords)
             eps_slices.append(eps)
             ef_slices.append(ef)
 
@@ -167,7 +200,7 @@ class _InvestmentArrays:
             return cls()
 
         effect_set = set(effect_ids)
-        n_effects = len(effect_ids)
+        tmpl = _effect_template({'effect': effect_ids}, period)
 
         ids: list[str] = []
         mins: list[float] = []
@@ -175,18 +208,6 @@ class _InvestmentArrays:
         mandatories: list[bool] = []
         lifetimes: list[float] = []
         prior_sizes: list[float] = []
-
-        # Template shape: (effect,) or (effect, period)
-        tmpl_coords: dict[str, Any] = {'effect': effect_ids}
-        tmpl_shape: list[int] = [n_effects]
-        tmpl_dims: list[str] = ['effect']
-        da_coords: dict[str, Any] = {}
-        if period is not None:
-            tmpl_coords['period'] = period
-            tmpl_shape.append(len(period))
-            tmpl_dims.append('period')
-            da_coords['period'] = period
-
         all_slices: dict[str, list[xr.DataArray]] = {
             'eps': [],
             'ef': [],
@@ -215,11 +236,11 @@ class _InvestmentArrays:
                 ('Investment.effects_per_size_periodic', inv.effects_per_size_periodic, 'eps_p'),
                 ('Investment.effects_fixed_periodic', inv.effects_fixed_periodic, 'ef_p'),
             ]:
-                arr = xr.DataArray(np.zeros(tmpl_shape), dims=tmpl_dims, coords=tmpl_coords)
+                arr = tmpl.zeros()
                 for ek, ev in src_dict.items():
                     if ek not in effect_set:
                         raise ValueError(f'Unknown effect {ek!r} in {label} on {item_id!r}')
-                    arr.loc[ek] = as_dataarray(ev, da_coords)
+                    arr.loc[ek] = as_dataarray(ev, tmpl.as_da_coords)
                 all_slices[dest_key].append(arr)
 
         coords = {dim: ids}
@@ -304,8 +325,7 @@ class _StatusArrays:
 
         prior_rates_map = prior_rates_map or {}
         effect_set = set(effect_ids)
-        n_effects = len(effect_ids)
-        n_time = len(time)
+        tmpl = _effect_template({'effect': effect_ids, 'time': time}, period)
 
         ids: list[str] = []
         min_ups: list[float] = []
@@ -336,29 +356,18 @@ class _StatusArrays:
                 prev_ups.append(np.nan)
                 prev_downs.append(np.nan)
 
-            # Effects per running hour — (effect, time, period?)
-            er_coords: dict[str, Any] = {'effect': effect_ids, 'time': time}
-            er_shape: list[int] = [n_effects, n_time]
-            er_dims: list[str] = ['effect', 'time']
-            as_da_coords: dict[str, Any] = {'time': time}
-            if period is not None:
-                er_coords['period'] = period
-                er_shape.append(len(period))
-                er_dims.append('period')
-                as_da_coords['period'] = period
-            er = xr.DataArray(np.zeros(er_shape), dims=er_dims, coords=er_coords)
+            er = tmpl.zeros()
             for ek, ev in s.effects_per_running_hour.items():
                 if ek not in effect_set:
                     raise ValueError(f'Unknown effect {ek!r} in Status.effects_per_running_hour on {item_id!r}')
-                er.loc[ek] = as_dataarray(ev, as_da_coords)
+                er.loc[ek] = as_dataarray(ev, tmpl.as_da_coords)
             er_slices.append(er)
 
-            # Effects per startup — (effect, time, period?)
-            es = xr.DataArray(np.zeros(er_shape), dims=er_dims, coords=er_coords)
+            es = tmpl.zeros()
             for ek, ev in s.effects_per_startup.items():
                 if ek not in effect_set:
                     raise ValueError(f'Unknown effect {ek!r} in Status.effects_per_startup on {item_id!r}')
-                es.loc[ek] = as_dataarray(ev, as_da_coords)
+                es.loc[ek] = as_dataarray(ev, tmpl.as_da_coords)
             es_slices.append(es)
 
         coords = {dim: ids}
@@ -929,41 +938,21 @@ class EffectsData:
             if cycle is not None:
                 raise ValueError(f'Circular contribution_from dependency: {" -> ".join(cycle)}')
 
-            # cf_periodic: (effect, source_effect, period?)
-            cf_p_coords: dict[str, Any] = {'effect': effect_ids, 'source_effect': effect_ids}
-            cf_p_shape: list[int] = [n, n]
-            cf_p_dims: list[str] = ['effect', 'source_effect']
-            cf_da_coords: dict[str, Any] = {}
-            if period is not None:
-                cf_p_coords['period'] = period
-                cf_p_shape.append(len(period))
-                cf_p_dims.append('period')
-                cf_da_coords['period'] = period
+            tmpl_p = _effect_template({'effect': effect_ids, 'source_effect': effect_ids}, period)
+            tmpl_t = _effect_template({'effect': effect_ids, 'source_effect': effect_ids, 'time': time}, period)
 
-            # cf_temporal: (effect, source_effect, time, period?)
-            cf_t_coords: dict[str, Any] = {'effect': effect_ids, 'source_effect': effect_ids, 'time': time}
-            cf_t_shape: list[int] = [n, n, n_time]
-            cf_t_dims: list[str] = ['effect', 'source_effect', 'time']
-            cf_t_da_coords: dict[str, Any] = {'time': time}
-            if period is not None:
-                cf_t_coords['period'] = period
-                cf_t_shape.append(len(period))
-                cf_t_dims.append('period')
-                cf_t_da_coords['period'] = period
-
-            periodic_mat = xr.DataArray(np.zeros(cf_p_shape), dims=cf_p_dims, coords=cf_p_coords)
-            temporal_mat = xr.DataArray(np.zeros(cf_t_shape), dims=cf_t_dims, coords=cf_t_coords)
+            periodic_mat = tmpl_p.zeros()
+            temporal_mat = tmpl_t.zeros()
             for e in effects:
                 for src_id, factor in e.contribution_from.items():
                     if src_id not in effect_set:
                         raise ValueError(f'Unknown effect {src_id!r} in Effect.contribution_from on {e.id!r}')
-                    factor_da = as_dataarray(factor, cf_da_coords)
-                    periodic_mat.loc[e.id, src_id] = factor_da
-                    temporal_mat.loc[e.id, src_id] = as_dataarray(factor, cf_t_da_coords)
+                    periodic_mat.loc[e.id, src_id] = as_dataarray(factor, tmpl_p.as_da_coords)
+                    temporal_mat.loc[e.id, src_id] = as_dataarray(factor, tmpl_t.as_da_coords)
                 for src_id, factor_ts in e.contribution_from_per_hour.items():
                     if src_id not in effect_set:
                         raise ValueError(f'Unknown effect {src_id!r} in Effect.contribution_from_per_hour on {e.id!r}')
-                    temporal_mat.loc[e.id, src_id] = as_dataarray(factor_ts, cf_t_da_coords)
+                    temporal_mat.loc[e.id, src_id] = as_dataarray(factor_ts, tmpl_t.as_da_coords)
             cf_periodic = periodic_mat
             cf_temporal = temporal_mat
 

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -50,8 +50,8 @@ class _SizingArrays:
     min: xr.DataArray | None = None
     max: xr.DataArray | None = None
     mandatory: xr.DataArray | None = None
-    effects_per_size: xr.DataArray | None = None
-    effects_fixed: xr.DataArray | None = None
+    effects_per_size: xr.DataArray | None = None  # (sizing_dim, effect, period?)
+    effects_fixed: xr.DataArray | None = None  # (sizing_dim, effect, period?)
 
     def __post_init__(self) -> None:
         """Validate min >= 0 and max >= min."""
@@ -71,6 +71,7 @@ class _SizingArrays:
         items: list[tuple[str, Sizing]],
         effect_ids: list[str],
         dim: str,
+        period: pd.Index | None = None,
     ) -> Self:
         """Validate Sizing objects and collect into DataArrays.
 
@@ -78,6 +79,7 @@ class _SizingArrays:
             items: Pairs of (element_id, Sizing).
             effect_ids: Known effect ids for validation.
             dim: Dimension name for the resulting arrays.
+            period: Period index for period-varying effects.
         """
         if not items:
             return cls()
@@ -89,38 +91,47 @@ class _SizingArrays:
         mins: list[float] = []
         maxs: list[float] = []
         mandatories: list[bool] = []
-        eps_rows: list[np.ndarray] = []
-        ef_rows: list[np.ndarray] = []
+        eps_slices: list[xr.DataArray] = []
+        ef_slices: list[xr.DataArray] = []
+
+        # Template shape: (effect,) or (effect, period)
+        tmpl_coords: dict[str, Any] = {'effect': effect_ids}
+        tmpl_shape: list[int] = [n_effects]
+        tmpl_dims: list[str] = ['effect']
+        da_coords: dict[str, Any] = {}
+        if period is not None:
+            tmpl_coords['period'] = period
+            tmpl_shape.append(len(period))
+            tmpl_dims.append('period')
+            da_coords['period'] = period
 
         for item_id, s in items:
             ids.append(item_id)
             mins.append(s.min_size)
             maxs.append(s.max_size)
             mandatories.append(s.mandatory)
-            eps_row = np.zeros(n_effects)
-            ef_row = np.zeros(n_effects)
+
+            eps = xr.DataArray(np.zeros(tmpl_shape), dims=tmpl_dims, coords=tmpl_coords)
+            ef = xr.DataArray(np.zeros(tmpl_shape), dims=tmpl_dims, coords=tmpl_coords)
             for ek, ev in s.effects_per_size.items():
                 if ek not in effect_set:
                     raise ValueError(f'Unknown effect {ek!r} in Sizing.effects_per_size on {item_id!r}')
-                eps_row[effect_ids.index(ek)] = ev
+                eps.loc[ek] = as_dataarray(ev, da_coords)
             for ek, ev in s.effects_fixed.items():
                 if ek not in effect_set:
                     raise ValueError(f'Unknown effect {ek!r} in Sizing.effects_fixed on {item_id!r}')
-                ef_row[effect_ids.index(ek)] = ev
-            eps_rows.append(eps_row)
-            ef_rows.append(ef_row)
+                ef.loc[ek] = as_dataarray(ev, da_coords)
+            eps_slices.append(eps)
+            ef_slices.append(ef)
 
         coords = {dim: ids}
+        sizing_idx = pd.Index(ids, name=dim)
         return cls(
             min=xr.DataArray(np.array(mins), dims=[dim], coords=coords),
             max=xr.DataArray(np.array(maxs), dims=[dim], coords=coords),
             mandatory=xr.DataArray(np.array(mandatories), dims=[dim], coords=coords),
-            effects_per_size=xr.DataArray(
-                np.array(eps_rows), dims=[dim, 'effect'], coords={dim: ids, 'effect': effect_ids}
-            ),
-            effects_fixed=xr.DataArray(
-                np.array(ef_rows), dims=[dim, 'effect'], coords={dim: ids, 'effect': effect_ids}
-            ),
+            effects_per_size=fast_concat(eps_slices, sizing_idx),
+            effects_fixed=fast_concat(ef_slices, sizing_idx),
         )
 
 
@@ -131,10 +142,10 @@ class _InvestmentArrays:
     mandatory: xr.DataArray | None = None  # (invest_dim,)
     lifetime: xr.DataArray | None = None  # (invest_dim,) — NaN = forever
     prior_size: xr.DataArray | None = None  # (invest_dim,)
-    effects_per_size: xr.DataArray | None = None  # (invest_dim, effect) — once
-    effects_fixed: xr.DataArray | None = None  # (invest_dim, effect) — once
-    effects_per_size_periodic: xr.DataArray | None = None  # (invest_dim, effect)
-    effects_fixed_periodic: xr.DataArray | None = None  # (invest_dim, effect)
+    effects_per_size: xr.DataArray | None = None  # (invest_dim, effect, period?) — once
+    effects_fixed: xr.DataArray | None = None  # (invest_dim, effect, period?) — once
+    effects_per_size_periodic: xr.DataArray | None = None  # (invest_dim, effect, period?)
+    effects_fixed_periodic: xr.DataArray | None = None  # (invest_dim, effect, period?)
 
     @classmethod
     def build(
@@ -142,6 +153,7 @@ class _InvestmentArrays:
         items: list[tuple[str, Investment]],
         effect_ids: list[str],
         dim: str,
+        period: pd.Index | None = None,
     ) -> Self:
         """Validate Investment objects and collect into DataArrays.
 
@@ -149,6 +161,7 @@ class _InvestmentArrays:
             items: Pairs of (element_id, Investment).
             effect_ids: Known effect ids for validation.
             dim: Dimension name for the resulting arrays.
+            period: Period index for period-varying effects.
         """
         if not items:
             return cls()
@@ -162,10 +175,24 @@ class _InvestmentArrays:
         mandatories: list[bool] = []
         lifetimes: list[float] = []
         prior_sizes: list[float] = []
-        eps_rows: list[np.ndarray] = []
-        ef_rows: list[np.ndarray] = []
-        eps_p_rows: list[np.ndarray] = []
-        ef_p_rows: list[np.ndarray] = []
+
+        # Template shape: (effect,) or (effect, period)
+        tmpl_coords: dict[str, Any] = {'effect': effect_ids}
+        tmpl_shape: list[int] = [n_effects]
+        tmpl_dims: list[str] = ['effect']
+        da_coords: dict[str, Any] = {}
+        if period is not None:
+            tmpl_coords['period'] = period
+            tmpl_shape.append(len(period))
+            tmpl_dims.append('period')
+            da_coords['period'] = period
+
+        all_slices: dict[str, list[xr.DataArray]] = {
+            'eps': [],
+            'ef': [],
+            'eps_p': [],
+            'ef_p': [],
+        }
 
         for item_id, inv in items:
             if inv.max_size < inv.min_size:
@@ -182,31 +209,31 @@ class _InvestmentArrays:
             lifetimes.append(float(inv.lifetime) if inv.lifetime is not None else np.nan)
             prior_sizes.append(inv.prior_size)
 
-            for label, src_dict, dest in [
-                ('Investment.effects_per_size', inv.effects_per_size, eps_rows),
-                ('Investment.effects_fixed', inv.effects_fixed, ef_rows),
-                ('Investment.effects_per_size_periodic', inv.effects_per_size_periodic, eps_p_rows),
-                ('Investment.effects_fixed_periodic', inv.effects_fixed_periodic, ef_p_rows),
+            for label, src_dict, dest_key in [
+                ('Investment.effects_per_size', inv.effects_per_size, 'eps'),
+                ('Investment.effects_fixed', inv.effects_fixed, 'ef'),
+                ('Investment.effects_per_size_periodic', inv.effects_per_size_periodic, 'eps_p'),
+                ('Investment.effects_fixed_periodic', inv.effects_fixed_periodic, 'ef_p'),
             ]:
-                row = np.zeros(n_effects)
+                arr = xr.DataArray(np.zeros(tmpl_shape), dims=tmpl_dims, coords=tmpl_coords)
                 for ek, ev in src_dict.items():
                     if ek not in effect_set:
                         raise ValueError(f'Unknown effect {ek!r} in {label} on {item_id!r}')
-                    row[effect_ids.index(ek)] = ev
-                dest.append(row)
+                    arr.loc[ek] = as_dataarray(ev, da_coords)
+                all_slices[dest_key].append(arr)
 
         coords = {dim: ids}
-        ec = {dim: ids, 'effect': effect_ids}
+        invest_idx = pd.Index(ids, name=dim)
         return cls(
             min=xr.DataArray(np.array(mins), dims=[dim], coords=coords),
             max=xr.DataArray(np.array(maxs), dims=[dim], coords=coords),
             mandatory=xr.DataArray(np.array(mandatories), dims=[dim], coords=coords),
             lifetime=xr.DataArray(np.array(lifetimes), dims=[dim], coords=coords),
             prior_size=xr.DataArray(np.array(prior_sizes), dims=[dim], coords=coords),
-            effects_per_size=xr.DataArray(np.array(eps_rows), dims=[dim, 'effect'], coords=ec),
-            effects_fixed=xr.DataArray(np.array(ef_rows), dims=[dim, 'effect'], coords=ec),
-            effects_per_size_periodic=xr.DataArray(np.array(eps_p_rows), dims=[dim, 'effect'], coords=ec),
-            effects_fixed_periodic=xr.DataArray(np.array(ef_p_rows), dims=[dim, 'effect'], coords=ec),
+            effects_per_size=fast_concat(all_slices['eps'], invest_idx),
+            effects_fixed=fast_concat(all_slices['ef'], invest_idx),
+            effects_per_size_periodic=fast_concat(all_slices['eps_p'], invest_idx),
+            effects_fixed_periodic=fast_concat(all_slices['ef_p'], invest_idx),
         )
 
 
@@ -217,8 +244,8 @@ class _StatusArrays:
     min_downtime: xr.DataArray | None = None  # (status_flow,)
     max_downtime: xr.DataArray | None = None  # (status_flow,)
     initial: xr.DataArray | None = None  # (status_flow,) — NaN = free
-    effects_running: xr.DataArray | None = None  # (status_flow, effect, time)
-    effects_startup: xr.DataArray | None = None  # (status_flow, effect, time)
+    effects_running: xr.DataArray | None = None  # (status_flow, effect, time, period?)
+    effects_startup: xr.DataArray | None = None  # (status_flow, effect, time, period?)
     previous_uptime: xr.DataArray | None = None  # (status_flow,) — hours, NaN = no prior
     previous_downtime: xr.DataArray | None = None  # (status_flow,) — hours, NaN = no prior
 
@@ -257,6 +284,7 @@ class _StatusArrays:
         dim: str,
         prior_rates_map: dict[str, list[float]] | None = None,
         dt: float = 1.0,
+        period: pd.Index | None = None,
     ) -> Self:
         """Validate Status objects and collect into DataArrays.
 
@@ -267,6 +295,7 @@ class _StatusArrays:
             dim: Dimension name for the resulting arrays.
             prior_rates_map: Flow id to prior flow rates (MW) before horizon.
             dt: Scalar timestep duration in hours for prior duration computation.
+            period: Period index for period-varying effects.
         """
         from fluxopt.constraints.status import compute_previous_duration
 
@@ -307,28 +336,29 @@ class _StatusArrays:
                 prev_ups.append(np.nan)
                 prev_downs.append(np.nan)
 
-            # Effects per running hour — (effect, time)
-            er = xr.DataArray(
-                np.zeros((n_effects, n_time)),
-                dims=['effect', 'time'],
-                coords={'effect': effect_ids, 'time': time},
-            )
+            # Effects per running hour — (effect, time, period?)
+            er_coords: dict[str, Any] = {'effect': effect_ids, 'time': time}
+            er_shape: list[int] = [n_effects, n_time]
+            er_dims: list[str] = ['effect', 'time']
+            as_da_coords: dict[str, Any] = {'time': time}
+            if period is not None:
+                er_coords['period'] = period
+                er_shape.append(len(period))
+                er_dims.append('period')
+                as_da_coords['period'] = period
+            er = xr.DataArray(np.zeros(er_shape), dims=er_dims, coords=er_coords)
             for ek, ev in s.effects_per_running_hour.items():
                 if ek not in effect_set:
                     raise ValueError(f'Unknown effect {ek!r} in Status.effects_per_running_hour on {item_id!r}')
-                er.loc[ek] = as_dataarray(ev, {'time': time})
+                er.loc[ek] = as_dataarray(ev, as_da_coords)
             er_slices.append(er)
 
-            # Effects per startup — (effect, time)
-            es = xr.DataArray(
-                np.zeros((n_effects, n_time)),
-                dims=['effect', 'time'],
-                coords={'effect': effect_ids, 'time': time},
-            )
+            # Effects per startup — (effect, time, period?)
+            es = xr.DataArray(np.zeros(er_shape), dims=er_dims, coords=er_coords)
             for ek, ev in s.effects_per_startup.items():
                 if ek not in effect_set:
                     raise ValueError(f'Unknown effect {ek!r} in Status.effects_per_startup on {item_id!r}')
-                es.loc[ek] = as_dataarray(ev, {'time': time})
+                es.loc[ek] = as_dataarray(ev, as_da_coords)
             es_slices.append(es)
 
         coords = {dim: ids}
@@ -365,15 +395,15 @@ class FlowsData:
     sizing_min: xr.DataArray | None = None  # (sizing_flow,)
     sizing_max: xr.DataArray | None = None  # (sizing_flow,)
     sizing_mandatory: xr.DataArray | None = None  # (sizing_flow,)
-    sizing_effects_per_size: xr.DataArray | None = None  # (sizing_flow, effect)
-    sizing_effects_fixed: xr.DataArray | None = None  # (sizing_flow, effect)
+    sizing_effects_per_size: xr.DataArray | None = None  # (sizing_flow, effect, period?)
+    sizing_effects_fixed: xr.DataArray | None = None  # (sizing_flow, effect, period?)
     status_min_uptime: xr.DataArray | None = None  # (status_flow,)
     status_max_uptime: xr.DataArray | None = None  # (status_flow,)
     status_min_downtime: xr.DataArray | None = None  # (status_flow,)
     status_max_downtime: xr.DataArray | None = None  # (status_flow,)
     status_initial: xr.DataArray | None = None  # (status_flow,)
-    status_effects_running: xr.DataArray | None = None  # (status_flow, effect, time)
-    status_effects_startup: xr.DataArray | None = None  # (status_flow, effect, time)
+    status_effects_running: xr.DataArray | None = None  # (status_flow, effect, time, period?)
+    status_effects_startup: xr.DataArray | None = None  # (status_flow, effect, time, period?)
     status_previous_uptime: xr.DataArray | None = None  # (status_flow,)
     status_previous_downtime: xr.DataArray | None = None  # (status_flow,)
     invest_min: xr.DataArray | None = None  # (invest_flow,)
@@ -381,10 +411,10 @@ class FlowsData:
     invest_mandatory: xr.DataArray | None = None  # (invest_flow,)
     invest_lifetime: xr.DataArray | None = None  # (invest_flow,) — NaN = forever
     invest_prior_size: xr.DataArray | None = None  # (invest_flow,)
-    invest_effects_per_size: xr.DataArray | None = None  # (invest_flow, effect) — once
-    invest_effects_fixed: xr.DataArray | None = None  # (invest_flow, effect) — once
-    invest_effects_per_size_periodic: xr.DataArray | None = None  # (invest_flow, effect)
-    invest_effects_fixed_periodic: xr.DataArray | None = None  # (invest_flow, effect)
+    invest_effects_per_size: xr.DataArray | None = None  # (invest_flow, effect, period?) — once
+    invest_effects_fixed: xr.DataArray | None = None  # (invest_flow, effect, period?) — once
+    invest_effects_per_size_periodic: xr.DataArray | None = None  # (invest_flow, effect, period?)
+    invest_effects_fixed_periodic: xr.DataArray | None = None  # (invest_flow, effect, period?)
 
     def __post_init__(self) -> None:
         """Validate relative bounds: non-negative and lb <= ub."""
@@ -502,10 +532,10 @@ class FlowsData:
                 prior_rates_map[f.id] = f.prior_rates
 
         flow_idx = pd.Index(flow_ids, name='flow')
-        sz = _SizingArrays.build(sizing_items, effect_ids, dim='sizing_flow')
-        inv = _InvestmentArrays.build(invest_items, effect_ids, dim='invest_flow')
+        sz = _SizingArrays.build(sizing_items, effect_ids, dim='sizing_flow', period=period)
+        inv = _InvestmentArrays.build(invest_items, effect_ids, dim='invest_flow', period=period)
         st = _StatusArrays.build(
-            status_items, effect_ids, time, dim='status_flow', prior_rates_map=prior_rates_map, dt=dt
+            status_items, effect_ids, time, dim='status_flow', prior_rates_map=prior_rates_map, dt=dt, period=period
         )
 
         return cls(
@@ -765,8 +795,8 @@ class EffectsData:
     max_per_hour: xr.DataArray  # (effect, time)
     is_objective: xr.DataArray  # (effect,)
     objective_effect: str
-    cf_periodic: xr.DataArray | None = None  # (effect, source_effect)
-    cf_temporal: xr.DataArray | None = None  # (effect, source_effect, time)
+    cf_periodic: xr.DataArray | None = None  # (effect, source_effect, period?)
+    cf_temporal: xr.DataArray | None = None  # (effect, source_effect, time, period?)
     period_weights_periodic: xr.DataArray | None = None  # (effect, period)
     period_weights_once: xr.DataArray | None = None  # (effect, period)
 
@@ -899,30 +929,43 @@ class EffectsData:
             if cycle is not None:
                 raise ValueError(f'Circular contribution_from dependency: {" -> ".join(cycle)}')
 
-            periodic_mat = np.zeros((n, n))
-            temporal_mat = np.zeros((n, n, n_time))
-            for i, e in enumerate(effects):
+            # cf_periodic: (effect, source_effect, period?)
+            cf_p_coords: dict[str, Any] = {'effect': effect_ids, 'source_effect': effect_ids}
+            cf_p_shape: list[int] = [n, n]
+            cf_p_dims: list[str] = ['effect', 'source_effect']
+            cf_da_coords: dict[str, Any] = {}
+            if period is not None:
+                cf_p_coords['period'] = period
+                cf_p_shape.append(len(period))
+                cf_p_dims.append('period')
+                cf_da_coords['period'] = period
+
+            # cf_temporal: (effect, source_effect, time, period?)
+            cf_t_coords: dict[str, Any] = {'effect': effect_ids, 'source_effect': effect_ids, 'time': time}
+            cf_t_shape: list[int] = [n, n, n_time]
+            cf_t_dims: list[str] = ['effect', 'source_effect', 'time']
+            cf_t_da_coords: dict[str, Any] = {'time': time}
+            if period is not None:
+                cf_t_coords['period'] = period
+                cf_t_shape.append(len(period))
+                cf_t_dims.append('period')
+                cf_t_da_coords['period'] = period
+
+            periodic_mat = xr.DataArray(np.zeros(cf_p_shape), dims=cf_p_dims, coords=cf_p_coords)
+            temporal_mat = xr.DataArray(np.zeros(cf_t_shape), dims=cf_t_dims, coords=cf_t_coords)
+            for e in effects:
                 for src_id, factor in e.contribution_from.items():
                     if src_id not in effect_set:
                         raise ValueError(f'Unknown effect {src_id!r} in Effect.contribution_from on {e.id!r}')
-                    j = effect_ids.index(src_id)
-                    periodic_mat[i, j] = factor
-                    temporal_mat[i, j, :] = factor  # default temporal = scalar
+                    factor_da = as_dataarray(factor, cf_da_coords)
+                    periodic_mat.loc[e.id, src_id] = factor_da
+                    temporal_mat.loc[e.id, src_id] = as_dataarray(factor, cf_t_da_coords)
                 for src_id, factor_ts in e.contribution_from_per_hour.items():
                     if src_id not in effect_set:
                         raise ValueError(f'Unknown effect {src_id!r} in Effect.contribution_from_per_hour on {e.id!r}')
-                    j = effect_ids.index(src_id)
-                    temporal_mat[i, j, :] = as_dataarray(factor_ts, {'time': time}).values
-            cf_periodic = xr.DataArray(
-                periodic_mat,
-                dims=['effect', 'source_effect'],
-                coords={'effect': effect_ids, 'source_effect': effect_ids},
-            )
-            cf_temporal = xr.DataArray(
-                temporal_mat,
-                dims=['effect', 'source_effect', 'time'],
-                coords={'effect': effect_ids, 'source_effect': effect_ids, 'time': time},
-            )
+                    temporal_mat.loc[e.id, src_id] = as_dataarray(factor_ts, cf_t_da_coords)
+            cf_periodic = periodic_mat
+            cf_temporal = temporal_mat
 
         effect_idx = pd.Index(effect_ids, name='effect')
 
@@ -991,17 +1034,17 @@ class StoragesData:
     sizing_min: xr.DataArray | None = None  # (sizing_storage,)
     sizing_max: xr.DataArray | None = None  # (sizing_storage,)
     sizing_mandatory: xr.DataArray | None = None  # (sizing_storage,)
-    sizing_effects_per_size: xr.DataArray | None = None  # (sizing_storage, effect)
-    sizing_effects_fixed: xr.DataArray | None = None  # (sizing_storage, effect)
+    sizing_effects_per_size: xr.DataArray | None = None  # (sizing_storage, effect, period?)
+    sizing_effects_fixed: xr.DataArray | None = None  # (sizing_storage, effect, period?)
     invest_min: xr.DataArray | None = None  # (invest_storage,)
     invest_max: xr.DataArray | None = None  # (invest_storage,)
     invest_mandatory: xr.DataArray | None = None  # (invest_storage,)
     invest_lifetime: xr.DataArray | None = None  # (invest_storage,) — NaN = forever
     invest_prior_size: xr.DataArray | None = None  # (invest_storage,)
-    invest_effects_per_size: xr.DataArray | None = None  # (invest_storage, effect) — once
-    invest_effects_fixed: xr.DataArray | None = None  # (invest_storage, effect) — once
-    invest_effects_per_size_periodic: xr.DataArray | None = None  # (invest_storage, effect)
-    invest_effects_fixed_periodic: xr.DataArray | None = None  # (invest_storage, effect)
+    invest_effects_per_size: xr.DataArray | None = None  # (invest_storage, effect, period?) — once
+    invest_effects_fixed: xr.DataArray | None = None  # (invest_storage, effect, period?) — once
+    invest_effects_per_size_periodic: xr.DataArray | None = None  # (invest_storage, effect, period?)
+    invest_effects_fixed_periodic: xr.DataArray | None = None  # (invest_storage, effect, period?)
 
     def __post_init__(self) -> None:
         """Validate capacity, efficiencies, and loss rates."""
@@ -1041,6 +1084,7 @@ class StoragesData:
         time: TimeIndex,
         dt: xr.DataArray,
         effects: list[Effect] | None = None,
+        period: pd.Index | None = None,
     ) -> Self | None:
         """Build StoragesData from element objects.
 
@@ -1049,6 +1093,7 @@ class StoragesData:
             time: Time index.
             dt: Timestep durations.
             effects: Effect definitions for sizing cost validation.
+            period: Period index for period-varying effects.
         """
         from fluxopt.elements import Investment, Sizing
 
@@ -1095,8 +1140,8 @@ class StoragesData:
             discharge_flow.append(s.discharging.id)
 
         stor_idx = pd.Index(stor_ids, name='storage')
-        sz = _SizingArrays.build(sizing_items, effect_ids, dim='sizing_storage')
-        inv = _InvestmentArrays.build(invest_items, effect_ids, dim='invest_storage')
+        sz = _SizingArrays.build(sizing_items, effect_ids, dim='sizing_storage', period=period)
+        inv = _InvestmentArrays.build(invest_items, effect_ids, dim='invest_storage', period=period)
 
         return cls(
             capacity=xr.DataArray(capacity_vals, dims=['storage'], coords={'storage': stor_ids}),
@@ -1372,7 +1417,7 @@ class ModelData:
         carriers_data = CarriersData.build(carriers, flows, carrier_coeff)
         converters_data = ConvertersData.build(converters, time)
         effects_data = EffectsData.build(effects, time, period=period_idx)
-        storages_data = StoragesData.build(stor_list, time, dims.dt, effects)
+        storages_data = StoragesData.build(stor_list, time, dims.dt, effects, period=period_idx)
 
         return cls(
             flows=flows_data,

--- a/tests/math_port/conftest.py
+++ b/tests/math_port/conftest.py
@@ -65,4 +65,5 @@ def optimize(request, tmp_path):
         _ = loaded.stats.effect_contributions  # validate contributions survive IO roundtrip
         return loaded
 
+    _optimize.pipeline = request.param  # type: ignore[attr-defined]
     return _optimize

--- a/tests/math_port/test_multi_period.py
+++ b/tests/math_port/test_multi_period.py
@@ -6,7 +6,7 @@ import xarray as xr
 from conftest import ts
 from numpy.testing import assert_allclose
 
-from fluxopt import Carrier, Effect, Flow, Investment, Port
+from fluxopt import Carrier, Effect, Flow, Investment, Port, Sizing
 
 
 class TestMultiPeriod:
@@ -370,3 +370,114 @@ class TestInvestment:
         )
         # Periodic: 2/MW * 10 MW = 20 per period. Weighted: 5*20 + 5*20 = 200.
         assert_allclose(result.objective, 200.0, rtol=1e-4)
+
+
+class TestPeriodVaryingEffects:
+    def test_sizing_effects_per_size_vary_by_period(self, optimize):
+        """Proves: Sizing.effects_per_size can vary across periods.
+
+        Grid with Sizing(10, 10), effects_per_size varies: 1 in 2020, 3 in 2025.
+        Size is fixed at 10. Periodic cost = effects_per_size * size.
+        2020: 1*10=10, 2025: 3*10=30. Weights=[1, 1]. Objective = 10 + 30 = 40.
+        """
+        periods = [2020, 2025]
+        cost_by_period = xr.DataArray([1.0, 3.0], dims=['period'], coords={'period': periods})
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([10, 10, 10])),
+                    ],
+                ),
+                Port(
+                    'Grid',
+                    imports=[
+                        Flow(
+                            'Heat',
+                            size=Sizing(10, 10, effects_per_size={'cost': cost_by_period}),
+                        ),
+                    ],
+                ),
+            ],
+            periods=periods,
+            period_weights=[1, 1],
+        )
+        assert_allclose(result.objective, 40.0, rtol=1e-4)
+
+    @_xfail_contributions
+    def test_investment_periodic_costs_vary_by_period(self, optimize):
+        """Proves: Investment.effects_per_size_periodic can vary across periods.
+
+        Investment(10, 10), recurring O&M varies: 1 in 2020, 3 in 2025.
+        Active in both periods. Periodic cost = O&M * size.
+        2020: 1*10=10, 2025: 3*10=30. Weights=[1, 1]. Objective = 10 + 30 = 40.
+        """
+        periods = [2020, 2025]
+        om_by_period = xr.DataArray([1.0, 3.0], dims=['period'], coords={'period': periods})
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([10, 10, 10])),
+                    ],
+                ),
+                Port(
+                    'Grid',
+                    imports=[
+                        Flow(
+                            'Heat',
+                            size=Investment(10, 10, effects_per_size_periodic={'cost': om_by_period}),
+                        ),
+                    ],
+                ),
+            ],
+            periods=periods,
+            period_weights=[1, 1],
+        )
+        assert_allclose(result.objective, 40.0, rtol=1e-4)
+
+    @_xfail_contributions
+    def test_contribution_from_varies_by_period(self, optimize):
+        """Proves: Effect.contribution_from can vary across periods.
+
+        CO2 effect tracks emissions. Cost effect gets contribution_from CO2
+        at rate 50 in 2020, 100 in 2025 (rising carbon price).
+        Grid emits 1 CO2/MWh, demand=10 for 3 timesteps.
+        CO2 per period = 30. Cost from CO2: 2020→50*30=1500, 2025→100*30=3000.
+        Weights=[1, 1]. Objective = 1500 + 3000 = 4500.
+        """
+        periods = [2020, 2025]
+        carbon_price = xr.DataArray([50.0, 100.0], dims=['period'], coords={'period': periods})
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[
+                Effect('co2'),
+                Effect('cost', is_objective=True, contribution_from={'co2': carbon_price}),
+            ],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([10, 10, 10])),
+                    ],
+                ),
+                Port(
+                    'Grid',
+                    imports=[
+                        Flow('Heat', effects_per_flow_hour={'co2': 1}),
+                    ],
+                ),
+            ],
+            periods=periods,
+            period_weights=[1, 1],
+        )
+        assert_allclose(result.objective, 4500.0, rtol=1e-4)

--- a/tests/math_port/test_multi_period.py
+++ b/tests/math_port/test_multi_period.py
@@ -6,7 +6,16 @@ import xarray as xr
 from conftest import ts
 from numpy.testing import assert_allclose
 
-from fluxopt import Carrier, Effect, Flow, Investment, Port, Sizing
+from fluxopt import Carrier, Effect, Flow, Investment, Port, Sizing, Status, Storage
+
+_VALIDATE = 'optimize->save->reload->validate'
+_XFAIL_REASON = 'effect_contributions does not yet support investment/period decomposition (#84)'
+
+
+def _xfail_if_validate(optimize: object) -> None:
+    """Mark expected failure for the validate pipeline."""
+    if getattr(optimize, 'pipeline', None) == _VALIDATE:
+        pytest.xfail(_XFAIL_REASON)
 
 
 class TestMultiPeriod:
@@ -134,14 +143,7 @@ class TestMultiPeriod:
         """Proves: scalar relative_maximum_final_level works in multi-period."""
 
 
-_xfail_contributions = pytest.mark.xfail(
-    reason='effect_contributions does not yet support investment/period decomposition (#84)',
-    strict=False,
-)
-
-
 class TestInvestment:
-    @_xfail_contributions
     def test_investment_mandatory_builds_once(self, optimize):
         """Proves: mandatory Investment builds exactly once across periods.
 
@@ -151,6 +153,7 @@ class TestInvestment:
         Operational cost per period: 10*3*1=30, weighted=5*30=150.
         Total recurring: 3*150=450. Total once: 100. Objective=450+100=550.
         """
+        _xfail_if_validate(optimize)
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
@@ -296,7 +299,6 @@ class TestInvestment:
         # Cost = 2 * 5 * 30 = 300 (operational only, no CAPEX)
         assert_allclose(result.objective, 300.0, rtol=1e-4)
 
-    @_xfail_contributions
     def test_investment_capex_charged_once(self, optimize):
         """Proves: effects_per_size goes to effect_once domain, not periodic.
 
@@ -304,6 +306,7 @@ class TestInvestment:
         No operational costs. 2 periods, weights=[5, 5].
         Objective = 5*0 + 5*0 + 1*100 = 100  (once costs have ω_once=1 by default).
         """
+        _xfail_if_validate(optimize)
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
@@ -333,13 +336,13 @@ class TestInvestment:
         # No flow costs. Objective = 100.
         assert_allclose(result.objective, 100.0, rtol=1e-4)
 
-    @_xfail_contributions
     def test_investment_periodic_costs_weighted(self, optimize):
         """Proves: effects_per_size_periodic goes to effect_periodic, scaled by period weights.
 
         Recurring O&M = 2/MW/period, size=10 MW. 2 periods, weights=[5, 5].
         Periodic cost per period = 2*10 = 20. Weighted: 5*20 + 5*20 = 200.
         """
+        _xfail_if_validate(optimize)
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
@@ -408,7 +411,41 @@ class TestPeriodVaryingEffects:
         )
         assert_allclose(result.objective, 40.0, rtol=1e-4)
 
-    @_xfail_contributions
+    def test_sizing_effects_fixed_vary_by_period(self, optimize):
+        """Proves: Sizing.effects_fixed can vary across periods.
+
+        Grid with Sizing(10, 10), effects_fixed varies: 5 in 2020, 15 in 2025.
+        Fixed cost is independent of size. Weights=[1, 1].
+        Objective = 5 + 15 = 20.
+        """
+        periods = [2020, 2025]
+        cost_by_period = xr.DataArray([5.0, 15.0], dims=['period'], coords={'period': periods})
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([10, 10, 10])),
+                    ],
+                ),
+                Port(
+                    'Grid',
+                    imports=[
+                        Flow(
+                            'Heat',
+                            size=Sizing(10, 10, effects_fixed={'cost': cost_by_period}),
+                        ),
+                    ],
+                ),
+            ],
+            periods=periods,
+            period_weights=[1, 1],
+        )
+        assert_allclose(result.objective, 20.0, rtol=1e-4)
+
     def test_investment_periodic_costs_vary_by_period(self, optimize):
         """Proves: Investment.effects_per_size_periodic can vary across periods.
 
@@ -416,6 +453,7 @@ class TestPeriodVaryingEffects:
         Active in both periods. Periodic cost = O&M * size.
         2020: 1*10=10, 2025: 3*10=30. Weights=[1, 1]. Objective = 10 + 30 = 40.
         """
+        _xfail_if_validate(optimize)
         periods = [2020, 2025]
         om_by_period = xr.DataArray([1.0, 3.0], dims=['period'], coords={'period': periods})
         result = optimize(
@@ -444,7 +482,188 @@ class TestPeriodVaryingEffects:
         )
         assert_allclose(result.objective, 40.0, rtol=1e-4)
 
-    @_xfail_contributions
+    def test_investment_fixed_periodic_costs_vary_by_period(self, optimize):
+        """Proves: Investment.effects_fixed_periodic can vary across periods.
+
+        Investment(10, 10), fixed periodic cost varies: 5 in 2020, 15 in 2025.
+        Active in both periods. Weights=[1, 1]. Objective = 5 + 15 = 20.
+        """
+        _xfail_if_validate(optimize)
+        periods = [2020, 2025]
+        cost_by_period = xr.DataArray([5.0, 15.0], dims=['period'], coords={'period': periods})
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([10, 10, 10])),
+                    ],
+                ),
+                Port(
+                    'Grid',
+                    imports=[
+                        Flow(
+                            'Heat',
+                            size=Investment(10, 10, effects_fixed_periodic={'cost': cost_by_period}),
+                        ),
+                    ],
+                ),
+            ],
+            periods=periods,
+            period_weights=[1, 1],
+        )
+        assert_allclose(result.objective, 20.0, rtol=1e-4)
+
+    def test_investment_capex_per_size_varies_by_period(self, optimize):
+        """Proves: Investment.effects_per_size (once) can vary across periods.
+
+        Investment(10, 10), CAPEX varies: 10 in 2020, 20 in 2025.
+        Mandatory build → builds in cheapest period (2020). Once cost = 10*10 = 100.
+        Weights=[1, 1]. Objective = 100.
+        """
+        _xfail_if_validate(optimize)
+        periods = [2020, 2025]
+        capex_by_period = xr.DataArray([10.0, 20.0], dims=['period'], coords={'period': periods})
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([10, 10, 10])),
+                    ],
+                ),
+                Port(
+                    'Grid',
+                    imports=[
+                        Flow(
+                            'Heat',
+                            size=Investment(10, 10, effects_per_size={'cost': capex_by_period}),
+                        ),
+                    ],
+                ),
+            ],
+            periods=periods,
+            period_weights=[1, 1],
+        )
+        assert_allclose(result.objective, 100.0, rtol=1e-4)
+
+    def test_investment_capex_fixed_varies_by_period(self, optimize):
+        """Proves: Investment.effects_fixed (once) can vary across periods.
+
+        Investment(10, 10), fixed CAPEX varies: 50 in 2020, 100 in 2025.
+        Mandatory build → builds in cheapest period (2020). Once cost = 50.
+        Weights=[1, 1]. Objective = 50.
+        """
+        _xfail_if_validate(optimize)
+        periods = [2020, 2025]
+        capex_by_period = xr.DataArray([50.0, 100.0], dims=['period'], coords={'period': periods})
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([10, 10, 10])),
+                    ],
+                ),
+                Port(
+                    'Grid',
+                    imports=[
+                        Flow(
+                            'Heat',
+                            size=Investment(10, 10, effects_fixed={'cost': capex_by_period}),
+                        ),
+                    ],
+                ),
+            ],
+            periods=periods,
+            period_weights=[1, 1],
+        )
+        assert_allclose(result.objective, 50.0, rtol=1e-4)
+
+    def test_status_running_cost_varies_by_period(self, optimize):
+        """Proves: Status.effects_per_running_hour can vary across periods.
+
+        Flow with status, demand=10 forces flow on for all 3 timesteps.
+        Running cost: 1 in 2020, 3 in 2025. dt=1h.
+        Running cost: 2020→1*3=3, 2025→3*3=9.
+        Weights=[1, 1]. Objective = 3 + 9 = 12.
+        """
+        periods = [2020, 2025]
+        cost_by_period = xr.DataArray([1.0, 3.0], dims=['period'], coords={'period': periods})
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([10, 10, 10])),
+                    ],
+                ),
+                Port(
+                    'Grid',
+                    imports=[
+                        Flow(
+                            'Heat',
+                            size=10,
+                            relative_minimum=0.5,
+                            status=Status(effects_per_running_hour={'cost': cost_by_period}),
+                        ),
+                    ],
+                ),
+            ],
+            periods=periods,
+            period_weights=[1, 1],
+        )
+        assert_allclose(result.objective, 12.0, rtol=1e-4)
+
+    def test_status_startup_cost_varies_by_period(self, optimize):
+        """Proves: Status.effects_per_startup can vary across periods.
+
+        Demand profile [10, 0, 10] forces off→on at t=2 (1 startup per period).
+        Startup cost: 100 in 2020, 300 in 2025.
+        Weights=[1, 1]. Objective = 100 + 300 = 400.
+        """
+        periods = [2020, 2025]
+        cost_by_period = xr.DataArray([100.0, 300.0], dims=['period'], coords={'period': periods})
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([10, 0, 10])),
+                    ],
+                ),
+                Port(
+                    'Grid',
+                    imports=[
+                        Flow(
+                            'Heat',
+                            size=10,
+                            relative_minimum=0.5,
+                            status=Status(effects_per_startup={'cost': cost_by_period}),
+                        ),
+                    ],
+                ),
+            ],
+            periods=periods,
+            period_weights=[1, 1],
+        )
+        assert_allclose(result.objective, 400.0, rtol=1e-4)
+
     def test_contribution_from_varies_by_period(self, optimize):
         """Proves: Effect.contribution_from can vary across periods.
 
@@ -454,6 +673,7 @@ class TestPeriodVaryingEffects:
         CO2 per period = 30. Cost from CO2: 2020→50*30=1500, 2025→100*30=3000.
         Weights=[1, 1]. Objective = 1500 + 3000 = 4500.
         """
+        _xfail_if_validate(optimize)
         periods = [2020, 2025]
         carbon_price = xr.DataArray([50.0, 100.0], dims=['period'], coords={'period': periods})
         result = optimize(
@@ -481,3 +701,80 @@ class TestPeriodVaryingEffects:
             period_weights=[1, 1],
         )
         assert_allclose(result.objective, 4500.0, rtol=1e-4)
+
+    def test_contribution_from_per_hour_varies_by_period(self, optimize):
+        """Proves: Effect.contribution_from_per_hour can vary across periods.
+
+        CO2 effect tracks emissions. Cost gets contribution_from_per_hour CO2
+        at rate 50 in 2020, 100 in 2025. Grid emits 1 CO2/MWh, demand=10 for 3 ts.
+        CO2 per period = 30. Cost: 2020→50*30=1500, 2025→100*30=3000.
+        Weights=[1, 1]. Objective = 1500 + 3000 = 4500.
+        """
+        _xfail_if_validate(optimize)
+        periods = [2020, 2025]
+        carbon_price = xr.DataArray([50.0, 100.0], dims=['period'], coords={'period': periods})
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[
+                Effect('co2'),
+                Effect('cost', is_objective=True, contribution_from_per_hour={'co2': carbon_price}),
+            ],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([10, 10, 10])),
+                    ],
+                ),
+                Port(
+                    'Grid',
+                    imports=[
+                        Flow('Heat', effects_per_flow_hour={'co2': 1}),
+                    ],
+                ),
+            ],
+            periods=periods,
+            period_weights=[1, 1],
+        )
+        assert_allclose(result.objective, 4500.0, rtol=1e-4)
+
+    def test_storage_sizing_effects_per_size_vary_by_period(self, optimize):
+        """Proves: Storage Sizing.effects_per_size can vary across periods.
+
+        Storage with capacity=Sizing(10, 10), effects_per_size varies: 1 in 2020, 3 in 2025.
+        Capacity fixed at 10. Periodic sizing cost: 2020→1*10=10, 2025→3*10=30.
+        Weights=[1, 1]. Objective = 10 + 30 = 40.
+        """
+        periods = [2020, 2025]
+        cost_by_period = xr.DataArray([1.0, 3.0], dims=['period'], coords={'period': periods})
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([5, 5, 5])),
+                    ],
+                ),
+                Port(
+                    'Grid',
+                    imports=[
+                        Flow('Heat'),
+                    ],
+                ),
+            ],
+            storages=[
+                Storage(
+                    'store',
+                    charging=Flow('Heat'),
+                    discharging=Flow('Heat'),
+                    capacity=Sizing(10, 10, effects_per_size={'cost': cost_by_period}),
+                ),
+            ],
+            periods=periods,
+            period_weights=[1, 1],
+        )
+        assert_allclose(result.objective, 40.0, rtol=1e-4)


### PR DESCRIPTION
## Summary

- Widen effect dict value types from `dict[str, float]` to `dict[str, TimeSeries]` on `Sizing`, `Investment`, and `Effect.contribution_from`
- Add optional `period` dimension to all effect arrays in `_SizingArrays`, `_InvestmentArrays`, `_StatusArrays`, and `EffectsData` builders
- Scalar values broadcast naturally — no API breakage for existing code
- No changes needed in `model.py` — xarray broadcasting handles the extra dimension

## Affected Parameters

| Parameter | Old dims | New dims |
|---|---|---|
| `Sizing.effects_per_size/fixed` | `(sizing_dim, effect)` | `(sizing_dim, effect, period?)` |
| `Investment.effects_*` (all 4) | `(invest_dim, effect)` | `(invest_dim, effect, period?)` |
| `Status.effects_running/startup` | `(status_flow, effect, time)` | `(status_flow, effect, time, period?)` |
| `Effect.contribution_from` (cf_periodic) | `(effect, source_effect)` | `(effect, source_effect, period?)` |
| `Effect.contribution_from_per_hour` (cf_temporal) | `(effect, source_effect, time)` | `(effect, source_effect, time, period?)` |

## Test plan

- [x] All 345 existing tests pass (342 + 3 new)
- [x] `mypy src/` — no errors
- [x] `ruff check .` — no errors
- [x] New tests: period-varying sizing costs, investment periodic costs, cross-effect contribution_from

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Effects and contributions now support optional period dimensions and time-series values, enabling period-varying sizing, investment, and contribution inputs.
* **Bug Fixes**
  * N/A
* **Tests**
  * Added comprehensive multi-period tests covering sizing, investment, status, contributions, and storage across periods.
* **Chores**
  * Test fixture metadata updated to expose the selected test pipeline for conditional test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->