### PR TITLE
refac: extract effect template helper, fix xfail, add period-varying tests

### DIFF
--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -15,6 +15,50 @@ if TYPE_CHECKING:
     from fluxopt.elements import Carrier, Effect, Flow, Investment, Sizing, Status, Storage
     from fluxopt.types import TimeIndex, Timesteps
 
+
+@dataclass(frozen=True)
+class _EffectTemplate:
+    """Pre-computed shape/dims/coords for an effect-dimensioned zero array."""
+
+    shape: tuple[int, ...]
+    dims: tuple[str, ...]
+    coords: dict[str, Any]
+    as_da_coords: dict[str, Any]
+
+    def zeros(self) -> xr.DataArray:
+        """Create a zero-filled DataArray with this template's shape."""
+        return xr.DataArray(np.zeros(self.shape), dims=list(self.dims), coords=self.coords)
+
+
+def _effect_template(
+    base_dims: dict[str, Any],
+    period: pd.Index | None = None,
+) -> _EffectTemplate:
+    """Build template shape/dims/coords for effect arrays with optional period.
+
+    Args:
+        base_dims: Ordered mapping of dim_name -> coord_values.
+        period: Period index to append as trailing dimension.
+    """
+    dims = list(base_dims.keys())
+    coords = dict(base_dims)
+    shape = [len(v) for v in base_dims.values()]
+    as_da_coords: dict[str, Any] = {k: v for k, v in base_dims.items() if k not in ('effect', 'source_effect')}
+
+    if period is not None:
+        dims.append('period')
+        coords['period'] = period
+        shape.append(len(period))
+        as_da_coords['period'] = period
+
+    return _EffectTemplate(
+        shape=tuple(shape),
+        dims=tuple(dims),
+        coords=coords,
+        as_da_coords=as_da_coords,
+    )
+
+
 _NC_GROUPS = {
     'flows': 'model/flows',
     'carriers': 'model/carriers',
@@ -85,7 +129,7 @@ class _SizingArrays:
             return cls()
 
         effect_set = set(effect_ids)
-        n_effects = len(effect_ids)
+        tmpl = _effect_template({'effect': effect_ids}, period)
 
         ids: list[str] = []
         mins: list[float] = []
@@ -94,33 +138,22 @@ class _SizingArrays:
         eps_slices: list[xr.DataArray] = []
         ef_slices: list[xr.DataArray] = []
 
-        # Template shape: (effect,) or (effect, period)
-        tmpl_coords: dict[str, Any] = {'effect': effect_ids}
-        tmpl_shape: list[int] = [n_effects]
-        tmpl_dims: list[str] = ['effect']
-        da_coords: dict[str, Any] = {}
-        if period is not None:
-            tmpl_coords['period'] = period
-            tmpl_shape.append(len(period))
-            tmpl_dims.append('period')
-            da_coords['period'] = period
-
         for item_id, s in items:
             ids.append(item_id)
             mins.append(s.min_size)
             maxs.append(s.max_size)
             mandatories.append(s.mandatory)
 
-            eps = xr.DataArray(np.zeros(tmpl_shape), dims=tmpl_dims, coords=tmpl_coords)
-            ef = xr.DataArray(np.zeros(tmpl_shape), dims=tmpl_dims, coords=tmpl_coords)
+            eps = tmpl.zeros()
+            ef = tmpl.zeros()
             for ek, ev in s.effects_per_size.items():
                 if ek not in effect_set:
                     raise ValueError(f'Unknown effect {ek!r} in Sizing.effects_per_size on {item_id!r}')
-                eps.loc[ek] = as_dataarray(ev, da_coords)
+                eps.loc[ek] = as_dataarray(ev, tmpl.as_da_coords)
             for ek, ev in s.effects_fixed.items():
                 if ek not in effect_set:
                     raise ValueError(f'Unknown effect {ek!r} in Sizing.effects_fixed on {item_id!r}')
-                ef.loc[ek] = as_dataarray(ev, da_coords)
+                ef.loc[ek] = as_dataarray(ev, tmpl.as_da_coords)
             eps_slices.append(eps)
             ef_slices.append(ef)
 
@@ -167,7 +200,7 @@ class _InvestmentArrays:
             return cls()
 
         effect_set = set(effect_ids)
-        n_effects = len(effect_ids)
+        tmpl = _effect_template({'effect': effect_ids}, period)
 
         ids: list[str] = []
         mins: list[float] = []
@@ -175,18 +208,6 @@ class _InvestmentArrays:
         mandatories: list[bool] = []
         lifetimes: list[float] = []
         prior_sizes: list[float] = []
-
-        # Template shape: (effect,) or (effect, period)
-        tmpl_coords: dict[str, Any] = {'effect': effect_ids}
-        tmpl_shape: list[int] = [n_effects]
-        tmpl_dims: list[str] = ['effect']
-        da_coords: dict[str, Any] = {}
-        if period is not None:
-            tmpl_coords['period'] = period
-            tmpl_shape.append(len(period))
-            tmpl_dims.append('period')
-            da_coords['period'] = period
-
         all_slices: dict[str, list[xr.DataArray]] = {
             'eps': [],
             'ef': [],
@@ -215,11 +236,11 @@ class _InvestmentArrays:
                 ('Investment.effects_per_size_periodic', inv.effects_per_size_periodic, 'eps_p'),
                 ('Investment.effects_fixed_periodic', inv.effects_fixed_periodic, 'ef_p'),
             ]:
-                arr = xr.DataArray(np.zeros(tmpl_shape), dims=tmpl_dims, coords=tmpl_coords)
+                arr = tmpl.zeros()
                 for ek, ev in src_dict.items():
                     if ek not in effect_set:
                         raise ValueError(f'Unknown effect {ek!r} in {label} on {item_id!r}')
-                    arr.loc[ek] = as_dataarray(ev, da_coords)
+                    arr.loc[ek] = as_dataarray(ev, tmpl.as_da_coords)
                 all_slices[dest_key].append(arr)
 
         coords = {dim: ids}
@@ -304,8 +325,7 @@ class _StatusArrays:
 
         prior_rates_map = prior_rates_map or {}
         effect_set = set(effect_ids)
-        n_effects = len(effect_ids)
-        n_time = len(time)
+        tmpl = _effect_template({'effect': effect_ids, 'time': time}, period)
 
         ids: list[str] = []
         min_ups: list[float] = []
@@ -336,29 +356,18 @@ class _StatusArrays:
                 prev_ups.append(np.nan)
                 prev_downs.append(np.nan)
 
-            # Effects per running hour — (effect, time, period?)
-            er_coords: dict[str, Any] = {'effect': effect_ids, 'time': time}
-            er_shape: list[int] = [n_effects, n_time]
-            er_dims: list[str] = ['effect', 'time']
-            as_da_coords: dict[str, Any] = {'time': time}
-            if period is not None:
-                er_coords['period'] = period
-                er_shape.append(len(period))
-                er_dims.append('period')
-                as_da_coords['period'] = period
-            er = xr.DataArray(np.zeros(er_shape), dims=er_dims, coords=er_coords)
+            er = tmpl.zeros()
             for ek, ev in s.effects_per_running_hour.items():
                 if ek not in effect_set:
                     raise ValueError(f'Unknown effect {ek!r} in Status.effects_per_running_hour on {item_id!r}')
-                er.loc[ek] = as_dataarray(ev, as_da_coords)
+                er.loc[ek] = as_dataarray(ev, tmpl.as_da_coords)
             er_slices.append(er)
 
-            # Effects per startup — (effect, time, period?)
-            es = xr.DataArray(np.zeros(er_shape), dims=er_dims, coords=er_coords)
+            es = tmpl.zeros()
             for ek, ev in s.effects_per_startup.items():
                 if ek not in effect_set:
                     raise ValueError(f'Unknown effect {ek!r} in Status.effects_per_startup on {item_id!r}')
-                es.loc[ek] = as_dataarray(ev, as_da_coords)
+                es.loc[ek] = as_dataarray(ev, tmpl.as_da_coords)
             es_slices.append(es)
 
         coords = {dim: ids}
@@ -929,41 +938,21 @@ class EffectsData:
             if cycle is not None:
                 raise ValueError(f'Circular contribution_from dependency: {" -> ".join(cycle)}')
 
-            # cf_periodic: (effect, source_effect, period?)
-            cf_p_coords: dict[str, Any] = {'effect': effect_ids, 'source_effect': effect_ids}
-            cf_p_shape: list[int] = [n, n]
-            cf_p_dims: list[str] = ['effect', 'source_effect']
-            cf_da_coords: dict[str, Any] = {}
-            if period is not None:
-                cf_p_coords['period'] = period
-                cf_p_shape.append(len(period))
-                cf_p_dims.append('period')
-                cf_da_coords['period'] = period
+            tmpl_p = _effect_template({'effect': effect_ids, 'source_effect': effect_ids}, period)
+            tmpl_t = _effect_template({'effect': effect_ids, 'source_effect': effect_ids, 'time': time}, period)
 
-            # cf_temporal: (effect, source_effect, time, period?)
-            cf_t_coords: dict[str, Any] = {'effect': effect_ids, 'source_effect': effect_ids, 'time': time}
-            cf_t_shape: list[int] = [n, n, n_time]
-            cf_t_dims: list[str] = ['effect', 'source_effect', 'time']
-            cf_t_da_coords: dict[str, Any] = {'time': time}
-            if period is not None:
-                cf_t_coords['period'] = period
-                cf_t_shape.append(len(period))
-                cf_t_dims.append('period')
-                cf_t_da_coords['period'] = period
-
-            periodic_mat = xr.DataArray(np.zeros(cf_p_shape), dims=cf_p_dims, coords=cf_p_coords)
-            temporal_mat = xr.DataArray(np.zeros(cf_t_shape), dims=cf_t_dims, coords=cf_t_coords)
+            periodic_mat = tmpl_p.zeros()
+            temporal_mat = tmpl_t.zeros()
             for e in effects:
                 for src_id, factor in e.contribution_from.items():
                     if src_id not in effect_set:
                         raise ValueError(f'Unknown effect {src_id!r} in Effect.contribution_from on {e.id!r}')
-                    factor_da = as_dataarray(factor, cf_da_coords)
-                    periodic_mat.loc[e.id, src_id] = factor_da
-                    temporal_mat.loc[e.id, src_id] = as_dataarray(factor, cf_t_da_coords)
+                    periodic_mat.loc[e.id, src_id] = as_dataarray(factor, tmpl_p.as_da_coords)
+                    temporal_mat.loc[e.id, src_id] = as_dataarray(factor, tmpl_t.as_da_coords)
                 for src_id, factor_ts in e.contribution_from_per_hour.items():
                     if src_id not in effect_set:
                         raise ValueError(f'Unknown effect {src_id!r} in Effect.contribution_from_per_hour on {e.id!r}')
-                    temporal_mat.loc[e.id, src_id] = as_dataarray(factor_ts, cf_t_da_coords)
+                    temporal_mat.loc[e.id, src_id] = as_dataarray(factor_ts, tmpl_t.as_da_coords)
             cf_periodic = periodic_mat
             cf_temporal = temporal_mat
 

--- a/tests/math_port/conftest.py
+++ b/tests/math_port/conftest.py
@@ -65,4 +65,5 @@ def optimize(request, tmp_path):
         _ = loaded.stats.effect_contributions  # validate contributions survive IO roundtrip
         return loaded
 
+    _optimize.pipeline = request.param  # type: ignore[attr-defined]
     return _optimize

--- a/tests/math_port/test_multi_period.py
+++ b/tests/math_port/test_multi_period.py
@@ -6,7 +6,16 @@ import xarray as xr
 from conftest import ts
 from numpy.testing import assert_allclose
 
-from fluxopt import Carrier, Effect, Flow, Investment, Port, Sizing
+from fluxopt import Carrier, Effect, Flow, Investment, Port, Sizing, Status, Storage
+
+_VALIDATE = 'optimize->save->reload->validate'
+_XFAIL_REASON = 'effect_contributions does not yet support investment/period decomposition (#84)'
+
+
+def _xfail_if_validate(optimize: object) -> None:
+    """Mark expected failure for the validate pipeline."""
+    if getattr(optimize, 'pipeline', None) == _VALIDATE:
+        pytest.xfail(_XFAIL_REASON)
 
 
 class TestMultiPeriod:
@@ -134,14 +143,7 @@ class TestMultiPeriod:
         """Proves: scalar relative_maximum_final_level works in multi-period."""
 
 
-_xfail_contributions = pytest.mark.xfail(
-    reason='effect_contributions does not yet support investment/period decomposition (#84)',
-    strict=False,
-)
-
-
 class TestInvestment:
-    @_xfail_contributions
     def test_investment_mandatory_builds_once(self, optimize):
         """Proves: mandatory Investment builds exactly once across periods.
 
@@ -151,6 +153,7 @@ class TestInvestment:
         Operational cost per period: 10*3*1=30, weighted=5*30=150.
         Total recurring: 3*150=450. Total once: 100. Objective=450+100=550.
         """
+        _xfail_if_validate(optimize)
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
@@ -296,7 +299,6 @@ class TestInvestment:
         # Cost = 2 * 5 * 30 = 300 (operational only, no CAPEX)
         assert_allclose(result.objective, 300.0, rtol=1e-4)
 
-    @_xfail_contributions
     def test_investment_capex_charged_once(self, optimize):
         """Proves: effects_per_size goes to effect_once domain, not periodic.
 
@@ -304,6 +306,7 @@ class TestInvestment:
         No operational costs. 2 periods, weights=[5, 5].
         Objective = 5*0 + 5*0 + 1*100 = 100  (once costs have ω_once=1 by default).
         """
+        _xfail_if_validate(optimize)
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
@@ -333,13 +336,13 @@ class TestInvestment:
         # No flow costs. Objective = 100.
         assert_allclose(result.objective, 100.0, rtol=1e-4)
 
-    @_xfail_contributions
     def test_investment_periodic_costs_weighted(self, optimize):
         """Proves: effects_per_size_periodic goes to effect_periodic, scaled by period weights.
 
         Recurring O&M = 2/MW/period, size=10 MW. 2 periods, weights=[5, 5].
         Periodic cost per period = 2*10 = 20. Weighted: 5*20 + 5*20 = 200.
         """
+        _xfail_if_validate(optimize)
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
@@ -408,7 +411,41 @@ class TestPeriodVaryingEffects:
         )
         assert_allclose(result.objective, 40.0, rtol=1e-4)
 
-    @_xfail_contributions
+    def test_sizing_effects_fixed_vary_by_period(self, optimize):
+        """Proves: Sizing.effects_fixed can vary across periods.
+
+        Grid with Sizing(10, 10), effects_fixed varies: 5 in 2020, 15 in 2025.
+        Fixed cost is independent of size. Weights=[1, 1].
+        Objective = 5 + 15 = 20.
+        """
+        periods = [2020, 2025]
+        cost_by_period = xr.DataArray([5.0, 15.0], dims=['period'], coords={'period': periods})
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([10, 10, 10])),
+                    ],
+                ),
+                Port(
+                    'Grid',
+                    imports=[
+                        Flow(
+                            'Heat',
+                            size=Sizing(10, 10, effects_fixed={'cost': cost_by_period}),
+                        ),
+                    ],
+                ),
+            ],
+            periods=periods,
+            period_weights=[1, 1],
+        )
+        assert_allclose(result.objective, 20.0, rtol=1e-4)
+
     def test_investment_periodic_costs_vary_by_period(self, optimize):
         """Proves: Investment.effects_per_size_periodic can vary across periods.
 
@@ -416,6 +453,7 @@ class TestPeriodVaryingEffects:
         Active in both periods. Periodic cost = O&M * size.
         2020: 1*10=10, 2025: 3*10=30. Weights=[1, 1]. Objective = 10 + 30 = 40.
         """
+        _xfail_if_validate(optimize)
         periods = [2020, 2025]
         om_by_period = xr.DataArray([1.0, 3.0], dims=['period'], coords={'period': periods})
         result = optimize(
@@ -444,7 +482,188 @@ class TestPeriodVaryingEffects:
         )
         assert_allclose(result.objective, 40.0, rtol=1e-4)
 
-    @_xfail_contributions
+    def test_investment_fixed_periodic_costs_vary_by_period(self, optimize):
+        """Proves: Investment.effects_fixed_periodic can vary across periods.
+
+        Investment(10, 10), fixed periodic cost varies: 5 in 2020, 15 in 2025.
+        Active in both periods. Weights=[1, 1]. Objective = 5 + 15 = 20.
+        """
+        _xfail_if_validate(optimize)
+        periods = [2020, 2025]
+        cost_by_period = xr.DataArray([5.0, 15.0], dims=['period'], coords={'period': periods})
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([10, 10, 10])),
+                    ],
+                ),
+                Port(
+                    'Grid',
+                    imports=[
+                        Flow(
+                            'Heat',
+                            size=Investment(10, 10, effects_fixed_periodic={'cost': cost_by_period}),
+                        ),
+                    ],
+                ),
+            ],
+            periods=periods,
+            period_weights=[1, 1],
+        )
+        assert_allclose(result.objective, 20.0, rtol=1e-4)
+
+    def test_investment_capex_per_size_varies_by_period(self, optimize):
+        """Proves: Investment.effects_per_size (once) can vary across periods.
+
+        Investment(10, 10), CAPEX varies: 10 in 2020, 20 in 2025.
+        Mandatory build → builds in cheapest period (2020). Once cost = 10*10 = 100.
+        Weights=[1, 1]. Objective = 100.
+        """
+        _xfail_if_validate(optimize)
+        periods = [2020, 2025]
+        capex_by_period = xr.DataArray([10.0, 20.0], dims=['period'], coords={'period': periods})
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([10, 10, 10])),
+                    ],
+                ),
+                Port(
+                    'Grid',
+                    imports=[
+                        Flow(
+                            'Heat',
+                            size=Investment(10, 10, effects_per_size={'cost': capex_by_period}),
+                        ),
+                    ],
+                ),
+            ],
+            periods=periods,
+            period_weights=[1, 1],
+        )
+        assert_allclose(result.objective, 100.0, rtol=1e-4)
+
+    def test_investment_capex_fixed_varies_by_period(self, optimize):
+        """Proves: Investment.effects_fixed (once) can vary across periods.
+
+        Investment(10, 10), fixed CAPEX varies: 50 in 2020, 100 in 2025.
+        Mandatory build → builds in cheapest period (2020). Once cost = 50.
+        Weights=[1, 1]. Objective = 50.
+        """
+        _xfail_if_validate(optimize)
+        periods = [2020, 2025]
+        capex_by_period = xr.DataArray([50.0, 100.0], dims=['period'], coords={'period': periods})
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([10, 10, 10])),
+                    ],
+                ),
+                Port(
+                    'Grid',
+                    imports=[
+                        Flow(
+                            'Heat',
+                            size=Investment(10, 10, effects_fixed={'cost': capex_by_period}),
+                        ),
+                    ],
+                ),
+            ],
+            periods=periods,
+            period_weights=[1, 1],
+        )
+        assert_allclose(result.objective, 50.0, rtol=1e-4)
+
+    def test_status_running_cost_varies_by_period(self, optimize):
+        """Proves: Status.effects_per_running_hour can vary across periods.
+
+        Flow with status, demand=10 forces flow on for all 3 timesteps.
+        Running cost: 1 in 2020, 3 in 2025. dt=1h.
+        Running cost: 2020→1*3=3, 2025→3*3=9.
+        Weights=[1, 1]. Objective = 3 + 9 = 12.
+        """
+        periods = [2020, 2025]
+        cost_by_period = xr.DataArray([1.0, 3.0], dims=['period'], coords={'period': periods})
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([10, 10, 10])),
+                    ],
+                ),
+                Port(
+                    'Grid',
+                    imports=[
+                        Flow(
+                            'Heat',
+                            size=10,
+                            relative_minimum=0.5,
+                            status=Status(effects_per_running_hour={'cost': cost_by_period}),
+                        ),
+                    ],
+                ),
+            ],
+            periods=periods,
+            period_weights=[1, 1],
+        )
+        assert_allclose(result.objective, 12.0, rtol=1e-4)
+
+    def test_status_startup_cost_varies_by_period(self, optimize):
+        """Proves: Status.effects_per_startup can vary across periods.
+
+        Demand profile [10, 0, 10] forces off→on at t=2 (1 startup per period).
+        Startup cost: 100 in 2020, 300 in 2025.
+        Weights=[1, 1]. Objective = 100 + 300 = 400.
+        """
+        periods = [2020, 2025]
+        cost_by_period = xr.DataArray([100.0, 300.0], dims=['period'], coords={'period': periods})
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([10, 0, 10])),
+                    ],
+                ),
+                Port(
+                    'Grid',
+                    imports=[
+                        Flow(
+                            'Heat',
+                            size=10,
+                            relative_minimum=0.5,
+                            status=Status(effects_per_startup={'cost': cost_by_period}),
+                        ),
+                    ],
+                ),
+            ],
+            periods=periods,
+            period_weights=[1, 1],
+        )
+        assert_allclose(result.objective, 400.0, rtol=1e-4)
+
     def test_contribution_from_varies_by_period(self, optimize):
         """Proves: Effect.contribution_from can vary across periods.
 
@@ -454,6 +673,7 @@ class TestPeriodVaryingEffects:
         CO2 per period = 30. Cost from CO2: 2020→50*30=1500, 2025→100*30=3000.
         Weights=[1, 1]. Objective = 1500 + 3000 = 4500.
         """
+        _xfail_if_validate(optimize)
         periods = [2020, 2025]
         carbon_price = xr.DataArray([50.0, 100.0], dims=['period'], coords={'period': periods})
         result = optimize(
@@ -481,3 +701,80 @@ class TestPeriodVaryingEffects:
             period_weights=[1, 1],
         )
         assert_allclose(result.objective, 4500.0, rtol=1e-4)
+
+    def test_contribution_from_per_hour_varies_by_period(self, optimize):
+        """Proves: Effect.contribution_from_per_hour can vary across periods.
+
+        CO2 effect tracks emissions. Cost gets contribution_from_per_hour CO2
+        at rate 50 in 2020, 100 in 2025. Grid emits 1 CO2/MWh, demand=10 for 3 ts.
+        CO2 per period = 30. Cost: 2020→50*30=1500, 2025→100*30=3000.
+        Weights=[1, 1]. Objective = 1500 + 3000 = 4500.
+        """
+        _xfail_if_validate(optimize)
+        periods = [2020, 2025]
+        carbon_price = xr.DataArray([50.0, 100.0], dims=['period'], coords={'period': periods})
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[
+                Effect('co2'),
+                Effect('cost', is_objective=True, contribution_from_per_hour={'co2': carbon_price}),
+            ],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([10, 10, 10])),
+                    ],
+                ),
+                Port(
+                    'Grid',
+                    imports=[
+                        Flow('Heat', effects_per_flow_hour={'co2': 1}),
+                    ],
+                ),
+            ],
+            periods=periods,
+            period_weights=[1, 1],
+        )
+        assert_allclose(result.objective, 4500.0, rtol=1e-4)
+
+    def test_storage_sizing_effects_per_size_vary_by_period(self, optimize):
+        """Proves: Storage Sizing.effects_per_size can vary across periods.
+
+        Storage with capacity=Sizing(10, 10), effects_per_size varies: 1 in 2020, 3 in 2025.
+        Capacity fixed at 10. Periodic sizing cost: 2020→1*10=10, 2025→3*10=30.
+        Weights=[1, 1]. Objective = 10 + 30 = 40.
+        """
+        periods = [2020, 2025]
+        cost_by_period = xr.DataArray([1.0, 3.0], dims=['period'], coords={'period': periods})
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[Effect('cost', is_objective=True)],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([5, 5, 5])),
+                    ],
+                ),
+                Port(
+                    'Grid',
+                    imports=[
+                        Flow('Heat'),
+                    ],
+                ),
+            ],
+            storages=[
+                Storage(
+                    'store',
+                    charging=Flow('Heat'),
+                    discharging=Flow('Heat'),
+                    capacity=Sizing(10, 10, effects_per_size={'cost': cost_by_period}),
+                ),
+            ],
+            periods=periods,
+            period_weights=[1, 1],
+        )
+        assert_allclose(result.objective, 40.0, rtol=1e-4)


### PR DESCRIPTION
## Summary
- **Extract `_EffectTemplate`** dataclass in `model_data.py` to DRY up the template-shape/dims/coords logic duplicated across `_SizingArrays.build`, `_InvestmentArrays.build`, `_StatusArrays.build`, and `EffectsData.build`
- **Fix stale `@_xfail_contributions`** — replace blanket decorator with selective `_xfail_if_validate()` that only marks the `optimize->save->reload->validate` pipeline (the other two pipelines now pass)
- **Add 8 new tests** for period-varying effect contributions covering previously untested paths: `Sizing.effects_fixed`, `Investment.effects_fixed_periodic`, `Investment.effects_per_size` (once/CAPEX), `Investment.effects_fixed` (once), `Status.effects_per_running_hour`, `Status.effects_per_startup`, `Effect.contribution_from_per_hour`, and Storage sizing effects

## Test plan
- [x] All 375 tests pass (51 multi-period, 9 xfailed validate pipeline)
- [x] `ruff check` and `ruff format` clean
- [x] `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded multi-period test coverage for storage and status functionality, including per-period costs, CAPEX/OPEX variations, and periodic validations to strengthen existing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->