### PR TITLE
docs: add auto-generated API reference pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
     - Effects: math/effects.md
     - Sizing: math/sizing.md
     - Status: math/status.md
+  - API Reference: api/
   - Changelog: changelog.md
 
 theme:
@@ -95,6 +96,13 @@ markdown_extensions:
 plugins:
   - search
   - include-markdown
+
+  - gen-files:
+      scripts:
+        - scripts/gen_ref_pages.py
+
+  - literate-nav:
+      nav_file: SUMMARY.md
 
   - mkdocs-jupyter:
       include_source: true

--- a/scripts/gen_ref_pages.py
+++ b/scripts/gen_ref_pages.py
@@ -1,0 +1,36 @@
+"""Generate the API reference pages automatically from source."""
+
+from pathlib import Path
+
+import mkdocs_gen_files
+
+nav = mkdocs_gen_files.Nav()
+root = Path('src')
+
+for path in sorted(root.rglob('*.py')):
+    module_path = path.relative_to(root).with_suffix('')
+    doc_path = path.relative_to(root).with_suffix('.md')
+    full_doc_path = Path('api', doc_path)
+
+    parts = tuple(module_path.parts)
+
+    if parts[-1] == '__init__':
+        parts = parts[:-1]
+        doc_path = doc_path.with_name('index.md')
+        full_doc_path = full_doc_path.with_name('index.md')
+    elif parts[-1].startswith('_'):
+        continue
+
+    if not parts:
+        continue
+
+    nav[parts] = doc_path.as_posix()
+
+    with mkdocs_gen_files.open(full_doc_path, 'w') as fd:
+        identifier = '.'.join(parts)
+        fd.write(f'::: {identifier}\n')
+
+    mkdocs_gen_files.set_edit_path(full_doc_path, Path('..', path))
+
+with mkdocs_gen_files.open('api/SUMMARY.md', 'w') as nav_file:
+    nav_file.writelines(nav.build_literate_nav())


### PR DESCRIPTION
## Summary
- Add mkdocs `gen-files` and `literate-nav` plugins to auto-generate API reference from source
- Add `scripts/gen_ref_pages.py` to generate reference pages for all public modules
- Add "API Reference" nav entry in mkdocs.yml

## Test plan
- [ ] Run `uv run mkdocs serve` and verify API reference pages render correctly
- [ ] Check that all public modules appear in the generated nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)