### PR TITLE
refac: rename cross-effect API and add once domain

### DIFF
--- a/docs/guide/effects.md
+++ b/docs/guide/effects.md
@@ -65,37 +65,70 @@ co2 = Effect('co2', unit='kg', maximum_per_hour=[50, 40, 60, 50])
 
 ## Cross-Effect Contributions
 
-An effect can include a weighted contribution from another effect using
-`contribution_from`. This is useful for carbon pricing, primary energy factors,
-or any chain where one tracked quantity feeds into another.
+An effect can include a weighted contribution from another effect. Each domain
+has its own field: `cross_temporal`, `cross_periodic`, and `cross_once`. This
+is useful for carbon pricing, primary energy factors, or any chain where one
+tracked quantity feeds into another.
 
-### Scalar (temporal + periodic)
+### Temporal (per-timestep)
 
-A scalar factor applies to **both** domains — temporal (per-timestep) and
-periodic (sizing, yearly costs):
+`cross_temporal` links effects in the temporal domain (flow operation costs).
+The factor can be scalar or time-varying:
 
 ```python
 effects = [
-    Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+    Effect('cost', is_objective=True, cross_temporal={'co2': 50}),
     Effect('co2', unit='kg'),
 ]
 ```
 
-Here, every kg of CO2 adds 50 to cost — both for temporal emissions
-(from flow operation) and periodic emissions (e.g., from `Sizing.effects_per_size`).
+Here, every kg of CO2 emitted per timestep adds 50 to the temporal cost.
 
-### Time-Varying (temporal only)
+Time-varying factors are also supported:
 
-Use `contribution_from_per_hour` for time-varying factors that override the
-scalar in the temporal domain:
+```python
+effects = [
+    Effect('cost', is_objective=True, cross_temporal={'co2': [40, 50, 60]}),
+    Effect('co2', unit='kg'),
+]
+```
+
+### Periodic (recurring costs)
+
+`cross_periodic` links effects in the periodic domain (sizing costs, fixed
+annual O&M — anything that recurs and is weighted by period weights):
+
+```python
+effects = [
+    Effect('cost', is_objective=True, cross_periodic={'co2': 50}),
+    Effect('co2', unit='kg'),
+]
+```
+
+### Once (one-time costs)
+
+`cross_once` links effects in the once domain (one-time investment CAPEX,
+decommissioning — costs that happen at a specific point, not recurring):
+
+```python
+effects = [
+    Effect('cost', is_objective=True, cross_once={'co2': 50}),
+    Effect('co2', unit='kg'),
+]
+```
+
+### Combining domains
+
+Typically you want the same factor in multiple domains. Set each explicitly:
 
 ```python
 effects = [
     Effect(
         'cost',
         is_objective=True,
-        contribution_from={'co2': 50},  # scalar for periodic domain
-        contribution_from_per_hour={'co2': [40, 50, 60]},  # time-varying for temporal domain
+        cross_temporal={'co2': 50},
+        cross_periodic={'co2': 50},
+        cross_once={'co2': 50},
     ),
     Effect('co2', unit='kg'),
 ]
@@ -107,8 +140,8 @@ Contributions chain transitively. A PE -> CO2 -> cost chain is modeled as:
 
 ```python
 effects = [
-    Effect('cost', is_objective=True, contribution_from={'co2': 50}),
-    Effect('co2', unit='kg', contribution_from={'pe': 0.3}),
+    Effect('cost', is_objective=True, cross_temporal={'co2': 50}),
+    Effect('co2', unit='kg', cross_temporal={'pe': 0.3}),
     Effect('pe', unit='kWh'),
 ]
 ```
@@ -212,5 +245,6 @@ print(result.effect_totals)
 | `minimum_total` | `float \| None` | `None` | Lower bound on total |
 | `maximum_per_hour` | `TimeSeries \| None` | `None` | Upper bound per timestep |
 | `minimum_per_hour` | `TimeSeries \| None` | `None` | Lower bound per timestep |
-| `contribution_from` | `dict[str, float]` | `{}` | Cross-effect factor (both domains) |
-| `contribution_from_per_hour` | `dict[str, TimeSeries]` | `{}` | Cross-effect factor (temporal domain only) |
+| `cross_temporal` | `dict[str, TimeSeries]` | `{}` | Cross-effect factor (temporal domain) |
+| `cross_periodic` | `dict[str, TimeSeries]` | `{}` | Cross-effect factor (periodic domain) |
+| `cross_once` | `dict[str, TimeSeries]` | `{}` | Cross-effect factor (once domain) |

--- a/docs/math/effects.md
+++ b/docs/math/effects.md
@@ -21,7 +21,8 @@ periods (e.g., annual O&M for 5 years), while **once** costs happen at a specifi
 differ — recurring costs scale with duration, one-time costs typically don't
 (or use discount factors instead).
 
-All domains support cross-effect chains via `contribution_from`.
+All domains support cross-effect chains via `cross_temporal`, `cross_periodic`,
+and `cross_once`.
 
 In multi-period mode, all variables gain an optional `period` dimension.
 See [Objective](objective.md) for how the domains are weighted in the objective.
@@ -37,8 +38,8 @@ Each effect accumulates contributions from all flows at each timestep:
 The coefficient \(c_{f,k,t}\) specifies how much of effect \(k\) is produced per
 flow-hour of flow \(f\) (e.g., €/MWh for cost, kg/MWh for emissions).
 
-The cross-effect factor \(\alpha_{k,j,t}\) can be time-varying
-(`contribution_from_per_hour`) or constant (`contribution_from`).
+The cross-effect factor \(\alpha_{k,j,t}\) is set via `cross_temporal` and
+can be time-varying or constant.
 Because \(\Phi_{k,t}^{\text{temporal}}\) is a **variable**, the solver resolves
 multi-level chains (e.g., PE → CO₂ → cost) automatically.
 
@@ -63,13 +64,14 @@ periodic domain just as it does through the temporal domain.
 
 ## Cross-Effect Contributions
 
-An effect can include a weighted fraction of another effect's value via
-`contribution_from`. This enables patterns like carbon pricing (CO₂ → cost)
+An effect can include a weighted fraction of another effect's value. Each domain
+has its own cross-effect field — `cross_temporal`, `cross_periodic`, and
+`cross_once` — enabling patterns like carbon pricing (CO₂ → cost)
 or transitive chains (PE → CO₂ → cost).
 
-The scalar factor \(\alpha_{k,j}\) from `contribution_from` applies to **both**
-domains. The time-varying factor from `contribution_from_per_hour` overrides the
-temporal factor only.
+The factor \(\alpha_{k,j}\) from `cross_periodic` applies to the periodic domain,
+\(\alpha_{k,j,t}\) from `cross_temporal` applies to the temporal domain (and can
+be time-varying), and \(\alpha_{k,j}\) from `cross_once` applies to the once domain.
 
 ### Validation
 
@@ -79,12 +81,13 @@ Self-references (\(\alpha_{k,k}\)) and circular dependencies
 ## Once Domain
 
 One-time costs that should not be scaled by period weights (e.g., investment CAPEX,
-decommissioning costs). Currently constrained to zero — a placeholder for future
-investment modelling:
+decommissioning costs):
 
 \[
-\Phi_{k(,p)}^{\text{once}} = 0 \quad \forall \, k
+\Phi_k^{\text{once}} = \underbrace{\Phi_k^{\text{once,direct}}}_{\text{direct one-time costs}} + \underbrace{\sum_{j \in \mathcal{K}} \alpha^{\text{once}}_{k,j} \cdot \Phi_j^{\text{once}}}_{\text{cross-effect contributions}} \quad \forall \, k
 \]
+
+The cross-effect factor \(\alpha^{\text{once}}_{k,j}\) is set via `cross_once`.
 
 ## Total Aggregation
 
@@ -125,8 +128,9 @@ This enforces per-hour limits (e.g., maximum hourly emissions).
 | \(\Phi_{k(,p)}^{\text{once}}\) | One-time effect variable | `effect_once[effect(, period)]` |
 | \(\Phi_{k(,p)}\) | Total effect variable | `effect_total[effect(, period)]` |
 | \(c_{f,k,t}\) | Effect coefficient per flow-hour | `Flow.effects_per_flow_hour` |
-| \(\alpha_{k,j,t}\) | Cross-effect contribution factor (per hour) | `Effect.contribution_from_per_hour` |
-| \(\alpha_{k,j}\) | Cross-effect contribution factor (scalar) | `Effect.contribution_from` |
+| \(\alpha_{k,j,t}\) | Cross-effect factor (temporal, possibly time-varying) | `Effect.cross_temporal` |
+| \(\alpha_{k,j}\) | Cross-effect factor (periodic) | `Effect.cross_periodic` |
+| \(\alpha^{\text{once}}_{k,j}\) | Cross-effect factor (once) | `Effect.cross_once` |
 | \(P_{f,t}\) | Flow rate variable | `flow_rate[flow, time]` |
 | \(\Delta t_t\) | Timestep duration | dt |
 | \(w_t\) | Timestep weight | weights |
@@ -161,13 +165,13 @@ At timestep \(t\) with \(P_{\text{gas},t} = 5\) MW and \(\Delta t = 1\) h:
 - \(\Phi_{\text{cost},t} = 30 \times 5 \times 1 = 150\) €
 - \(\Phi_{\text{CO₂},t} = 0.2 \times 5 \times 1 = 1.0\) kg
 
-### Carbon pricing via `contribution_from`
+### Carbon pricing via cross-effects
 
-CO₂ priced at 50 €/t into the cost effect:
+CO₂ priced at 50 €/t into the cost effect (temporal domain):
 
 ```python
 effects = [
-    Effect("cost", is_objective=True, contribution_from={"co2": 50}),
+    Effect("cost", is_objective=True, cross_temporal={"co2": 50}),
     Effect("co2", unit="kg"),
 ]
 ```
@@ -178,4 +182,4 @@ With \(\alpha_{\text{cost,co2}} = 50\), the per-timestep cost becomes:
 \Phi_{\text{cost},t} = c_{\text{cost}} \cdot P_t \cdot \Delta t + 50 \cdot \Phi_{\text{co2},t}
 \]
 
-The CO₂ total itself is **not** affected — `contribution_from` is one-directional.
+The CO₂ total itself is **not** affected — cross-effects are one-directional.

--- a/docs/math/notation.md
+++ b/docs/math/notation.md
@@ -51,8 +51,9 @@ Each symbol maps to a specific field or variable in the code.
 | \(\underline{e}_s\) | `Storage.relative_minimum_level` | \([0, 1]\) | — | Relative min SOC |
 | \(\bar{e}_s\) | `Storage.relative_maximum_level` | \([0, 1]\) | — | Relative max SOC |
 | \(a_{f}\) | `Converter.conversion_factors` | \(\mathbb{R}\) | — | Conversion coefficient |
-| \(\alpha_{k,j}\) | `Effect.contribution_from` | \(\mathbb{R}\) | varies | Cross-effect factor (scalar) |
-| \(\alpha_{k,j,t}\) | `Effect.contribution_from_per_hour` | \(\mathbb{R}\) | varies | Cross-effect factor (time-varying) |
+| \(\alpha_{k,j}\) | `Effect.cross_periodic` | \(\mathbb{R}\) | varies | Cross-effect factor (periodic) |
+| \(\alpha_{k,j,t}\) | `Effect.cross_temporal` | \(\mathbb{R}\) | varies | Cross-effect factor (temporal, possibly time-varying) |
+| \(\alpha^{\text{once}}_{k,j}\) | `Effect.cross_once` | \(\mathbb{R}\) | varies | Cross-effect factor (once) |
 | \(S^-\) | `Sizing.min_size` | \(\geq 0\) | MW or MWh | Minimum invested size (flow or storage) |
 | \(S^+\) | `Sizing.max_size` | \(\geq 0\) | MW or MWh | Maximum invested size (flow or storage) |
 | \(\gamma_{f,k}\) | `Sizing.effects_per_size` | \(\mathbb{R}\) | varies | Per-size investment cost |

--- a/src/fluxopt/contributions.py
+++ b/src/fluxopt/contributions.py
@@ -33,7 +33,7 @@ def _leontief(cf: xr.DataArray) -> xr.DataArray:
     vals = cf.transpose(*ordered).values  # (..., n, n)
     mat = np.eye(n) - vals
     if np.any(np.linalg.matrix_rank(mat) < n):
-        raise ValueError('Cross-effect matrix (I - C) is singular — check for circular contribution_from chains')
+        raise ValueError('Cross-effect matrix (I - C) is singular — check for circular cross-effect chains')
     inv = np.linalg.inv(mat)  # (..., n, n)
     return xr.DataArray(inv, dims=ordered, coords=cf.coords)
 
@@ -400,6 +400,10 @@ def compute_effect_contributions(solution: xr.Dataset, data: ModelData) -> xr.Da
             dims=['contributor', 'effect'],
             coords={'contributor': all_ids, 'effect': effect_ids},
         )
+
+    # Cross-effects on once via Leontief inverse
+    if data.effects.cf_once is not None:
+        once = _apply_leontief(_leontief(data.effects.cf_once), once)
 
     # --- Total: temporal (weighted sum over time) + periodic + once ---
     total = (

--- a/src/fluxopt/contributions.py
+++ b/src/fluxopt/contributions.py
@@ -4,9 +4,9 @@ Decomposes solver effect totals into per-contributor (flow/storage) parts,
 split into temporal (per-timestep), periodic (sizing, recurring investment),
 and once (one-time investment) domains — matching the model's own structure.
 
-Cross-effects use the Leontief inverse: total = (I - C)^-1 * direct,
-where C is the cross-effect coefficient matrix. One-time costs bypass
-the Leontief pass (matching the solver's ``effect_once`` variable).
+Each domain supports cross-effect propagation via the Leontief inverse:
+total = (I - C)^-1 * direct, where C is the domain's cross-effect matrix
+(``cf_temporal``, ``cf_periodic``, ``cf_once``).
 """
 
 from __future__ import annotations

--- a/src/fluxopt/elements.py
+++ b/src/fluxopt/elements.py
@@ -247,8 +247,9 @@ class Effect:
     minimum_total: float | None = None  # Φ̲_k  [unit]
     maximum_per_hour: TimeSeries | None = None  # Φ̄_{k,t}  [unit]
     minimum_per_hour: TimeSeries | None = None  # Φ̲_{k,t}  [unit]
-    contribution_from: dict[str, TimeSeries] = field(default_factory=dict)
-    contribution_from_per_hour: dict[str, TimeSeries] = field(default_factory=dict)
+    cross_periodic: dict[str, TimeSeries] = field(default_factory=dict)
+    cross_temporal: dict[str, TimeSeries] = field(default_factory=dict)
+    cross_once: dict[str, TimeSeries] = field(default_factory=dict)
     period_weights_periodic: list[float] | None = None  # ω_periodic[p] — scales temporal+periodic
     period_weights_once: list[float] | None = None  # ω_once[p] — scales once
 

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -1333,7 +1333,14 @@ class FlowSystem:
                 if (ef_once != 0).any():
                     once_direct = once_direct + (ef_once * self.pw_invest_build).sum('pw_converter')
 
-        self.m.add_constraints(self.effect_once == once_direct, name='effect_once_eq')
+        # Cross-effect once: cf_once[k,j] * effect_once[j]
+        once_rhs: Any = once_direct
+        if ds.cf_once is not None:
+            source_o = self.effect_once.rename({'effect': 'source_effect'})
+            cross = (ds.cf_once * source_o).sum('source_effect')
+            once_rhs = cross + once_direct
+
+        self.m.add_constraints(self.effect_once == once_rhs, name='effect_once_eq')
 
         # --- Total: effect_total[effect(, period)] ---
         self.effect_total = self.m.add_variables(coords={'effect': effect_ids, **pc}, name='effect--total')

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -1086,16 +1086,10 @@ class EffectsData:
             once_mat = tmpl_p.zeros()
             for e in effects:
                 for src_id, factor in e.cross_periodic.items():
-                    if src_id not in effect_set:
-                        raise ValueError(f'Unknown effect {src_id!r} in Effect.cross_periodic on {e.id!r}')
                     periodic_mat.loc[e.id, src_id] = as_dataarray(factor, tmpl_p.as_da_coords)
                 for src_id, factor_ts in e.cross_temporal.items():
-                    if src_id not in effect_set:
-                        raise ValueError(f'Unknown effect {src_id!r} in Effect.cross_temporal on {e.id!r}')
                     temporal_mat.loc[e.id, src_id] = as_dataarray(factor_ts, tmpl_t.as_da_coords)
                 for src_id, factor in e.cross_once.items():
-                    if src_id not in effect_set:
-                        raise ValueError(f'Unknown effect {src_id!r} in Effect.cross_once on {e.id!r}')
                     once_mat.loc[e.id, src_id] = as_dataarray(factor, tmpl_p.as_da_coords)
             cf_periodic = periodic_mat
             cf_temporal = temporal_mat

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -944,6 +944,7 @@ class EffectsData:
     objective_effect: str
     cf_periodic: xr.DataArray | None = None  # (effect, source_effect, period?)
     cf_temporal: xr.DataArray | None = None  # (effect, source_effect, time, period?)
+    cf_once: xr.DataArray | None = None  # (effect, source_effect, period?)
     period_weights_periodic: xr.DataArray | None = None  # (effect, period)
     period_weights_once: xr.DataArray | None = None  # (effect, period)
 
@@ -1052,47 +1053,53 @@ class EffectsData:
                 as_dataarray(e.maximum_per_hour, {'time': time}) if e.maximum_per_hour is not None else nan_time
             )
             is_objective[i] = e.is_objective
-            if e.contribution_from or e.contribution_from_per_hour:
+            if e.cross_periodic or e.cross_temporal or e.cross_once:
                 has_contributions = True
 
         # Build cross-effect contribution arrays
         cf_periodic: xr.DataArray | None = None
         cf_temporal: xr.DataArray | None = None
+        cf_once: xr.DataArray | None = None
         if has_contributions:
             # Self-reference check
             for e in effects:
-                for src_id in (*e.contribution_from, *e.contribution_from_per_hour):
+                for src_id in (*e.cross_periodic, *e.cross_temporal, *e.cross_once):
                     if src_id == e.id:
-                        raise ValueError(f'Effect {e.id!r} cannot reference itself in contribution_from')
+                        raise ValueError(f'Effect {e.id!r} cannot reference itself in cross-effect fields')
 
             # Cycle check
             adjacency: dict[str, list[str]] = {eid: [] for eid in effect_ids}
             for e in effects:
-                for src_id in {*e.contribution_from, *e.contribution_from_per_hour}:
+                for src_id in {*e.cross_periodic, *e.cross_temporal, *e.cross_once}:
                     if src_id not in effect_set:
-                        raise ValueError(f'Unknown effect {src_id!r} in contribution_from on {e.id!r}')
+                        raise ValueError(f'Unknown effect {src_id!r} in cross-effect fields on {e.id!r}')
                     adjacency[e.id].append(src_id)
             cycle = _detect_contribution_cycle(adjacency)
             if cycle is not None:
-                raise ValueError(f'Circular contribution_from dependency: {" -> ".join(cycle)}')
+                raise ValueError(f'Circular cross-effect dependency: {" -> ".join(cycle)}')
 
             tmpl_p = _effect_template({'effect': effect_ids, 'source_effect': effect_ids}, period)
             tmpl_t = _effect_template({'effect': effect_ids, 'source_effect': effect_ids, 'time': time}, period)
 
             periodic_mat = tmpl_p.zeros()
             temporal_mat = tmpl_t.zeros()
+            once_mat = tmpl_p.zeros()
             for e in effects:
-                for src_id, factor in e.contribution_from.items():
+                for src_id, factor in e.cross_periodic.items():
                     if src_id not in effect_set:
-                        raise ValueError(f'Unknown effect {src_id!r} in Effect.contribution_from on {e.id!r}')
+                        raise ValueError(f'Unknown effect {src_id!r} in Effect.cross_periodic on {e.id!r}')
                     periodic_mat.loc[e.id, src_id] = as_dataarray(factor, tmpl_p.as_da_coords)
-                    temporal_mat.loc[e.id, src_id] = as_dataarray(factor, tmpl_t.as_da_coords)
-                for src_id, factor_ts in e.contribution_from_per_hour.items():
+                for src_id, factor_ts in e.cross_temporal.items():
                     if src_id not in effect_set:
-                        raise ValueError(f'Unknown effect {src_id!r} in Effect.contribution_from_per_hour on {e.id!r}')
+                        raise ValueError(f'Unknown effect {src_id!r} in Effect.cross_temporal on {e.id!r}')
                     temporal_mat.loc[e.id, src_id] = as_dataarray(factor_ts, tmpl_t.as_da_coords)
+                for src_id, factor in e.cross_once.items():
+                    if src_id not in effect_set:
+                        raise ValueError(f'Unknown effect {src_id!r} in Effect.cross_once on {e.id!r}')
+                    once_mat.loc[e.id, src_id] = as_dataarray(factor, tmpl_p.as_da_coords)
             cf_periodic = periodic_mat
             cf_temporal = temporal_mat
+            cf_once = once_mat if (once_mat != 0).any() else None
 
         effect_idx = pd.Index(effect_ids, name='effect')
 
@@ -1141,6 +1148,7 @@ class EffectsData:
             objective_effect=objective_effect,
             cf_periodic=cf_periodic,
             cf_temporal=cf_temporal,
+            cf_once=cf_once,
             period_weights_periodic=pw_periodic,
             period_weights_once=pw_once,
         )

--- a/tests/math/test_contributions.py
+++ b/tests/math/test_contributions.py
@@ -108,7 +108,7 @@ class TestCrossEffects:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('cost', is_objective=True, cross_periodic={'co2': 50}, cross_temporal={'co2': 50}),
                 Effect('co2', unit='kg'),
             ],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
@@ -140,7 +140,7 @@ class TestCrossEffects:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('cost', is_objective=True, cross_periodic={'co2': 50}, cross_temporal={'co2': 50}),
                 Effect('co2', maximum_total=co2_limit),
             ],
             ports=[
@@ -170,8 +170,8 @@ class TestCrossEffects:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
-                Effect('co2', unit='kg', contribution_from={'pe': 0.3}),
+                Effect('cost', is_objective=True, cross_periodic={'co2': 50}, cross_temporal={'co2': 50}),
+                Effect('co2', unit='kg', cross_periodic={'pe': 0.3}, cross_temporal={'pe': 0.3}),
                 Effect('pe', unit='kWh'),
             ],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
@@ -243,7 +243,7 @@ class TestSizing:
         assert grid_periodic == pytest.approx(1000, abs=1e-6)
 
     def test_sizing_cross_effect_investment(self):
-        """Sizing CO2 priced into cost via contribution_from."""
+        """Sizing CO2 priced into cost via cross-effects."""
 
         source = Flow(
             'elec',
@@ -256,7 +256,7 @@ class TestSizing:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('cost', is_objective=True, cross_periodic={'co2': 50}, cross_temporal={'co2': 50}),
                 Effect('co2', unit='kg'),
             ],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
@@ -374,7 +374,7 @@ class TestStorage:
         assert total_from_contrib == pytest.approx(solver_total, abs=1e-6)
 
     def test_storage_sizing_cross_effect(self):
-        """Storage sizing CO2 priced into cost via contribution_from."""
+        """Storage sizing CO2 priced into cost via cross-effects."""
 
         charge = Flow('elec')
         discharge = Flow('elec')
@@ -385,7 +385,7 @@ class TestStorage:
             timesteps=ts(4),
             carriers=[Carrier('elec')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('cost', is_objective=True, cross_periodic={'co2': 50}, cross_temporal={'co2': 50}),
                 Effect('co2', unit='kg'),
             ],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],

--- a/tests/math/test_contributions.py
+++ b/tests/math/test_contributions.py
@@ -4,7 +4,7 @@ import pytest
 import xarray as xr
 from conftest import ts
 
-from fluxopt import Carrier, Effect, Flow, Port, Sizing, Status, Storage, optimize
+from fluxopt import Carrier, Effect, Flow, Investment, Port, Sizing, Status, Storage, optimize
 from fluxopt.components import Converter
 
 
@@ -272,6 +272,41 @@ class TestSizing:
         invest_co2 = invest_size * 10
         expected_inv_cost = invest_co2 * 50
         assert grid_inv_cost == pytest.approx(expected_inv_cost, abs=1e-6)
+
+
+class TestCrossOnce:
+    def test_cross_once_prices_embodied_co2(self):
+        """cross_once prices one-time investment CO2 into cost via Leontief."""
+
+        source = Flow(
+            'elec',
+            size=Investment(50, 50, mandatory=True, effects_per_size={'co2': 10}),
+            effects_per_flow_hour={'co2': 1},
+        )
+        sink = Flow('elec', size=1, fixed_relative_profile=[10, 10, 10])
+
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('elec')],
+            effects=[
+                Effect('cost', is_objective=True, cross_temporal={'co2': 50}, cross_once={'co2': 50}),
+                Effect('co2', unit='kg'),
+            ],
+            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+            periods=[2020, 2025],
+            period_weights=[1, 1],
+        )
+
+        contrib = result.stats.effect_contributions
+        assert 'once' in contrib
+
+        # Once domain: 50 MW * 10 CO2/MW = 500 CO2, priced at 50 → 25000 cost
+        grid_once_cost = float(contrib['once'].sel(contributor='grid(elec)', effect='cost').sum().values)
+        assert grid_once_cost == pytest.approx(25000.0, abs=1e-4)
+
+        # Total matches solver
+        diff = abs(contrib['total'].sum('contributor') - result.solution['effect--total'])
+        assert float(diff.max().values) < 1e-4
 
 
 class TestStatus:

--- a/tests/math/test_effects.py
+++ b/tests/math/test_effects.py
@@ -126,6 +126,20 @@ class TestCrossEffects:
                 ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
             )
 
+    def test_cross_effect_unknown_effect_raises(self):
+        """Referencing a non-existent effect in cross-effect raises ValueError."""
+
+        source = Flow('elec', size=100, effects_per_flow_hour={'cost': 0.04})
+        sink = Flow('elec', size=100, fixed_relative_profile=[0.5, 0.5, 0.5])
+
+        with pytest.raises(ValueError, match='Unknown effect'):
+            optimize(
+                timesteps=ts(3),
+                carriers=[Carrier('elec')],
+                effects=[Effect('cost', is_objective=True, cross_periodic={'nonexistent': 50})],
+                ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+            )
+
     def test_cross_effect_carbon_pricing(self):
         """CO2 at 0.5 kg/MWh, carbon price 50 €/kg → cost includes CO2 * 50."""
         demand = [50.0, 80.0, 60.0]

--- a/tests/math/test_effects.py
+++ b/tests/math/test_effects.py
@@ -94,39 +94,39 @@ class TestEffects:
         assert result.objective == pytest.approx(expected, abs=1e-6)
 
 
-class TestContributionFrom:
-    def test_contribution_from_self_reference_raises(self):
-        """Self-referencing contribution_from raises ValueError."""
+class TestCrossEffects:
+    def test_cross_effect_self_reference_raises(self):
+        """Self-referencing cross-effect raises ValueError."""
 
         source = Flow('elec', size=100, effects_per_flow_hour={'cost': 0.04})
         sink = Flow('elec', size=100, fixed_relative_profile=[0.5, 0.5, 0.5])
 
-        with pytest.raises(ValueError, match='cannot reference itself'):
+        with pytest.raises(ValueError, match='cannot reference itself in cross-effect fields'):
             optimize(
                 timesteps=ts(3),
                 carriers=[Carrier('elec')],
-                effects=[Effect('cost', is_objective=True, contribution_from={'cost': 0.5})],
+                effects=[Effect('cost', is_objective=True, cross_periodic={'cost': 0.5})],
                 ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
             )
 
-    def test_contribution_from_circular_raises(self):
-        """Circular contribution_from dependency raises ValueError."""
+    def test_cross_effect_circular_raises(self):
+        """Circular cross-effect dependency raises ValueError."""
 
         source = Flow('elec', size=100, effects_per_flow_hour={'cost': 0.04, 'co2': 0.5})
         sink = Flow('elec', size=100, fixed_relative_profile=[0.5, 0.5, 0.5])
 
-        with pytest.raises(ValueError, match='Circular contribution_from dependency'):
+        with pytest.raises(ValueError, match='Circular cross-effect dependency'):
             optimize(
                 timesteps=ts(3),
                 carriers=[Carrier('elec')],
                 effects=[
-                    Effect('cost', is_objective=True, contribution_from={'co2': 50}),
-                    Effect('co2', unit='kg', contribution_from={'cost': 0.01}),
+                    Effect('cost', is_objective=True, cross_periodic={'co2': 50}),
+                    Effect('co2', unit='kg', cross_periodic={'cost': 0.01}),
                 ],
                 ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
             )
 
-    def test_contribution_from_carbon_pricing(self):
+    def test_cross_effect_carbon_pricing(self):
         """CO2 at 0.5 kg/MWh, carbon price 50 €/kg → cost includes CO2 * 50."""
         demand = [50.0, 80.0, 60.0]
 
@@ -141,7 +141,7 @@ class TestContributionFrom:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('cost', is_objective=True, cross_periodic={'co2': 50}, cross_temporal={'co2': 50}),
                 Effect('co2', unit='kg'),
             ],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
@@ -154,8 +154,8 @@ class TestContributionFrom:
         expected_cost = direct_cost + co2_cost
         assert result.objective == pytest.approx(expected_cost, abs=1e-6)
 
-    def test_contribution_from_source_unaffected(self):
-        """Source effect total is unchanged by contribution_from on target."""
+    def test_cross_effect_source_unaffected(self):
+        """Source effect total is unchanged by cross-effect on target."""
         demand = [50.0, 80.0, 60.0]
 
         source = Flow(
@@ -169,7 +169,7 @@ class TestContributionFrom:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('cost', is_objective=True, cross_periodic={'co2': 50}, cross_temporal={'co2': 50}),
                 Effect('co2', unit='kg'),
             ],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
@@ -180,7 +180,7 @@ class TestContributionFrom:
         co2_total = float(result.effect_totals.sel(effect='co2').values)
         assert co2_total == pytest.approx(expected_co2, abs=1e-6)
 
-    def test_contribution_from_transitive(self):
+    def test_cross_effect_transitive(self):
         """PE → CO2 → cost chain: transitivity via variable chaining."""
         demand = [50.0, 80.0, 60.0]
 
@@ -195,8 +195,8 @@ class TestContributionFrom:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
-                Effect('co2', unit='kg', contribution_from={'pe': 0.3}),  # 0.3 kg_CO2/kWh_PE
+                Effect('cost', is_objective=True, cross_periodic={'co2': 50}, cross_temporal={'co2': 50}),
+                Effect('co2', unit='kg', cross_periodic={'pe': 0.3}, cross_temporal={'pe': 0.3}),
                 Effect('pe', unit='kWh'),
             ],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
@@ -211,8 +211,8 @@ class TestContributionFrom:
         assert float(result.effect_totals.sel(effect='co2').values) == pytest.approx(co2_total, abs=1e-6)
         assert result.objective == pytest.approx(cost_total, abs=1e-6)
 
-    def test_contribution_from_per_hour(self):
-        """Time-varying carbon price overrides scalar for per-timestep."""
+    def test_cross_temporal_time_varying(self):
+        """Time-varying carbon price for per-timestep cross-effect."""
         demand = [50.0, 80.0, 60.0]
 
         source = Flow(
@@ -230,8 +230,8 @@ class TestContributionFrom:
                 Effect(
                     'cost',
                     is_objective=True,
-                    contribution_from={'co2': 50},  # scalar for invest
-                    contribution_from_per_hour={'co2': carbon_prices},  # time-varying for ops
+                    cross_periodic={'co2': 50},  # scalar for invest
+                    cross_temporal={'co2': carbon_prices},  # time-varying for ops
                 ),
                 Effect('co2', unit='kg'),
             ],
@@ -244,8 +244,8 @@ class TestContributionFrom:
         expected = sum(d * 0.5 * p for d, p in zip(demand, carbon_prices, strict=True))
         assert result.objective == pytest.approx(expected, abs=1e-6)
 
-    def test_contribution_from_investment(self):
-        """Sizing CO2 priced into cost via contribution_from."""
+    def test_cross_effect_investment(self):
+        """Sizing CO2 priced into cost via cross-effects."""
         demand = [50.0, 50.0, 50.0]
 
         source = Flow(
@@ -259,7 +259,7 @@ class TestContributionFrom:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('cost', is_objective=True, cross_periodic={'co2': 50}, cross_temporal={'co2': 50}),
                 Effect('co2', unit='kg'),
             ],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
@@ -278,7 +278,7 @@ class TestContributionFrom:
         assert float(result.effect_totals.sel(effect='co2').values) == pytest.approx(co2_total, abs=1e-6)
         assert result.objective == pytest.approx(cost_total, abs=1e-6)
 
-    def test_contribution_from_investment_transitive(self):
+    def test_cross_effect_investment_transitive(self):
         """PE → CO2 → cost: 3-level chain with investment costs propagates correctly."""
         demand = [50.0, 50.0, 50.0]
 
@@ -293,8 +293,8 @@ class TestContributionFrom:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
-                Effect('co2', unit='kg', contribution_from={'pe': 0.3}),
+                Effect('cost', is_objective=True, cross_periodic={'co2': 50}, cross_temporal={'co2': 50}),
+                Effect('co2', unit='kg', cross_periodic={'pe': 0.3}, cross_temporal={'pe': 0.3}),
                 Effect('pe', unit='kWh'),
             ],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],

--- a/tests/math_port/test_effects.py
+++ b/tests/math_port/test_effects.py
@@ -51,21 +51,21 @@ class TestEffects:
         assert_allclose(result.effect_totals.sel(effect='cost').item(), 60.0, rtol=1e-5)
         assert_allclose(result.effect_totals.sel(effect='CO2').item(), 15.0, rtol=1e-5)
 
-    def test_contribution_from_temporal(self, optimize):
-        """Proves: contribution_from adds a weighted fraction of one effect's
+    def test_cross_effect_temporal(self, optimize):
+        """Proves: cross_temporal adds a weighted fraction of one effect's
         temporal sum into another effect's total.
 
-        cost has contribution_from={'CO2': 0.5}. Source: cost=1, CO2=10 per kWh.
+        cost has cross_temporal={'CO2': 0.5}. Source: cost=1, CO2=10 per kWh.
         Demand=20. Direct cost=20, CO2=200. Cross: 0.5*200=100. Total cost=120.
 
         Sensitivity: Without cross-effect, cost=20 (6x less). The 120
-        value is impossible without contribution_from working.
+        value is impossible without cross_temporal working.
         """
         result = optimize(
             timesteps=ts(2),
             carriers=[Carrier('Heat')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'CO2': 0.5}),
+                Effect('cost', is_objective=True, cross_periodic={'CO2': 0.5}, cross_temporal={'CO2': 0.5}),
                 Effect('CO2'),
             ],
             ports=[
@@ -276,22 +276,22 @@ class TestEffects:
         """
         raise NotImplementedError  # TODO: implement minimum_temporal on Effect
 
-    def test_contribution_from_periodic(self, optimize):
-        """Proves: contribution_from adds a weighted fraction of one effect's periodic
+    def test_cross_effect_periodic(self, optimize):
+        """Proves: cross_periodic adds a weighted fraction of one effect's periodic
         (investment) sum into another effect's total.
 
-        cost has contribution_from={'CO2': 10}. Boiler invest: fixed cost=100, CO2=5.
+        cost has cross_periodic={'CO2': 10}. Boiler invest: fixed cost=100, CO2=5.
         Fuel cost=20. Direct cost = 100 + 20 = 120. CO2 periodic = 5.
         Cross: 10 * 5 = 50. Total cost = 170.
 
-        Sensitivity: Without contribution_from, cost=120. With it, cost=170.
+        Sensitivity: Without cross_periodic, cost=120. With it, cost=170.
         """
 
         result = optimize(
             timesteps=ts(2),
             carriers=[Carrier('Gas'), Carrier('Heat')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'CO2': 10}),
+                Effect('cost', is_objective=True, cross_periodic={'CO2': 10}, cross_temporal={'CO2': 10}),
                 Effect('CO2'),
             ],
             ports=[

--- a/tests/math_port/test_multi_period.py
+++ b/tests/math_port/test_multi_period.py
@@ -664,10 +664,10 @@ class TestPeriodVaryingEffects:
         )
         assert_allclose(result.objective, 400.0, rtol=1e-4)
 
-    def test_contribution_from_varies_by_period(self, optimize):
-        """Proves: Effect.contribution_from can vary across periods.
+    def test_cross_periodic_varies_by_period(self, optimize):
+        """Proves: Effect.cross_periodic can vary across periods.
 
-        CO2 effect tracks emissions. Cost effect gets contribution_from CO2
+        CO2 effect tracks emissions. Cost effect gets cross_periodic CO2
         at rate 50 in 2020, 100 in 2025 (rising carbon price).
         Grid emits 1 CO2/MWh, demand=10 for 3 timesteps.
         CO2 per period = 30. Cost from CO2: 2020→50*30=1500, 2025→100*30=3000.
@@ -681,7 +681,12 @@ class TestPeriodVaryingEffects:
             carriers=[Carrier('Heat')],
             effects=[
                 Effect('co2'),
-                Effect('cost', is_objective=True, contribution_from={'co2': carbon_price}),
+                Effect(
+                    'cost',
+                    is_objective=True,
+                    cross_periodic={'co2': carbon_price},
+                    cross_temporal={'co2': carbon_price},
+                ),
             ],
             ports=[
                 Port(
@@ -702,10 +707,10 @@ class TestPeriodVaryingEffects:
         )
         assert_allclose(result.objective, 4500.0, rtol=1e-4)
 
-    def test_contribution_from_per_hour_varies_by_period(self, optimize):
-        """Proves: Effect.contribution_from_per_hour can vary across periods.
+    def test_cross_temporal_varies_by_period(self, optimize):
+        """Proves: Effect.cross_temporal can vary across periods.
 
-        CO2 effect tracks emissions. Cost gets contribution_from_per_hour CO2
+        CO2 effect tracks emissions. Cost gets cross_temporal CO2
         at rate 50 in 2020, 100 in 2025. Grid emits 1 CO2/MWh, demand=10 for 3 ts.
         CO2 per period = 30. Cost: 2020→50*30=1500, 2025→100*30=3000.
         Weights=[1, 1]. Objective = 1500 + 3000 = 4500.
@@ -718,7 +723,7 @@ class TestPeriodVaryingEffects:
             carriers=[Carrier('Heat')],
             effects=[
                 Effect('co2'),
-                Effect('cost', is_objective=True, contribution_from_per_hour={'co2': carbon_price}),
+                Effect('cost', is_objective=True, cross_temporal={'co2': carbon_price}),
             ],
             ports=[
                 Port(
@@ -779,13 +784,13 @@ class TestPeriodVaryingEffects:
         )
         assert_allclose(result.objective, 40.0, rtol=1e-4)
 
-    def test_contribution_from_with_investment_once_costs(self, optimize):
+    def test_cross_effect_with_investment_once_costs(self, optimize):
         """Proves: one-time investment costs bypass periodic Leontief pass.
 
         Grid with Investment(50, 50, mandatory=True):
         - one-time cost: 1000 €/MW → 50000 € in effect_once
         - operational: 1 €/MWh, demand=10 for 3 ts → 30 €/period
-        CO2 tracks emissions (1 CO2/MWh), cost has contribution_from CO2 at 50.
+        CO2 tracks emissions (1 CO2/MWh), cost has cross-effects from CO2 at 50.
 
         Objective = temporal_cost(0) + periodic_leontief(0 + 30*50*2) + once(50000)
         The key: effect_contributions validation must pass, confirming
@@ -798,7 +803,7 @@ class TestPeriodVaryingEffects:
             carriers=[Carrier('Heat')],
             effects=[
                 Effect('co2'),
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('cost', is_objective=True, cross_periodic={'co2': 50}, cross_temporal={'co2': 50}),
             ],
             ports=[
                 Port(
@@ -828,5 +833,55 @@ class TestPeriodVaryingEffects:
         contribs = result.stats.effect_contributions
         assert 'once' in contribs
         # Verify contributions match solver totals (xarray-aligned)
+        diff = abs(contribs['total'].sum('contributor') - result.solution['effect--total'])
+        assert float(diff.max().values) < 1e-4
+
+    def test_cross_once_prices_embodied_emissions(self, optimize):
+        """Proves: cross_once prices one-time investment emissions into cost.
+
+        Grid with Investment(50, 50, mandatory=True), embodied CO2 = 10 kg/MW.
+        cross_once={'co2': 50} prices this into cost.
+        Demand=10 for 3 ts, operational CO2=1/MWh, cross_temporal={'co2': 50}.
+
+        Operational CO2: 30/period * 2 periods = 60. Cost via temporal: 60*50=3000.
+        Embodied CO2: 50 MW * 10 = 500. Cost via once: 500*50 = 25000.
+        Total CO2 = 60 + 500 = 560. Objective = 3000 + 25000 = 28000.
+        """
+        _xfail_if_validate(optimize)
+        periods = [2020, 2025]
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[
+                Effect('co2'),
+                Effect('cost', is_objective=True, cross_temporal={'co2': 50}, cross_once={'co2': 50}),
+            ],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([10, 10, 10])),
+                    ],
+                ),
+                Port(
+                    'Grid',
+                    imports=[
+                        Flow(
+                            'Heat',
+                            size=Investment(50, 50, mandatory=True, effects_per_size={'co2': 10}),
+                            effects_per_flow_hour={'co2': 1},
+                        ),
+                    ],
+                ),
+            ],
+            periods=periods,
+            period_weights=[1, 1],
+        )
+        # CO2 total: operational 60 + embodied 500 = 560
+        assert_allclose(float(result.effect_totals.sel(effect='co2').sum().values), 560.0, rtol=1e-4)
+        # Cost: temporal Leontief(60*50=3000) + once Leontief(500*50=25000) = 28000
+        assert_allclose(result.objective, 28000.0, rtol=1e-4)
+        # Contribution validation
+        contribs = result.stats.effect_contributions
         diff = abs(contribs['total'].sum('contributor') - result.solution['effect--total'])
         assert float(diff.max().values) < 1e-4

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -138,9 +138,9 @@ class TestCarrierMetadataRoundtrip:
         assert str(loaded.data.carriers.description.sel(carrier='elec').values) == 'Electrical energy'
 
 
-class TestRoundtripContributionFrom:
-    def test_roundtrip_with_contribution_from(self, tmp_nc: Path) -> None:
-        """ModelData with contribution_from survives NetCDF roundtrip."""
+class TestRoundtripCrossEffects:
+    def test_roundtrip_with_cross_effects(self, tmp_nc: Path) -> None:
+        """ModelData with cross-effects survives NetCDF roundtrip."""
         ts = [datetime(2024, 1, 1, h) for h in range(3)]
         source = Flow('elec', size=200, effects_per_flow_hour={'cost': 0.04, 'co2': 0.5})
         sink = Flow('elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])
@@ -149,7 +149,7 @@ class TestRoundtripContributionFrom:
             timesteps=ts,
             carriers=[Carrier('elec')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('cost', is_objective=True, cross_periodic={'co2': 50}, cross_temporal={'co2': 50}),
                 Effect('co2', unit='kg'),
             ],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],


### PR DESCRIPTION
## Summary

- **Rename** `Effect.contribution_from` → `Effect.cross_periodic` and `Effect.contribution_from_per_hour` → `Effect.cross_temporal`
- **Add** `Effect.cross_once` for one-time investment cross-effects (e.g., embodied CO2 → carbon cost)
- **Add** `cf_once` Leontief pass in both solver (`model.py`) and attribution (`contributions.py`)
- **Update** all tests and documentation

Closes #105.

**BREAKING CHANGE**: `contribution_from` and `contribution_from_per_hour` removed. The old `contribution_from` set both periodic and temporal matrices; the new API requires explicit per-domain fields.

## Test plan

- [x] `uv run pytest tests/ -q` — 442 passed, 179 skipped, 11 xfailed
- [x] `uv run mypy src/` — no issues
- [x] `uv run ruff check .` — all checks passed
- [x] New test: `test_cross_once_prices_embodied_emissions` — verifies Investment CO2 priced into cost via `cross_once`
- [x] Existing cross-effect tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Restructured cross-effect API with domain-specific fields: periodic, temporal, and one-time contributions are now separated for clearer effect modeling and relationships.

* **Documentation**
  * Updated comprehensive guides and mathematical notation to reflect the new cross-effect field organization and per-domain semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->