### PR TITLE
fix(ci): let config control prerelease default, dispatch overrides

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
           manifest-file: .release-please-manifest.json
           token: ${{ steps.app-token.outputs.token }}
           target-branch: ${{ inputs.branch || github.ref_name }}
-          prerelease: ${{ inputs.prerelease == '' && true || inputs.prerelease }}
+          prerelease: ${{ inputs.prerelease }}
 
   publish:
     needs: [release-please]

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -9,6 +9,7 @@
       "bump-minor-for-major-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "changelog-path": "CHANGELOG.md",
+      "prerelease": true,
       "prerelease-type": "alpha",
       "initial-version": "0.0.2-alpha.0"
     }


### PR DESCRIPTION
## Summary

Follow-up to #110 — the fix commit landed after the merge.

- Restore `prerelease: true` in release-please config as the default
- Simplify workflow expression to `${{ inputs.prerelease }}` — empty on push (config applies), explicit on dispatch (overrides config)
- Fixes a GitHub Actions boolean coercion bug where `false == ''` evaluates to `true`

## Test plan

- [ ] Push to main → release-please creates alpha prerelease PR (config default)
- [ ] Dispatch with `prerelease: true` → alpha prerelease
- [ ] Dispatch with `prerelease: false` → stable release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated prerelease configuration to improve release handling and workflow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->