### PR TITLE
ci: remove workflow_call from publish for trusted publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,14 +3,9 @@ name: Publish
 on:
   push:
     tags: ["v*"]
-  workflow_call:
-    inputs:
-      tag:
-        required: true
-        type: string
 
 concurrency:
-  group: publish-${{ inputs.tag || github.ref_name }}
+  group: publish-${{ github.ref_name }}
   cancel-in-progress: false
 
 permissions:
@@ -29,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.tag || github.ref_name }}
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
 
       - uses: astral-sh/setup-uv@v7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,9 +12,6 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-24.04
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: actions/create-github-app-token@v3
         id: app-token
@@ -28,14 +25,3 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
-
-  publish:
-    needs: release-please
-    if: needs.release-please.outputs.release_created
-    permissions:
-      id-token: write
-      contents: write
-      attestations: write
-    uses: ./.github/workflows/publish.yaml
-    with:
-      tag: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
## Summary

- Remove `workflow_call` trigger from `publish.yaml` — PyPI trusted publishing doesn't work with reusable workflow calls (it sees the caller workflow, not the publish workflow)
- Remove `publish` job from `release.yaml` — release-please creates the tag via app token, which triggers `publish.yaml` directly via tag push
- Simplify ref handling (no more `inputs.tag` fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified release automation workflow by removing manual tag input requirements; Git references are now automatically derived from triggering events
  * Updated release pipeline to eliminate unnecessary workflow coordination between release and publish stages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->