### PR TITLE
fix: scale effect per-hour bounds by timestep duration

### DIFF
--- a/docs/guide/effects.md
+++ b/docs/guide/effects.md
@@ -53,10 +53,12 @@ revenue = Effect('revenue', minimum_total=500)
 
 ### Per-Hour Bounds
 
-Limit the effect value at each timestep:
+Limit the effect **rate** at each timestep. The bound is specified per hour and
+scales with the timestep duration (`dt`), so the constraint is
+resolution-independent:
 
 ```python
-# Max 50 kg CO2 per hour
+# Max 50 kg CO2 per hour — allows 200 kg in a 4h timestep
 co2 = Effect('co2', unit='kg', maximum_per_hour=50)
 
 # Time-varying per-hour bound
@@ -210,7 +212,7 @@ print(result.effect_totals)
 | `is_objective` | `bool` | `False` | Whether this effect is minimized |
 | `maximum_total` | `float \| None` | `None` | Upper bound on total |
 | `minimum_total` | `float \| None` | `None` | Lower bound on total |
-| `maximum_per_hour` | `TimeSeries \| None` | `None` | Upper bound per timestep |
-| `minimum_per_hour` | `TimeSeries \| None` | `None` | Lower bound per timestep |
+| `maximum_per_hour` | `TimeSeries \| None` | `None` | Upper bound rate (per hour), scaled by `dt` |
+| `minimum_per_hour` | `TimeSeries \| None` | `None` | Lower bound rate (per hour), scaled by `dt` |
 | `contribution_from` | `dict[str, float]` | `{}` | Cross-effect factor (both domains) |
 | `contribution_from_per_hour` | `dict[str, TimeSeries]` | `{}` | Cross-effect factor (temporal domain only) |

--- a/docs/math/effects.md
+++ b/docs/math/effects.md
@@ -112,7 +112,7 @@ The per-hour bounds are **rates** (e.g., kg/h, €/h) that scale with the timest
 duration \(\Delta t_t\). This ensures the constraint is resolution-independent:
 
 \[
-\underline{\Phi}_{k,t}^{\text{per hour}} \cdot \Delta t_t \leq \Phi_{k,t}^{\text{temporal}} \leq \bar{\Phi}_{k,t}^{\text{per hour}} \cdot \Delta t_t \quad \forall \, t \in \mathcal{T}
+\underline{\Phi}_{k,t}^{\text{per hour}} \cdot \Delta t_t \leq \Phi_{k,t}^{\text{temporal}} \leq \bar{\Phi}_{k,t}^{\text{per hour}} \cdot \Delta t_t \quad \forall \, k \in \mathcal{K}, \; t \in \mathcal{T}
 \]
 
 For example, `maximum_per_hour=100` (kg/h) with a 4-hour timestep allows up to

--- a/docs/math/effects.md
+++ b/docs/math/effects.md
@@ -106,15 +106,17 @@ Upper and lower bounds on the total effect over the entire horizon:
 
 This is useful for emission caps or budget constraints.
 
-## Per-Timestep Bounds
+## Per-Hour Bounds
 
-Bounds on the effect value at each timestep:
+The per-hour bounds are **rates** (e.g., kg/h, €/h) that scale with the timestep
+duration \(\Delta t_t\). This ensures the constraint is resolution-independent:
 
 \[
-\underline{\Phi}_{k,t} \leq \Phi_{k,t} \leq \bar{\Phi}_{k,t} \quad \forall \, t \in \mathcal{T}
+\underline{\Phi}_{k,t}^{\text{per hour}} \cdot \Delta t_t \leq \Phi_{k,t}^{\text{temporal}} \leq \bar{\Phi}_{k,t}^{\text{per hour}} \cdot \Delta t_t \quad \forall \, t \in \mathcal{T}
 \]
 
-This enforces per-hour limits (e.g., maximum hourly emissions).
+For example, `maximum_per_hour=100` (kg/h) with a 4-hour timestep allows up to
+400 kg of emissions in that timestep.
 
 ## Parameters
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "netcdf4>=1.6.0",
     "numpy>=1.26",
     "pandas>=2.1",
-    "xarray>=2024.1.0",
+    "xarray>=2024.1.0,<2026.4.0",  # 2026.4.0 breaks linopy (Dataset-as-data_vars)
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "highspy>=1.13.1",
+    "highspy>=1.13.1,!=1.14.0",  # 1.14.0 has MIP presolve bug (ERGO-Code/HiGHS#2975)
     "linopy @ git+https://github.com/PyPSA/linopy.git@f53d1968e53d70962eb208b01c3f938f693f0083",
     "netcdf4>=1.6.0",
     "numpy>=1.26",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "highspy>=1.13.1",
+    "highspy>=1.13.1,<1.14.0",  # 1.14.0 has MIP regression in optional invest tests
     "linopy @ git+https://github.com/PyPSA/linopy.git@f53d1968e53d70962eb208b01c3f938f693f0083",
     "netcdf4>=1.6.0",
     "numpy>=1.26",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "highspy>=1.13.1,!=1.14.0",  # 1.14.0 has MIP presolve bug (ERGO-Code/HiGHS#2975)
+    "highspy>=1.13.1",
     "linopy @ git+https://github.com/PyPSA/linopy.git@f53d1968e53d70962eb208b01c3f938f693f0083",
     "netcdf4>=1.6.0",
     "numpy>=1.26",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "highspy>=1.13.1,<1.14.0",  # 1.14.0 has MIP regression in optional invest tests
+    "highspy>=1.13.1",
     "linopy @ git+https://github.com/PyPSA/linopy.git@f53d1968e53d70962eb208b01c3f938f693f0083",
     "netcdf4>=1.6.0",
     "numpy>=1.26",

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -771,13 +771,16 @@ class FlowSystem:
 
         self.m.add_constraints(self.effect_temporal == temporal_rhs, name='effect_temporal_eq')
 
-        # Per-hour bounds on effect_temporal
-        min_ph = ds.min_per_hour  # (effect, time) — NaN = unbounded
+        # Per-hour bounds: effect[t] <= max_per_hour * dt[t]
+        # effect_temporal is in absolute units (e.g. EUR), so the per-hour rate
+        # must be scaled by the timestep duration to get the per-timestep limit.
+        dt = d.dims.dt
+        min_ph = ds.min_per_hour * dt  # (effect, time) — NaN = unbounded
         has_min_ph = min_ph.notnull()
         if has_min_ph.any():
             self.m.add_constraints(self.effect_temporal >= min_ph, name='effect_min_ph', mask=has_min_ph)
 
-        max_ph = ds.max_per_hour
+        max_ph = ds.max_per_hour * dt
         has_max_ph = max_ph.notnull()
         if has_max_ph.any():
             self.m.add_constraints(self.effect_temporal <= max_ph, name='effect_max_ph', mask=has_max_ph)

--- a/tests/math_port/test_effects.py
+++ b/tests/math_port/test_effects.py
@@ -249,6 +249,96 @@ class TestEffects:
         assert_allclose(result.effect_totals.sel(effect='cost').item(), 20.0, rtol=1e-5)
         assert_allclose(result.effect_totals.sel(effect='CO2').item(), 20.0, rtol=1e-5)
 
+    def test_effect_maximum_per_hour_scales_with_dt(self, optimize):
+        """Proves: maximum_per_hour scales with timestep duration.
+
+        CO2 max_per_hour=4. dt=2h. Dirty: 1€+1kgCO2/kWh. Clean: 5€+0kgCO2/kWh.
+        Demand=[15,5] (power in MW). CO2 per timestep = rate * 1 * dt.
+
+        Per-timestep CO2 cap = max_per_hour * dt = 4 * 2 = 8 kgCO2.
+        Dirty rate capped at 4 MW (since 4 * 1 * 2 = 8 = cap).
+        t=0: Dirty_rate=4, Clean_rate=11. t=1: Dirty_rate=4, Clean_rate=1.
+        cost = (4*2 + 4*2)*1 + (11*2 + 1*2)*5 = 16 + 120 = 136.
+
+        Sensitivity: With dt=1h, cap=4/ts, Dirty=[4,4], Clean=[11,1], cost=68.
+        """
+        from datetime import datetime, timedelta
+
+        start = datetime(2024, 1, 1)
+        timesteps = [start, start + timedelta(hours=2)]
+        result = optimize(
+            timesteps=timesteps,
+            carriers=[Carrier('Heat')],
+            effects=[
+                Effect('cost', is_objective=True),
+                Effect('CO2', maximum_per_hour=4),
+            ],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([15, 5])),
+                    ],
+                ),
+                Port(
+                    'Dirty',
+                    imports=[
+                        Flow('Heat', effects_per_flow_hour={'cost': 1, 'CO2': 1}),
+                    ],
+                ),
+                Port(
+                    'Clean',
+                    imports=[
+                        Flow('Heat', effects_per_flow_hour={'cost': 5, 'CO2': 0}),
+                    ],
+                ),
+            ],
+        )
+        # t=0: Dirty_rate=4 (capped), Clean_rate=11. t=1: Dirty_rate=4, Clean_rate=1.
+        # cost = (4+4)*1*2 + (11+1)*5*2 = 16 + 120 = 136
+        assert_allclose(result.effect_totals.sel(effect='cost').item(), 136.0, rtol=1e-5)
+
+    def test_effect_minimum_per_hour_scales_with_dt(self, optimize):
+        """Proves: minimum_per_hour scales with timestep duration.
+
+        CO2 min_per_hour=5. dt=2h. Dirty: 1€+1kgCO2/kWh. Demand=[3,3] (power).
+        Per-timestep energy: [6,6] kWh. Per-timestep CO2 floor = 5 * 2 = 10 kgCO2.
+        Dirty must produce ≥10 kWh each ts → excess absorbed by waste.
+
+        cost = 10 + 10 = 20.
+        Sensitivity: Without min_per_hour, Dirty=6 each ts → cost=12.
+        """
+        from datetime import datetime, timedelta
+
+        start = datetime(2024, 1, 1)
+        timesteps = [start, start + timedelta(hours=2)]
+        result = optimize(
+            timesteps=timesteps,
+            carriers=[Carrier('Heat')],
+            effects=[
+                Effect('cost', is_objective=True),
+                Effect('CO2', minimum_per_hour=5),
+            ],
+            ports=[
+                Port(
+                    'Demand',
+                    exports=[
+                        Flow('Heat', size=1, fixed_relative_profile=np.array([3, 3])),
+                    ],
+                ),
+                Port(
+                    'Dirty',
+                    imports=[
+                        Flow('Heat', effects_per_flow_hour={'cost': 1, 'CO2': 1}),
+                    ],
+                ),
+                waste('Heat'),
+            ],
+        )
+        # Must emit ≥10 CO2 each ts → Dirty ≥ 10 each ts → cost = 20
+        assert_allclose(result.effect_totals.sel(effect='cost').item(), 20.0, rtol=1e-5)
+        assert_allclose(result.effect_totals.sel(effect='CO2').item(), 20.0, rtol=1e-5)
+
     @pytest.mark.skip(reason='maximum_temporal not supported in fluxopt')
     def test_effect_maximum_temporal(self, optimize):
         """Proves: maximum_temporal caps the sum of an effect's per-timestep contributions

--- a/tests/math_port/test_flow_invest.py
+++ b/tests/math_port/test_flow_invest.py
@@ -60,7 +60,6 @@ class TestFlowInvest:
         assert_allclose(result.sizes.sel(flow='Boiler(Heat)').item(), 50.0, rtol=1e-5)
         assert_allclose(result.effect_totals.sel(effect='cost').item(), 140.0, rtol=1e-5)
 
-    @pytest.mark.xfail(reason='HiGHS >=1.14 presolve regression (#128)', strict=False)
     def test_invest_optional_not_built(self, optimize):
         """Proves: Optional investment is correctly skipped when the fixed investment
         cost outweighs operational savings.
@@ -279,7 +278,6 @@ class TestFlowInvest:
         # invest=1000+10*1=1010, fuel from ExpensiveBoiler=20 (eta=1.0), total=1030
         assert_allclose(result.effect_totals.sel(effect='cost').item(), 1030.0, rtol=1e-5)
 
-    @pytest.mark.xfail(reason='HiGHS >=1.14 presolve regression (#128)', strict=False)
     def test_invest_not_mandatory_skips_when_uneconomical(self, optimize):
         """Proves: mandatory=False (default) allows optimizer to skip investment
         when it's not economical.

--- a/tests/math_port/test_flow_invest.py
+++ b/tests/math_port/test_flow_invest.py
@@ -60,6 +60,7 @@ class TestFlowInvest:
         assert_allclose(result.sizes.sel(flow='Boiler(Heat)').item(), 50.0, rtol=1e-5)
         assert_allclose(result.effect_totals.sel(effect='cost').item(), 140.0, rtol=1e-5)
 
+    @pytest.mark.xfail(reason='HiGHS >=1.14 presolve regression (#128)', strict=False)
     def test_invest_optional_not_built(self, optimize):
         """Proves: Optional investment is correctly skipped when the fixed investment
         cost outweighs operational savings.
@@ -278,6 +279,7 @@ class TestFlowInvest:
         # invest=1000+10*1=1010, fuel from ExpensiveBoiler=20 (eta=1.0), total=1030
         assert_allclose(result.effect_totals.sel(effect='cost').item(), 1030.0, rtol=1e-5)
 
+    @pytest.mark.xfail(reason='HiGHS >=1.14 presolve regression (#128)', strict=False)
     def test_invest_not_mandatory_skips_when_uneconomical(self, optimize):
         """Proves: mandatory=False (default) allows optimizer to skip investment
         when it's not economical.


### PR DESCRIPTION
## Summary

- `maximum_per_hour` and `minimum_per_hour` on `Effect` are rates (e.g. kg/h, EUR/h), but `effect_temporal` holds absolute values per timestep. The constraint now multiplies the bound by `dt`: `effect[t] <= max_per_hour * dt[t]`
- Previously the raw rate was compared directly, which was only correct when `dt=1h`
- Added two tests with 2h timesteps proving the bounds scale correctly
- Updated math docs and user guide to clarify the rate semantics

## Test plan

- [x] Existing `test_effect_maximum_per_hour` and `test_effect_minimum_per_hour` still pass (dt=1h, behavior unchanged)
- [x] New `test_effect_maximum_per_hour_scales_with_dt` proves correct scaling with dt=2h
- [x] New `test_effect_minimum_per_hour_scales_with_dt` proves correct scaling with dt=2h
- [x] Full test suite passes (381 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `maximum_per_hour` and `minimum_per_hour` are rate limits scaled by timestep duration for resolution independence, replacing per-timestep framing.

* **Bug Fixes**
  * Corrected per-hour bound constraint calculations to properly scale bounds by timestep duration.

* **Tests**
  * Added test cases validating that per-hour bounds correctly scale with different timestep durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->