### PR TITLE
fix: exclude highspy 1.14.0 due to MIP presolve bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "netcdf4>=1.6.0",
     "numpy>=1.26",
     "pandas>=2.1",
-    "xarray>=2024.1.0",
+    "xarray>=2024.1.0,<2026.4.0",  # 2026.4.0 breaks linopy (Dataset-as-data_vars)
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "highspy>=1.13.1",
+    "highspy>=1.13.1,!=1.14.0",  # 1.14.0 has MIP presolve bug (ERGO-Code/HiGHS#2975)
     "linopy @ git+https://github.com/PyPSA/linopy.git@f53d1968e53d70962eb208b01c3f938f693f0083",
     "netcdf4>=1.6.0",
     "numpy>=1.26",


### PR DESCRIPTION
## Summary

- Excludes `highspy==1.14.0` which has a MIP presolve bug that incorrectly fixes binary variables with big-M constraints
- Reported upstream: ERGO-Code/HiGHS#2975
- Minimal repro: 3-variable MIP where presolve picks obj=99999 over obj=20

## Test plan

- [x] Confirmed bug reproduces with `highspy==1.14.0` and correct result with `1.13.1` on the same LP file
- [x] `!=1.14.0` allows future versions that fix the regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)