### PR TITLE
refac: redesign effect system — named buckets, two domains, objective at solve time

### DIFF
--- a/docs/guide/converters.md
+++ b/docs/guide/converters.md
@@ -130,6 +130,7 @@ result = optimize(
     effects=[Effect('cost')],
     ports=[Port('grid', imports=[gas_source]), Port('demand', exports=[demand_flow])],
     converters=[Converter.boiler('boiler', thermal_efficiency=0.9, fuel_flow=fuel, thermal_flow=heat_out)],
+    objective_effects='cost',
 )
 
 # Gas consumed = heat / efficiency

--- a/docs/guide/converters.md
+++ b/docs/guide/converters.md
@@ -127,7 +127,7 @@ heat = Carrier('heat')
 result = optimize(
     timesteps=timesteps,
     carriers=[gas, heat],
-    effects=[Effect('cost', is_objective=True)],
+    effects=[Effect('cost')],
     ports=[Port('grid', imports=[gas_source]), Port('demand', exports=[demand_flow])],
     converters=[Converter.boiler('boiler', thermal_efficiency=0.9, fuel_flow=fuel, thermal_flow=heat_out)],
 )

--- a/docs/guide/effects.md
+++ b/docs/guide/effects.md
@@ -18,8 +18,9 @@ cost = Effect('cost')
 co2 = Effect('co2', unit='kg')
 ```
 
-The objective is specified in the `optimize()` call via `objective_effects='cost'`
-(defaults to `'cost'`).
+The objective is specified in the `optimize()` call via the mandatory
+`objective_effects` argument, e.g. `objective_effects='cost'`. Pass a list to
+minimize a sum of effect totals, e.g. `objective_effects=['opex', 'capex']`.
 
 ## Linking Flows to Effects
 
@@ -208,8 +209,11 @@ print(result.effect_totals)
 |---|---|---|---|
 | `id` | `str` | required | Effect identifier |
 | `unit` | `str` | `''` | Unit label |
-| `maximum` | `float \| None` | `None` | Upper bound on total |
-| `minimum` | `float \| None` | `None` | Lower bound on total |
+| `maximum` | `float \| None` | `None` | Upper bound on weighted total across all periods |
+| `minimum` | `float \| None` | `None` | Lower bound on weighted total across all periods |
+| `maximum_per_period` | `float \| None` | `None` | Upper bound on each period independently |
+| `minimum_per_period` | `float \| None` | `None` | Lower bound on each period independently |
 | `maximum_per_hour` | `TimeSeries \| None` | `None` | Upper bound rate (per hour), scaled by `dt` |
 | `minimum_per_hour` | `TimeSeries \| None` | `None` | Lower bound rate (per hour), scaled by `dt` |
-| `contribution_from` | `dict[str, TimeSeries]` | `{}` | Cross-effect factor (both domains) |
+| `contribution_from` | `dict[str, TimeSeries]` | `{}` | Cross-effect factor (scalar or time-varying; lump uses `mean('time')`) |
+| `period_weights` | `list[float] \| None` | `None` | Per-period weights for total aggregation (overrides global `period_weights`) |

--- a/docs/guide/effects.md
+++ b/docs/guide/effects.md
@@ -18,7 +18,7 @@ cost = Effect('cost')
 co2 = Effect('co2', unit='kg')
 ```
 
-The objective is specified in the `optimize()` call via `objective='cost'`
+The objective is specified in the `optimize()` call via `objective_effects='cost'`
 (defaults to `'cost'`).
 
 ## Linking Flows to Effects
@@ -195,6 +195,7 @@ result = optimize(
         Port('clean', imports=[expensive_clean]),
         Port('demand', exports=[demand]),
     ],
+    objective_effects='cost',
 )
 
 print(f"Total cost: {result.objective:.2f}")

--- a/docs/guide/effects.md
+++ b/docs/guide/effects.md
@@ -11,14 +11,15 @@ See [Effects (Math)](../math/effects.md) for the formulation.
 ```python
 from fluxopt import Effect
 
-# Objective effect (minimized)
-cost = Effect('cost', is_objective=True)
+# Cost effect (will be used as objective in optimize())
+cost = Effect('cost')
 
 # Tracked effect with a unit
 co2 = Effect('co2', unit='kg')
 ```
 
-Exactly one effect must have `is_objective=True`.
+The objective is specified in the `optimize()` call via `objective='cost'`
+(defaults to `'cost'`).
 
 ## Linking Flows to Effects
 
@@ -45,10 +46,10 @@ Limit the total effect over the entire horizon:
 
 ```python
 # CO2 budget: max 1000 kg total
-co2 = Effect('co2', unit='kg', maximum_total=1000)
+co2 = Effect('co2', unit='kg', maximum=1000)
 
 # Cost floor (e.g., minimum revenue)
-revenue = Effect('revenue', minimum_total=500)
+revenue = Effect('revenue', minimum=500)
 ```
 
 ### Per-Hour Bounds
@@ -71,33 +72,30 @@ An effect can include a weighted contribution from another effect using
 `contribution_from`. This is useful for carbon pricing, primary energy factors,
 or any chain where one tracked quantity feeds into another.
 
-### Scalar (temporal + periodic)
+### Scalar (both domains)
 
 A scalar factor applies to **both** domains — temporal (per-timestep) and
-periodic (sizing, yearly costs):
+lump (sizing, yearly costs):
 
 ```python
 effects = [
-    Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+    Effect('cost', contribution_from={'co2': 50}),
     Effect('co2', unit='kg'),
 ]
 ```
 
 Here, every kg of CO2 adds 50 to cost — both for temporal emissions
-(from flow operation) and periodic emissions (e.g., from `Sizing.effects_per_size`).
+(from flow operation) and lump emissions (e.g., from `Sizing.effects_per_size`).
 
-### Time-Varying (temporal only)
+### Time-Varying
 
-Use `contribution_from_per_hour` for time-varying factors that override the
-scalar in the temporal domain:
+Use `TimeSeries` values in `contribution_from` for time-varying factors:
 
 ```python
 effects = [
     Effect(
         'cost',
-        is_objective=True,
-        contribution_from={'co2': 50},  # scalar for periodic domain
-        contribution_from_per_hour={'co2': [40, 50, 60]},  # time-varying for temporal domain
+        contribution_from={'co2': [40, 50, 60]},  # time-varying
     ),
     Effect('co2', unit='kg'),
 ]
@@ -109,7 +107,7 @@ Contributions chain transitively. A PE -> CO2 -> cost chain is modeled as:
 
 ```python
 effects = [
-    Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+    Effect('cost', contribution_from={'co2': 50}),
     Effect('co2', unit='kg', contribution_from={'pe': 0.3}),
     Effect('pe', unit='kWh'),
 ]
@@ -139,15 +137,15 @@ print(result.effect_totals)
 # Temporal: per-timestep effect values as (effect, time) DataArray
 print(result.effects_temporal)
 
-# Periodic: sizing and fixed-cost effect values as (effect,) DataArray
-print(result.effects_periodic)
+# Lump: sizing and fixed-cost effect values as (effect,) DataArray
+print(result.effects_lump)
 ```
 
 ### Per-Contributor Breakdown
 
 `stats.effect_contributions` decomposes effect totals into per-contributor parts
 on a unified `contributor` dimension (flow IDs + storage IDs), matching the
-model's temporal/periodic domain structure:
+model's temporal/lump domain structure:
 
 ```python
 contrib = result.stats.effect_contributions
@@ -155,10 +153,10 @@ contrib = result.stats.effect_contributions
 # Per-timestep contributions (contributor, effect, time) — flows only
 contrib['temporal']
 
-# Periodic contributions (contributor, effect) — flows + storages
-contrib['periodic']
+# Lump contributions (contributor, effect) — flows + storages
+contrib['lump']
 
-# Total per contributor: temporal summed over time + periodic (contributor, effect)
+# Total per contributor: temporal summed over time + lump (contributor, effect)
 contrib['total']
 ```
 
@@ -189,8 +187,8 @@ result = optimize(
     timesteps=timesteps,
     carriers=[elec],
     effects=[
-        Effect('cost', is_objective=True),
-        Effect('co2', maximum_total=100),
+        Effect('cost'),
+        Effect('co2', maximum=100),
     ],
     ports=[
         Port('cheap', imports=[cheap_dirty]),
@@ -209,10 +207,8 @@ print(result.effect_totals)
 |---|---|---|---|
 | `id` | `str` | required | Effect identifier |
 | `unit` | `str` | `''` | Unit label |
-| `is_objective` | `bool` | `False` | Whether this effect is minimized |
-| `maximum_total` | `float \| None` | `None` | Upper bound on total |
-| `minimum_total` | `float \| None` | `None` | Lower bound on total |
+| `maximum` | `float \| None` | `None` | Upper bound on total |
+| `minimum` | `float \| None` | `None` | Lower bound on total |
 | `maximum_per_hour` | `TimeSeries \| None` | `None` | Upper bound rate (per hour), scaled by `dt` |
 | `minimum_per_hour` | `TimeSeries \| None` | `None` | Lower bound rate (per hour), scaled by `dt` |
-| `contribution_from` | `dict[str, float]` | `{}` | Cross-effect factor (both domains) |
-| `contribution_from_per_hour` | `dict[str, TimeSeries]` | `{}` | Cross-effect factor (temporal domain only) |
+| `contribution_from` | `dict[str, TimeSeries]` | `{}` | Cross-effect factor (both domains) |

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -39,10 +39,11 @@ heat = Carrier('heat')
 
 ### 3. Define Effects
 
-Effects track quantities across the horizon. Mark one as the objective.
+Effects track quantities across the horizon. The objective is specified
+in the `optimize()` call (defaults to `'cost'`).
 
 ```python
-effects = [Effect('cost', is_objective=True)]
+effects = [Effect('cost')]
 ```
 
 ### 4. Define Flows

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -88,6 +88,7 @@ result = optimize(
     effects=effects,
     ports=ports,
     converters=converters,
+    objective_effects='cost',
 )
 ```
 

--- a/docs/guide/sizing.md
+++ b/docs/guide/sizing.md
@@ -157,6 +157,7 @@ result = optimize(
         Port('solar', imports=[solar]),
         Port('demand', exports=[demand]),
     ],
+    objective_effects='cost',
 )
 
 print(f"Objective: {result.objective:.2f}")

--- a/docs/guide/sizing.md
+++ b/docs/guide/sizing.md
@@ -151,7 +151,7 @@ elec = Carrier('elec')
 result = optimize(
     timesteps=timesteps,
     carriers=[elec],
-    effects=[Effect('cost', is_objective=True)],
+    effects=[Effect('cost')],
     ports=[
         Port('grid', imports=[grid]),
         Port('solar', imports=[solar]),

--- a/docs/guide/status.md
+++ b/docs/guide/status.md
@@ -197,6 +197,7 @@ result = optimize(
     effects=[Effect('cost')],
     ports=[Port('grid', imports=[gas_source]), Port('demand', exports=[demand])],
     converters=[Converter.boiler('boiler', 0.9, fuel, heat_out)],
+    objective_effects='cost',
 )
 ```
 

--- a/docs/guide/status.md
+++ b/docs/guide/status.md
@@ -194,7 +194,7 @@ heat = Carrier('heat')
 result = optimize(
     timesteps=timesteps,
     carriers=[gas, heat],
-    effects=[Effect('cost', is_objective=True)],
+    effects=[Effect('cost')],
     ports=[Port('grid', imports=[gas_source]), Port('demand', exports=[demand])],
     converters=[Converter.boiler('boiler', 0.9, fuel, heat_out)],
 )

--- a/docs/guide/storage.md
+++ b/docs/guide/storage.md
@@ -111,7 +111,7 @@ elec = Carrier('elec')
 result = optimize(
     timesteps=timesteps,
     carriers=[elec],
-    effects=[Effect('cost', is_objective=True)],
+    effects=[Effect('cost')],
     ports=[Port('grid', imports=[source]), Port('demand', exports=[demand])],
     storages=[battery],
 )

--- a/docs/guide/storage.md
+++ b/docs/guide/storage.md
@@ -114,6 +114,7 @@ result = optimize(
     effects=[Effect('cost')],
     ports=[Port('grid', imports=[source]), Port('demand', exports=[demand])],
     storages=[battery],
+    objective_effects='cost',
 )
 
 print(result.flow_rate('battery(charge)'))

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ demand = Flow('heat', size=100, fixed_relative_profile=[0.4, 0.7, 0.5, 0.6])
 result = optimize(
     timesteps=timesteps,
     carriers=[gas, heat],
-    effects=[Effect('cost', is_objective=True)],
+    effects=[Effect('cost')],
     ports=[Port('grid', imports=[gas_source]), Port('demand', exports=[demand])],
     converters=[Converter.boiler('boiler', thermal_efficiency=0.9, fuel_flow=fuel, thermal_flow=heat_out)],
 )

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ result = optimize(
     effects=[Effect('cost')],
     ports=[Port('grid', imports=[gas_source]), Port('demand', exports=[demand])],
     converters=[Converter.boiler('boiler', thermal_efficiency=0.9, fuel_flow=fuel, thermal_flow=heat_out)],
+    objective_effects='cost',
 )
 
 print(f"Total cost: {result.objective:.2f}")

--- a/docs/math/effects.md
+++ b/docs/math/effects.md
@@ -137,10 +137,13 @@ For example, `maximum_per_hour=100` (kg/h) with a 4-hour timestep allows up to
 | \(P_{f,t}\) | Flow rate variable | `flow_rate[flow, time]` |
 | \(\Delta t_t\) | Timestep duration | dt |
 | \(w_t\) | Timestep weight | weights |
-| \(\bar{\Phi}_k\) | Maximum total | `Effect.maximum` |
-| \(\underline{\Phi}_k\) | Minimum total | `Effect.minimum` |
-| \(\bar{\Phi}_{k,t}\) | Maximum per hour | `Effect.maximum_per_hour` |
-| \(\underline{\Phi}_{k,t}\) | Minimum per hour | `Effect.minimum_per_hour` |
+| \(\bar{\Phi}_k\) | Maximum aggregate (weighted sum across periods) | `Effect.maximum` |
+| \(\underline{\Phi}_k\) | Minimum aggregate (weighted sum across periods) | `Effect.minimum` |
+| \(\bar{\Phi}_k^{\text{per period}}\) | Maximum per period | `Effect.maximum_per_period` |
+| \(\underline{\Phi}_k^{\text{per period}}\) | Minimum per period | `Effect.minimum_per_period` |
+| \(\bar{\Phi}_{k,t}^{\text{per hour}}\) | Maximum per hour (rate, scaled by \(\Delta t_t\)) | `Effect.maximum_per_hour` |
+| \(\underline{\Phi}_{k,t}^{\text{per hour}}\) | Minimum per hour (rate, scaled by \(\Delta t_t\)) | `Effect.minimum_per_hour` |
+| \(\omega_{k,p}\) | Period weight (per-effect, falls back to global, then 1) | `Effect.period_weights` / global `period_weights` |
 
 See [Notation](notation.md) for the full symbol table.
 

--- a/docs/math/effects.md
+++ b/docs/math/effects.md
@@ -6,20 +6,13 @@ Effects represent quantities that are tracked across the optimization horizon (e
 cost, CO₂ emissions, primary energy). One effect is designated as the objective to
 minimize.
 
-Effects are split into three **domains** based on how they vary over time and
+Effects are split into two **domains** based on how they vary over time and
 how they are weighted in multi-period optimization:
 
 | Domain | Dims | What goes here | Multi-period weighting |
 |---|---|---|---|
-| **Temporal** | `(effect, time)` | Flow costs, running costs, startup costs — anything that varies per timestep | Summed over time (× \(w_t\)), then weighted like periodic |
-| **Periodic** | `(effect,)` | Recurring costs that repeat each period — sizing costs, fixed annual O&M | Weighted by \(\omega^{\text{periodic}}_{k,p}\) (defaults to global `period_weights`) |
-| **Once** | `(effect,)` | One-time costs at a point in time — CAPEX, decommissioning | Weighted by \(\omega^{\text{once}}_{k,p}\) (defaults to 1, no scaling) |
-
-The key distinction: **periodic** costs are assumed to recur across the gap between
-periods (e.g., annual O&M for 5 years), while **once** costs happen at a specific point
-(e.g., an investment decision in 2025). This matters because their period weights
-differ — recurring costs scale with duration, one-time costs typically don't
-(or use discount factors instead).
+| **Temporal** | `(effect, time)` | Flow costs, running costs, startup costs — anything that varies per timestep | Summed over time (× \(w_t\)), then weighted by `period_weights` |
+| **Lump** | `(effect,)` | Sizing costs, fixed O&M, one-time CAPEX — anything not per-timestep | Weighted by \(\omega_{k,p}\) (defaults to global `period_weights`) |
 
 All domains support cross-effect chains via `contribution_from`.
 
@@ -37,17 +30,17 @@ Each effect accumulates contributions from all flows at each timestep:
 The coefficient \(c_{f,k,t}\) specifies how much of effect \(k\) is produced per
 flow-hour of flow \(f\) (e.g., €/MWh for cost, kg/MWh for emissions).
 
-The cross-effect factor \(\alpha_{k,j,t}\) can be time-varying
-(`contribution_from_per_hour`) or constant (`contribution_from`).
+The cross-effect factor \(\alpha_{k,j,t}\) can be time-varying or constant
+(both via `contribution_from`).
 Because \(\Phi_{k,t}^{\text{temporal}}\) is a **variable**, the solver resolves
 multi-level chains (e.g., PE → CO₂ → cost) automatically.
 
-## Periodic Domain
+## Lump Domain
 
-Sizing costs and fixed costs (not time-varying) are accumulated per effect:
+Sizing costs, fixed costs, and one-time costs (not time-varying) are accumulated per effect:
 
 \[
-\Phi_k^{\text{periodic}} = \underbrace{\Phi_k^{\text{invest,direct}}}_{\text{direct sizing costs}} + \underbrace{\sum_{j \in \mathcal{K}} \alpha_{k,j} \cdot \Phi_j^{\text{periodic}}}_{\text{cross-effect contributions}} \quad \forall \, k
+\Phi_k^{\text{lump}} = \underbrace{\Phi_k^{\text{invest,direct}}}_{\text{direct sizing costs}} + \underbrace{\sum_{j \in \mathcal{K}} \alpha_{k,j} \cdot \Phi_j^{\text{lump}}}_{\text{cross-effect contributions}} \quad \forall \, k
 \]
 
 where the direct investment term is:
@@ -56,10 +49,10 @@ where the direct investment term is:
 \Phi_k^{\text{invest,direct}} = \sum_{f} \gamma_{f,k} \cdot S_f + \sum_{f} \phi_{f,k} \cdot y_f + \sum_{s} \gamma_{s,k} \cdot S_s + \sum_{s} \phi_{s,k} \cdot y_s
 \]
 
-Because \(\Phi_k^{\text{periodic}}\) is a **variable** (not an expression), the
+Because \(\Phi_k^{\text{lump}}\) is a **variable** (not an expression), the
 solver resolves multi-level chains correctly: if PE has sizing costs
 and CO₂ depends on PE and cost depends on CO₂, the chain propagates through the
-periodic domain just as it does through the temporal domain.
+lump domain just as it does through the temporal domain.
 
 ## Cross-Effect Contributions
 
@@ -68,30 +61,20 @@ An effect can include a weighted fraction of another effect's value via
 or transitive chains (PE → CO₂ → cost).
 
 The scalar factor \(\alpha_{k,j}\) from `contribution_from` applies to **both**
-domains. The time-varying factor from `contribution_from_per_hour` overrides the
-temporal factor only.
+domains. Time-varying values in `contribution_from` apply to the temporal domain only;
+the lump domain uses the scalar value.
 
 ### Validation
 
 Self-references (\(\alpha_{k,k}\)) and circular dependencies
 (\(k \to j \to \cdots \to k\)) are rejected at build time to prevent singular systems.
 
-## Once Domain
-
-One-time costs that should not be scaled by period weights (e.g., investment CAPEX,
-decommissioning costs). Currently constrained to zero — a placeholder for future
-investment modelling:
-
-\[
-\Phi_{k(,p)}^{\text{once}} = 0 \quad \forall \, k
-\]
-
 ## Total Aggregation
 
-The total effect combines all three domains:
+The total effect combines both domains:
 
 \[
-\Phi_{k(,p)} = \sum_{t \in \mathcal{T}} \Phi_{k,t(,p)}^{\text{temporal}} \cdot w_t + \Phi_{k(,p)}^{\text{periodic}} + \Phi_{k(,p)}^{\text{once}} \quad \forall \, k \in \mathcal{K}
+\Phi_{k(,p)} = \sum_{t \in \mathcal{T}} \Phi_{k,t(,p)}^{\text{temporal}} \cdot w_t + \Phi_{k(,p)}^{\text{lump}} \quad \forall \, k \in \mathcal{K}
 \]
 
 Weights \(w_t\) allow scaling timesteps (e.g., a representative week scaled to a year).
@@ -123,17 +106,16 @@ For example, `maximum_per_hour=100` (kg/h) with a 4-hour timestep allows up to
 | Symbol | Description | Reference |
 |---|---|---|
 | \(\Phi_{k,t(,p)}^{\text{temporal}}\) | Per-timestep effect variable | `effect_temporal[effect, time(, period)]` |
-| \(\Phi_{k(,p)}^{\text{periodic}}\) | Periodic effect variable (recurring costs) | `effect_periodic[effect(, period)]` |
-| \(\Phi_{k(,p)}^{\text{once}}\) | One-time effect variable | `effect_once[effect(, period)]` |
+| \(\Phi_{k(,p)}^{\text{lump}}\) | Lump effect variable (sizing + one-time costs) | `effect_lump[effect(, period)]` |
 | \(\Phi_{k(,p)}\) | Total effect variable | `effect_total[effect(, period)]` |
 | \(c_{f,k,t}\) | Effect coefficient per flow-hour | `Flow.effects_per_flow_hour` |
-| \(\alpha_{k,j,t}\) | Cross-effect contribution factor (per hour) | `Effect.contribution_from_per_hour` |
-| \(\alpha_{k,j}\) | Cross-effect contribution factor (scalar) | `Effect.contribution_from` |
+| \(\alpha_{k,j,t}\) | Cross-effect contribution factor (time-varying) | `Effect.contribution_from` (TimeSeries) |
+| \(\alpha_{k,j}\) | Cross-effect contribution factor (scalar) | `Effect.contribution_from` (scalar) |
 | \(P_{f,t}\) | Flow rate variable | `flow_rate[flow, time]` |
 | \(\Delta t_t\) | Timestep duration | dt |
 | \(w_t\) | Timestep weight | weights |
-| \(\bar{\Phi}_k\) | Maximum total | `Effect.maximum_total` |
-| \(\underline{\Phi}_k\) | Minimum total | `Effect.minimum_total` |
+| \(\bar{\Phi}_k\) | Maximum total | `Effect.maximum` |
+| \(\underline{\Phi}_k\) | Minimum total | `Effect.minimum` |
 | \(\bar{\Phi}_{k,t}\) | Maximum per hour | `Effect.maximum_per_hour` |
 | \(\underline{\Phi}_{k,t}\) | Minimum per hour | `Effect.minimum_per_hour` |
 
@@ -147,8 +129,8 @@ A system with two effects — cost (objective) and CO₂ (capped at 1000 kg):
 
 ```python
 effects = [
-    Effect("cost", unit="€", is_objective=True),
-    Effect("CO2", unit="kg", maximum_total=1000),
+    Effect("cost", unit="€"),
+    Effect("CO2", unit="kg", maximum=1000),
 ]
 ```
 
@@ -169,7 +151,7 @@ CO₂ priced at 50 €/t into the cost effect:
 
 ```python
 effects = [
-    Effect("cost", is_objective=True, contribution_from={"co2": 50}),
+    Effect("cost", contribution_from={"co2": 50}),
     Effect("co2", unit="kg"),
 ]
 ```

--- a/docs/math/effects.md
+++ b/docs/math/effects.md
@@ -60,9 +60,17 @@ An effect can include a weighted fraction of another effect's value via
 `contribution_from`. This enables patterns like carbon pricing (CO₂ → cost)
 or transitive chains (PE → CO₂ → cost).
 
-The scalar factor \(\alpha_{k,j}\) from `contribution_from` applies to **both**
-domains. Time-varying values in `contribution_from` apply to the temporal domain only;
-the lump domain uses the scalar value.
+The factor \(\alpha_{k,j}\) from `contribution_from` accepts either a scalar
+or a `TimeSeries`:
+
+- **Scalar**: applied identically to both temporal and lump domains.
+- **TimeSeries** (time-varying): applied per-timestep in the temporal domain;
+  for the lump domain the arithmetic mean over time is used
+  (`cf_temporal.mean('time')` in `model.py`). A `UserWarning` is emitted when
+  a time-varying factor is averaged for a non-trivial lump contribution.
+
+If you need different cross-effect factors for the two domains, split into
+separate effects.
 
 ### Validation
 
@@ -71,21 +79,36 @@ Self-references (\(\alpha_{k,k}\)) and circular dependencies
 
 ## Total Aggregation
 
-The total effect combines both domains:
+The total effect for each period \(p\) combines both domains:
 
 \[
-\Phi_{k(,p)} = \sum_{t \in \mathcal{T}} \Phi_{k,t(,p)}^{\text{temporal}} \cdot w_t + \Phi_{k(,p)}^{\text{lump}} \quad \forall \, k \in \mathcal{K}
+\Phi_{k,p} = \sum_{t \in \mathcal{T}} \Phi_{k,t,p}^{\text{temporal}} \cdot w_t + \Phi_{k,p}^{\text{lump}} \quad \forall \, k \in \mathcal{K}, \; p \in \mathcal{P}
 \]
 
 Weights \(w_t\) allow scaling timesteps (e.g., a representative week scaled to a year).
+Single-period models drop the \(p\) index.
 
-## Total Bounds
+## Bounds
 
-Upper and lower bounds on the total effect over the entire horizon:
+Three levels of bound granularity, all per-effect:
+
+**Per-hour bounds** (`maximum_per_hour` / `minimum_per_hour`) — see [Per-Hour Bounds](#per-hour-bounds) below.
+
+**Per-period bounds** (`maximum_per_period` / `minimum_per_period`) — each period independently:
 
 \[
-\underline{\Phi}_k \leq \Phi_k \leq \bar{\Phi}_k
+\underline{\Phi}_k^{\text{per period}} \leq \Phi_{k,p} \leq \bar{\Phi}_k^{\text{per period}} \quad \forall \, p
 \]
+
+**Aggregate bounds** (`maximum` / `minimum`) — weighted sum across all periods, where
+\(\omega_{k,p}\) is `Effect.period_weights` (falling back to global `period_weights`, then 1):
+
+\[
+\underline{\Phi}_k \leq \sum_{p \in \mathcal{P}} \omega_{k,p} \cdot \Phi_{k,p} \leq \bar{\Phi}_k
+\]
+
+For physical quantities (e.g., total CO₂ across all years), `period_weights` should
+typically encode the period duration so the aggregate is a true physical sum.
 
 This is useful for emission caps or budget constraints.
 

--- a/docs/math/notation.md
+++ b/docs/math/notation.md
@@ -22,8 +22,7 @@ Each symbol maps to a specific field or variable in the code.
 | \(P_{f,t(,p)}\) | `flow--rate[flow, time(, period)]` | \(\geq 0\) | MW | Flow rate |
 | \(E_{s,t(,p)}\) | `storage--level[storage, time(, period)]` | \(\geq 0\) | MWh | Stored energy |
 | \(\Phi_{k,t(,p)}^{\text{temporal}}\) | `effect--temporal[effect, time(, period)]` | \(\mathbb{R}\) | varies | Temporal (per-timestep) effect |
-| \(\Phi_{k(,p)}^{\text{periodic}}\) | `effect--periodic[effect(, period)]` | \(\mathbb{R}\) | varies | Periodic (recurring) effect |
-| \(\Phi_{k(,p)}^{\text{once}}\) | `effect--once[effect(, period)]` | \(\mathbb{R}\) | varies | One-time effect |
+| \(\Phi_{k(,p)}^{\text{lump}}\) | `effect--lump[effect(, period)]` | \(\mathbb{R}\) | varies | Lump (sizing + one-time) effect |
 | \(\Phi_{k(,p)}\) | `effect--total[effect(, period)]` | \(\mathbb{R}\) | varies | Total effect per period |
 | \(S_{f(,p)}\) | `flow--size[flow(, period)]` | \(\geq 0\) | MW | Flow capacity |
 | \(y_{f(,p)}\) | `flow--size_indicator[flow(, period)]` | \(\{0, 1\}\) | — | Binary invest indicator (flow) |
@@ -52,7 +51,7 @@ Each symbol maps to a specific field or variable in the code.
 | \(\bar{e}_s\) | `Storage.relative_maximum_level` | \([0, 1]\) | — | Relative max SOC |
 | \(a_{f}\) | `Converter.conversion_factors` | \(\mathbb{R}\) | — | Conversion coefficient |
 | \(\alpha_{k,j}\) | `Effect.contribution_from` | \(\mathbb{R}\) | varies | Cross-effect factor (scalar) |
-| \(\alpha_{k,j,t}\) | `Effect.contribution_from_per_hour` | \(\mathbb{R}\) | varies | Cross-effect factor (time-varying) |
+| \(\alpha_{k,j,t}\) | `Effect.contribution_from` (TimeSeries) | \(\mathbb{R}\) | varies | Cross-effect factor (time-varying) |
 | \(S^-\) | `Sizing.min_size` | \(\geq 0\) | MW or MWh | Minimum invested size (flow or storage) |
 | \(S^+\) | `Sizing.max_size` | \(\geq 0\) | MW or MWh | Maximum invested size (flow or storage) |
 | \(\gamma_{f,k}\) | `Sizing.effects_per_size` | \(\mathbb{R}\) | varies | Per-size investment cost |
@@ -66,8 +65,7 @@ Each symbol maps to a specific field or variable in the code.
 | \(w_t\) | weights | \(> 0\) | — | Timestep weight |
 | \(\Delta t_t\) | dt | \(> 0\) | h | Timestep duration |
 | \(\omega_p\) | `Dims.period_weights` | \(> 0\) | — | Global period weight (multi-period only) |
-| \(\omega^{\text{periodic}}_{k,p}\) | `Effect.period_weights_periodic` | \(> 0\) | — | Per-effect weight for recurring domain |
-| \(\omega^{\text{once}}_{k,p}\) | `Effect.period_weights_once` | \(> 0\) | — | Per-effect weight for one-time domain |
+| \(\omega_{k,p}\) | `Effect.period_weights` | \(> 0\) | — | Per-effect period weight |
 
 ## Naming Conventions
 

--- a/docs/math/notation.md
+++ b/docs/math/notation.md
@@ -51,11 +51,21 @@ Each symbol maps to a specific field or variable in the code.
 | \(\bar{e}_s\) | `Storage.relative_maximum_level` | \([0, 1]\) | — | Relative max SOC |
 | \(a_{f}\) | `Converter.conversion_factors` | \(\mathbb{R}\) | — | Conversion coefficient |
 | \(\alpha_{k,j}\) | `Effect.contribution_from` | \(\mathbb{R}\) | varies | Cross-effect factor (scalar) |
-| \(\alpha_{k,j,t}\) | `Effect.contribution_from` (TimeSeries) | \(\mathbb{R}\) | varies | Cross-effect factor (time-varying) |
+| \(\alpha_{k,j,t}\) | `Effect.contribution_from` (TimeSeries) | \(\mathbb{R}\) | varies | Cross-effect factor (time-varying; lump uses time-mean) |
+| \(\bar{\Phi}_k\) | `Effect.maximum` | \(\mathbb{R}\) | varies | Maximum aggregate (weighted sum across periods) |
+| \(\underline{\Phi}_k\) | `Effect.minimum` | \(\mathbb{R}\) | varies | Minimum aggregate (weighted sum across periods) |
+| \(\bar{\Phi}_k^{\text{per period}}\) | `Effect.maximum_per_period` | \(\mathbb{R}\) | varies | Maximum per period |
+| \(\underline{\Phi}_k^{\text{per period}}\) | `Effect.minimum_per_period` | \(\mathbb{R}\) | varies | Minimum per period |
+| \(\bar{\Phi}_{k,t}^{\text{per hour}}\) | `Effect.maximum_per_hour` | \(\mathbb{R}\) | varies/h | Maximum per hour (rate, scaled by \(\Delta t_t\)) |
+| \(\underline{\Phi}_{k,t}^{\text{per hour}}\) | `Effect.minimum_per_hour` | \(\mathbb{R}\) | varies/h | Minimum per hour (rate, scaled by \(\Delta t_t\)) |
 | \(S^-\) | `Sizing.min_size` | \(\geq 0\) | MW or MWh | Minimum invested size (flow or storage) |
 | \(S^+\) | `Sizing.max_size` | \(\geq 0\) | MW or MWh | Maximum invested size (flow or storage) |
-| \(\gamma_{f,k}\) | `Sizing.effects_per_size` | \(\mathbb{R}\) | varies | Per-size investment cost |
-| \(\phi_{f,k}\) | `Sizing.effects_fixed` | \(\mathbb{R}\) | varies | Fixed investment cost |
+| \(\gamma_{f,k}\) | `Sizing.effects_per_size` | \(\mathbb{R}\) | varies | Per-size investment cost (one-time, sized) |
+| \(\phi_{f,k}\) | `Sizing.effects_fixed` | \(\mathbb{R}\) | varies | Fixed investment cost (one-time, sized) |
+| \(\gamma^{\text{build}}_{f,k}\) | `Investment.effects_per_size_at_build` | \(\mathbb{R}\) | varies | Per-size CAPEX charged in the build period |
+| \(\phi^{\text{build}}_{f,k}\) | `Investment.effects_fixed_at_build` | \(\mathbb{R}\) | varies | Fixed CAPEX charged in the build period |
+| \(\gamma^{\text{rec}}_{f,k}\) | `Investment.effects_per_size_recurring` | \(\mathbb{R}\) | varies | Recurring per-size cost (each active period) |
+| \(\phi^{\text{rec}}_{f,k}\) | `Investment.effects_fixed_recurring` | \(\mathbb{R}\) | varies | Recurring fixed cost (each active period) |
 | \(D^{\text{up,min}}\) | `Status.min_uptime` | \(\geq 0\) | h | Minimum consecutive uptime |
 | \(D^{\text{up,max}}\) | `Status.max_uptime` | \(\geq 0\) | h | Maximum consecutive uptime |
 | \(D^{\text{down,min}}\) | `Status.min_downtime` | \(\geq 0\) | h | Minimum consecutive downtime |

--- a/docs/math/objective.md
+++ b/docs/math/objective.md
@@ -3,7 +3,7 @@
 ## Formulation
 
 The model minimizes the total value of the designated objective effect \(k^*\)
-(specified via `optimize(objective='cost')`).
+(specified via `optimize(objective_effects='cost')`).
 
 ### Single-period
 
@@ -55,7 +55,7 @@ full formulations of each term.
 
 | Symbol | Description | Reference |
 |---|---|---|
-| \(k^*\) | Objective effect | `optimize(objective='cost')` |
+| \(k^*\) | Objective effect | `optimize(objective_effects='cost')` |
 | \(c_{f,k,t}\) | Effect coefficient per flow-hour | `Flow.effects_per_flow_hour` |
 | \(P_{f,t}\) | Flow rate variable | `flow--rate[flow, time]` |
 | \(\Delta t_t\) | Timestep duration | dt |

--- a/docs/math/objective.md
+++ b/docs/math/objective.md
@@ -3,7 +3,7 @@
 ## Formulation
 
 The model minimizes the total value of the designated objective effect \(k^*\)
-(the one with `is_objective=True`).
+(specified via `optimize(objective='cost')`).
 
 ### Single-period
 
@@ -15,27 +15,24 @@ Without periods, the objective is simply:
 
 ### Multi-period
 
-With periods \(p \in \mathcal{P}\), the objective separates recurring and one-time
-domains with independent per-effect weights:
+With periods \(p \in \mathcal{P}\), the objective weights each period's total effect:
 
 \[
-\min \; \sum_{p \in \mathcal{P}} \omega^{\text{periodic}}_{k^*,p} \cdot \left(\sum_t \Phi_{k^*,t,p}^{\text{temporal}} \cdot w_t + \Phi_{k^*,p}^{\text{periodic}}\right) + \omega^{\text{once}}_{k^*,p} \cdot \Phi_{k^*,p}^{\text{once}}
+\min \; \sum_{p \in \mathcal{P}} \omega_{k^*,p} \cdot \left(\sum_t \Phi_{k^*,t,p}^{\text{temporal}} \cdot w_t + \Phi_{k^*,p}^{\text{lump}}\right)
 \]
 
-- \(\omega^{\text{periodic}}_{k,p}\) defaults to the global `period_weights` (inferred from
-  gaps between period labels, or explicit). Override per effect via `Effect.period_weights_periodic`.
-- \(\omega^{\text{once}}_{k,p}\) defaults to 1 (no scaling). Override per effect via
-  `Effect.period_weights_once`.
+- \(\omega_{k,p}\) defaults to the global `period_weights` (inferred from
+  gaps between period labels, or explicit). Override per effect via `Effect.period_weights`.
 
 This allows different weighting strategies per effect (e.g., NPV discounting for costs,
 flat weights for emissions).
 
 ### Total effect
 
-The total effect per period combines all three domains:
+The total effect per period combines both domains:
 
 \[
-\Phi_{k(,p)} = \sum_{t \in \mathcal{T}} \Phi_{k,t(,p)}^{\text{temporal}} \cdot w_t + \Phi_{k(,p)}^{\text{periodic}} + \Phi_{k(,p)}^{\text{once}}
+\Phi_{k(,p)} = \sum_{t \in \mathcal{T}} \Phi_{k,t(,p)}^{\text{temporal}} \cdot w_t + \Phi_{k(,p)}^{\text{lump}}
 \]
 
 The **temporal** domain accumulates flow contributions, running costs,
@@ -45,14 +42,11 @@ startup costs, and cross-effect contributions per timestep:
 \Phi_{k,t}^{\text{temporal}} = \underbrace{\sum_{f} c_{f,k,t} \cdot P_{f,t} \cdot \Delta t_t}_{\text{flow}} + \underbrace{\sum_{f} r_{f,k,t} \cdot \sigma_{f,t} \cdot \Delta t_t}_{\text{running}} + \underbrace{\sum_{f} u_{f,k,t} \cdot \tau^+_{f,t}}_{\text{startup}} + \underbrace{\sum_{j} \alpha_{k,j,t} \cdot \Phi_{j,t}^{\text{temporal}}}_{\text{cross-effect}}
 \]
 
-The **periodic** domain accumulates recurring sizing costs, fixed costs, and cross-effect contributions:
+The **lump** domain accumulates sizing costs, fixed costs, one-time costs, and cross-effect contributions:
 
 \[
-\Phi_k^{\text{periodic}} = \underbrace{\sum_{f} \gamma_{f,k} \cdot S_f + \sum_{f} \phi_{f,k} \cdot y_f + \sum_{s} \gamma_{s,k} \cdot S_s + \sum_{s} \phi_{s,k} \cdot y_s}_{\text{direct sizing costs}} + \underbrace{\sum_{j} \alpha_{k,j} \cdot \Phi_j^{\text{periodic}}}_{\text{cross-effect}}
+\Phi_k^{\text{lump}} = \underbrace{\sum_{f} \gamma_{f,k} \cdot S_f + \sum_{f} \phi_{f,k} \cdot y_f + \sum_{s} \gamma_{s,k} \cdot S_s + \sum_{s} \phi_{s,k} \cdot y_s}_{\text{direct sizing costs}} + \underbrace{\sum_{j} \alpha_{k,j} \cdot \Phi_j^{\text{lump}}}_{\text{cross-effect}}
 \]
-
-The **once** domain is reserved for one-time costs (e.g., investment CAPEX)
-that should not be scaled by period weights. Currently constrained to zero.
 
 See [Sizing](sizing.md), [Status](status.md), and [Effects](effects.md) for
 full formulations of each term.
@@ -61,16 +55,14 @@ full formulations of each term.
 
 | Symbol | Description | Reference |
 |---|---|---|
-| \(k^*\) | Objective effect | `Effect.is_objective = True` |
+| \(k^*\) | Objective effect | `optimize(objective='cost')` |
 | \(c_{f,k,t}\) | Effect coefficient per flow-hour | `Flow.effects_per_flow_hour` |
 | \(P_{f,t}\) | Flow rate variable | `flow--rate[flow, time]` |
 | \(\Delta t_t\) | Timestep duration | dt |
 | \(w_t\) | Timestep weight | weights |
-| \(\omega^{\text{periodic}}_{k,p}\) | Period weight for recurring domain | `Effect.period_weights_periodic` (fallback: `Dims.period_weights`) |
-| \(\omega^{\text{once}}_{k,p}\) | Period weight for one-time domain | `Effect.period_weights_once` (default: 1) |
+| \(\omega_{k,p}\) | Period weight | `Effect.period_weights` (fallback: `Dims.period_weights`) |
 | \(\Phi_{k,t(,p)}^{\text{temporal}}\) | Temporal (per-timestep) effect variable | `effect--temporal[effect, time(, period)]` |
-| \(\Phi_{k(,p)}^{\text{periodic}}\) | Periodic effect variable (recurring costs) | `effect--periodic[effect(, period)]` |
-| \(\Phi_{k(,p)}^{\text{once}}\) | One-time effect variable | `effect--once[effect(, period)]` |
+| \(\Phi_{k(,p)}^{\text{lump}}\) | Lump effect variable (sizing + one-time costs) | `effect--lump[effect(, period)]` |
 | \(\Phi_{k(,p)}\) | Total effect variable | `effect--total[effect(, period)]` |
 
 See [Notation](notation.md) for the full symbol table.

--- a/docs/notebooks/01-quickstart.ipynb
+++ b/docs/notebooks/01-quickstart.ipynb
@@ -78,6 +78,7 @@
     "            thermal_flow=Flow('heat', size=100),\n",
     "        ),\n",
     "    ],\n",
+    "    objective_effects='cost',\n",
     ")"
    ]
   },

--- a/docs/notebooks/01-quickstart.ipynb
+++ b/docs/notebooks/01-quickstart.ipynb
@@ -55,7 +55,7 @@
     "result = optimize(\n",
     "    timesteps=timesteps,\n",
     "    carriers=[Carrier('gas'), Carrier('heat')],\n",
-    "    effects=[Effect('cost', unit='EUR', is_objective=True)],\n",
+    "    effects=[Effect('cost', unit='EUR')],\n",
     "    ports=[\n",
     "        Port(\n",
     "            'gas_grid',\n",

--- a/docs/notebooks/02-heat-system.ipynb
+++ b/docs/notebooks/02-heat-system.ipynb
@@ -92,7 +92,7 @@
     "result = optimize(\n",
     "    timesteps=timesteps,\n",
     "    carriers=[Carrier('gas'), Carrier('heat')],\n",
-    "    effects=[Effect('cost', unit='EUR', is_objective=True)],\n",
+    "    effects=[Effect('cost', unit='EUR')],\n",
     "    ports=[\n",
     "        Port(\n",
     "            'gas_grid',\n",

--- a/docs/notebooks/02-heat-system.ipynb
+++ b/docs/notebooks/02-heat-system.ipynb
@@ -127,6 +127,7 @@
     "            cyclic=True,\n",
     "        )\n",
     "    ],\n",
+    "    objective_effects='cost',\n",
     ")"
    ]
   },

--- a/docs/notebooks/03-multi-node-heat.ipynb
+++ b/docs/notebooks/03-multi-node-heat.ipynb
@@ -107,6 +107,7 @@
     "        ),\n",
     "        Converter.boiler('backup_boiler', 0.85, Flow('oil', size=200), Flow('heat', node='B', size=100)),\n",
     "    ],\n",
+    "    objective_effects='cost',\n",
     ")\n",
     "\n",
     "print(f'Total cost: {result.objective:.2f} EUR  |  Avg: {result.objective / sum(demand) * 100:.2f} ct/kWh')"

--- a/docs/notebooks/03-multi-node-heat.ipynb
+++ b/docs/notebooks/03-multi-node-heat.ipynb
@@ -88,7 +88,7 @@
     "result = optimize(\n",
     "    timesteps=timesteps,\n",
     "    carriers=[Carrier('gas'), Carrier('oil'), Carrier('heat', nodes=['A', 'B'])],\n",
-    "    effects=[Effect('cost', unit='EUR', is_objective=True)],\n",
+    "    effects=[Effect('cost', unit='EUR')],\n",
     "    ports=[\n",
     "        Port('gas_grid', imports=[Flow('gas', size=200, effects_per_flow_hour={'cost': 0.05})]),\n",
     "        Port('oil_supply', imports=[Flow('oil', size=200, effects_per_flow_hour={'cost': 0.12})]),\n",

--- a/docs/notebooks/04-multi-period.ipynb
+++ b/docs/notebooks/04-multi-period.ipynb
@@ -122,6 +122,7 @@
     "            )\n",
     "        ],\n",
     "        'periods': periods,\n",
+    "        'objective_effects': 'cost',\n",
     "    }\n",
     "\n",
     "\n",

--- a/docs/notebooks/04-multi-period.ipynb
+++ b/docs/notebooks/04-multi-period.ipynb
@@ -22,8 +22,8 @@
     "| **NPV** | `[4.55, 3.56, 2.79]` (discounted) | Present-value costing |\n",
     "| **Custom** | any `list[float]` | Scenario-specific |\n",
     "\n",
-    "This notebook shows how to use `period_weights_periodic` on an `Effect`\n",
-    "to apply NPV discounting to costs while keeping CO₂ on flat weights."
+    "This notebook shows how to use `period_weights` on an `Effect`\n",
+    "to apply NPV discounting to costs while keeping CO2 on flat weights."
    ]
   },
   {
@@ -96,7 +96,7 @@
     "        'timesteps': timesteps,\n",
     "        'carriers': [Carrier('gas'), Carrier('heat')],\n",
     "        'effects': [\n",
-    "            Effect('cost', unit='EUR', is_objective=True, **effect_kw),\n",
+    "            Effect('cost', unit='EUR', **effect_kw),\n",
     "            Effect('CO2', unit='kg'),\n",
     "        ],\n",
     "        'ports': [\n",
@@ -156,7 +156,7 @@
     "## NPV weights\n",
     "\n",
     "Future costs are worth less today. To discount them, compute your own\n",
-    "weight factors and pass them via `Effect.period_weights_periodic`.\n",
+    "weight factors and pass them via `Effect.period_weights`.\n",
     "\n",
     "With a 5% discount rate and 5-year periods:"
    ]
@@ -200,7 +200,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result_npv = optimize(**build_system(period_weights_periodic=npv_weights))"
+    "result_npv = optimize(**build_system(period_weights=npv_weights))"
    ]
   },
   {
@@ -261,16 +261,15 @@
     "The objective function weights each period's total effect:\n",
     "\n",
     "$$\n",
-    "\\min \\sum_p \\omega^{\\text{periodic}}_{k^*,p} \\cdot \\Phi_{k^*,p}\n",
+    "\\min \\sum_p \\omega_{k^*,p} \\cdot \\Phi_{k^*,p}\n",
     "$$\n",
     "\n",
-    "where $\\Phi_{k,p}$ combines temporal (dispatch) and periodic (sizing) costs.\n",
+    "where $\\Phi_{k,p}$ combines temporal (dispatch) and lump (sizing) costs.\n",
     "\n",
     "| Parameter | Default | Override | Purpose |\n",
     "|---|---|---|---|\n",
     "| `period_weights` | Inferred from gaps | `optimize(period_weights=...)` | Global weights for all effects |\n",
-    "| `period_weights_periodic` | Global weights | `Effect(period_weights_periodic=...)` | Per-effect override (e.g. NPV on cost only) |\n",
-    "| `period_weights_once` | `1` (no scaling) | `Effect(period_weights_once=...)` | One-time cost weighting |\n",
+    "| `period_weights` | Global weights | `Effect(period_weights=...)` | Per-effect override (e.g. NPV on cost only) |\n",
     "\n",
     "The library provides the weight slots — **you** decide the factors.\n",
     "Flat, NPV, annuity, or any custom scheme."

--- a/docs/notebooks/05-investment.ipynb
+++ b/docs/notebooks/05-investment.ipynb
@@ -224,7 +224,7 @@
     "        Carrier('ambient'),\n",
     "    ],\n",
     "    effects=[\n",
-    "        Effect('cost', unit='EUR', is_objective=True, period_weights_periodic=npv_weights),\n",
+    "        Effect('cost', unit='EUR', period_weights=npv_weights),\n",
     "    ],\n",
     "    ports=[\n",
     "        Port(\n",
@@ -275,7 +275,7 @@
     "                    15,\n",
     "                    mandatory=False,\n",
     "                    lifetime=2,\n",
-    "                    effects_per_size={'cost': 20_000},\n",
+    "                    effects_per_size_at_build={'cost': 20_000},\n",
     "                ),\n",
     "            ),\n",
     "        ),\n",
@@ -291,7 +291,7 @@
     "                    15,\n",
     "                    mandatory=False,\n",
     "                    lifetime=3,\n",
-    "                    effects_per_size={'cost': 200_000},\n",
+    "                    effects_per_size_at_build={'cost': 200_000},\n",
     "                ),\n",
     "            ),\n",
     "        ),\n",
@@ -518,9 +518,9 @@
     "**Key API patterns:**\n",
     "- `Investment(prior_size=...)` -- pre-existing capacity with limited lifetime\n",
     "- `Investment(lifetime=...)` -- solver decides build period; capacity expires\n",
-    "- `effects_per_size` -- one-time CAPEX charged in the build period\n",
+    "- `effects_per_size_at_build` -- one-time CAPEX charged in the build period\n",
     "- `effects_per_flow_hour` with `xr.DataArray(period=...)` -- period-varying prices\n",
-    "- NPV `period_weights_periodic` on `Effect` -- discount future costs"
+    "- NPV `period_weights` on `Effect` -- discount future costs"
    ]
   }
  ],

--- a/docs/notebooks/05-investment.ipynb
+++ b/docs/notebooks/05-investment.ipynb
@@ -299,6 +299,7 @@
     "    periods=periods,\n",
     "    period_weights=npv_weights,\n",
     "    dt=dt,\n",
+    "    objective_effects='cost',\n",
     ")"
    ]
   },

--- a/src/fluxopt/__init__.py
+++ b/src/fluxopt/__init__.py
@@ -25,6 +25,7 @@ def optimize(
     dt: float | list[float] | None = None,
     periods: list[int] | None = None,
     period_weights: list[float] | None = None,
+    objective: str | list[str] = 'cost',
     solver: str = 'highs',
     customize: Callable[[FlowSystem], None] | None = None,
     **kwargs: Any,
@@ -41,6 +42,7 @@ def optimize(
         dt: Timestep duration in hours. Auto-derived if None.
         periods: Integer period labels for multi-period optimization.
         period_weights: Explicit weights per period. Inferred from gaps if None.
+        objective: Effect name(s) to minimize. Sum of named effect totals.
         solver: Solver backend name.
         customize: Optional callback to modify the linopy model between build and solve.
             Receives the built FlowSystem; use ``model.m`` to add variables/constraints.
@@ -58,7 +60,7 @@ def optimize(
         period_weights=period_weights,
     )
     model = FlowSystem(data)
-    return model.optimize(customize=customize, solver=solver, **kwargs)
+    return model.optimize(objective=objective, customize=customize, solver=solver, **kwargs)
 
 
 __all__ = [

--- a/src/fluxopt/__init__.py
+++ b/src/fluxopt/__init__.py
@@ -20,12 +20,12 @@ def optimize(
     carriers: list[Carrier],
     effects: list[Effect],
     ports: list[Port],
+    objective_effects: str | list[str],
     converters: list[Converter] | None = None,
     storages: list[Storage] | None = None,
     dt: float | list[float] | None = None,
     periods: list[int] | None = None,
     period_weights: list[float] | None = None,
-    objective: str | list[str] = 'cost',
     solver: str = 'highs',
     customize: Callable[[FlowSystem], None] | None = None,
     **kwargs: Any,
@@ -37,12 +37,12 @@ def optimize(
         carriers: Carrier declarations.
         effects: Effects to track (costs, emissions, etc.).
         ports: System boundary ports with imports/exports.
+        objective_effects: Effect name(s) to minimize. Sum of named effect totals.
         converters: Linear converters between carriers.
         storages: Energy storages.
         dt: Timestep duration in hours. Auto-derived if None.
         periods: Integer period labels for multi-period optimization.
         period_weights: Explicit weights per period. Inferred from gaps if None.
-        objective: Effect name(s) to minimize. Sum of named effect totals.
         solver: Solver backend name.
         customize: Optional callback to modify the linopy model between build and solve.
             Receives the built FlowSystem; use ``model.m`` to add variables/constraints.
@@ -60,7 +60,7 @@ def optimize(
         period_weights=period_weights,
     )
     model = FlowSystem(data)
-    return model.optimize(objective=objective, customize=customize, solver=solver, **kwargs)
+    return model.optimize(objective_effects=objective_effects, customize=customize, solver=solver, **kwargs)
 
 
 __all__ = [

--- a/src/fluxopt/contributions.py
+++ b/src/fluxopt/contributions.py
@@ -127,7 +127,7 @@ def compute_effect_contributions(solution: xr.Dataset, data: ModelData) -> xr.Da
         - ``total`` (contributor, effect) — temporal summed over time + periodic
     """
     flow_ids: list[str] = list(data.flows.effect_coeff.coords['flow'].values)
-    effect_ids: list[str] = list(data.effects.min_total.coords['effect'].values)
+    effect_ids: list[str] = list(data.effects.min_bound.coords['effect'].values)
     stor_ids: list[str] = list(data.storages.capacity.coords['storage'].values) if data.storages is not None else []
     all_ids = flow_ids + stor_ids
 

--- a/src/fluxopt/contributions.py
+++ b/src/fluxopt/contributions.py
@@ -123,8 +123,8 @@ def compute_effect_contributions(solution: xr.Dataset, data: ModelData) -> xr.Da
     Returns:
         Dataset with:
         - ``temporal`` (contributor, effect, time) — per-timestep contributions
-        - ``periodic`` (contributor, effect) — periodic contributions (flows + storages)
-        - ``total`` (contributor, effect) — temporal summed over time + periodic
+        - ``lump`` (contributor, effect) — lump contributions (flows + storages)
+        - ``total`` (contributor, effect) — temporal summed over time + lump
     """
     flow_ids: list[str] = list(data.flows.effect_coeff.coords['flow'].values)
     effect_ids: list[str] = list(data.effects.min_bound.coords['effect'].values)
@@ -154,8 +154,8 @@ def compute_effect_contributions(solution: xr.Dataset, data: ModelData) -> xr.Da
     # Rename to contributor dim
     temporal = temporal_flow.rename({'flow': 'contributor'})
 
-    # --- Periodic: flow costs ---
-    flow_periodic = _compute_periodic(
+    # --- Lump: flow costs ---
+    flow_lump = _compute_periodic(
         data.flows.sizing_effects_per_size,
         data.flows.sizing_effects_fixed,
         data.flows.sizing_mandatory,
@@ -168,9 +168,9 @@ def compute_effect_contributions(solution: xr.Dataset, data: ModelData) -> xr.Da
         'flow--size_indicator',
     )
 
-    # --- Periodic: storage costs ---
+    # --- Lump: storage costs ---
     if stor_ids:
-        stor_periodic = _compute_periodic(
+        stor_lump = _compute_periodic(
             data.storages.sizing_effects_per_size,  # type: ignore[union-attr]
             data.storages.sizing_effects_fixed,  # type: ignore[union-attr]
             data.storages.sizing_mandatory,  # type: ignore[union-attr]
@@ -182,16 +182,16 @@ def compute_effect_contributions(solution: xr.Dataset, data: ModelData) -> xr.Da
             'storage--capacity',
             'storage--size_indicator',
         )
-        periodic = xr.concat([flow_periodic, stor_periodic], dim='contributor')
+        lump = xr.concat([flow_lump, stor_lump], dim='contributor')
     else:
-        periodic = flow_periodic
+        lump = flow_lump
 
-    # Cross-effects on periodic via Leontief inverse
+    # Cross-effects on lump via Leontief inverse
     if data.effects.cf_periodic is not None:
-        periodic = _apply_leontief(_leontief(data.effects.cf_periodic), periodic)
+        lump = _apply_leontief(_leontief(data.effects.cf_periodic), lump)
 
-    # --- Total: temporal (weighted sum over time) + periodic ---
-    total = (temporal * data.dims.weights).sum('time').reindex(contributor=all_ids, fill_value=0.0) + periodic.reindex(
+    # --- Total: temporal (weighted sum over time) + lump ---
+    total = (temporal * data.dims.weights).sum('time').reindex(contributor=all_ids, fill_value=0.0) + lump.reindex(
         contributor=all_ids, fill_value=0.0
     )
 
@@ -204,4 +204,4 @@ def compute_effect_contributions(solution: xr.Dataset, data: ModelData) -> xr.Da
             f'Effect contributions do not sum to solver totals. Max deviation: {float(diff.max().values):.6g}'
         )
 
-    return xr.Dataset({'temporal': temporal, 'periodic': periodic, 'total': total})
+    return xr.Dataset({'temporal': temporal, 'lump': lump, 'total': total})

--- a/src/fluxopt/contributions.py
+++ b/src/fluxopt/contributions.py
@@ -186,9 +186,10 @@ def compute_effect_contributions(solution: xr.Dataset, data: ModelData) -> xr.Da
     else:
         lump = flow_lump
 
-    # Cross-effects on lump via Leontief inverse
-    if data.effects.cf_periodic is not None:
-        lump = _apply_leontief(_leontief(data.effects.cf_periodic), lump)
+    # Cross-effects on lump via Leontief inverse (using mean of temporal cross-effect)
+    if data.effects.cf_temporal is not None:
+        cf_lump = data.effects.cf_temporal.mean('time')
+        lump = _apply_leontief(_leontief(cf_lump), lump)
 
     # --- Total: temporal (weighted sum over time) + lump ---
     total = (temporal * data.dims.weights).sum('time').reindex(contributor=all_ids, fill_value=0.0) + lump.reindex(

--- a/src/fluxopt/elements.py
+++ b/src/fluxopt/elements.py
@@ -161,7 +161,6 @@ class Effect:
     maximum_per_hour: TimeSeries | None = None  # Φ̄_{k,t}  [unit/h] — rate, scaled by dt
     minimum_per_hour: TimeSeries | None = None  # Φ̲_{k,t}  [unit/h] — rate, scaled by dt
     contribution_from: dict[str, TimeSeries] = field(default_factory=dict)
-    contribution_from_per_hour: dict[str, TimeSeries] = field(default_factory=dict)
     period_weights_periodic: list[float] | None = None  # ω_periodic[p] — scales temporal+periodic
     period_weights_once: list[float] | None = None  # ω_once[p] — scales once
 

--- a/src/fluxopt/elements.py
+++ b/src/fluxopt/elements.py
@@ -73,10 +73,10 @@ class Investment:
         mandatory: If True, must build exactly once; if False, may build at most once.
         lifetime: Periods active after build; None = forever.
         prior_size: Pre-existing capacity available from period 0.
-        effects_per_size: One-time per-MW costs charged in the build period.
-        effects_fixed: One-time fixed costs charged in the build period.
-        effects_per_size_periodic: Recurring per-MW costs charged every active period.
-        effects_fixed_periodic: Recurring fixed costs charged every active period.
+        effects_per_size_at_build: One-time per-MW costs charged in the build period.
+        effects_fixed_at_build: One-time fixed costs charged in the build period.
+        effects_per_size_recurring: Recurring per-MW costs charged every active period.
+        effects_fixed_recurring: Recurring fixed costs charged every active period.
     """
 
     min_size: float
@@ -84,10 +84,10 @@ class Investment:
     mandatory: bool = True
     lifetime: int | None = None
     prior_size: float = 0.0
-    effects_per_size: dict[str, TimeSeries] = field(default_factory=dict)
-    effects_fixed: dict[str, TimeSeries] = field(default_factory=dict)
-    effects_per_size_periodic: dict[str, TimeSeries] = field(default_factory=dict)
-    effects_fixed_periodic: dict[str, TimeSeries] = field(default_factory=dict)
+    effects_per_size_at_build: dict[str, TimeSeries] = field(default_factory=dict)
+    effects_fixed_at_build: dict[str, TimeSeries] = field(default_factory=dict)
+    effects_per_size_recurring: dict[str, TimeSeries] = field(default_factory=dict)
+    effects_fixed_recurring: dict[str, TimeSeries] = field(default_factory=dict)
 
 
 @dataclass

--- a/src/fluxopt/elements.py
+++ b/src/fluxopt/elements.py
@@ -154,10 +154,12 @@ class Effect:
     id: str
     unit: str = ''
     is_objective: bool = False
-    maximum_total: float | None = None  # Φ̄_k  [unit]
-    minimum_total: float | None = None  # Φ̲_k  [unit]
-    maximum_per_hour: TimeSeries | None = None  # Φ̄_{k,t}  [unit]
-    minimum_per_hour: TimeSeries | None = None  # Φ̲_{k,t}  [unit]
+    maximum: float | None = None  # Φ̄_k  [unit] — weighted total across all periods
+    minimum: float | None = None  # Φ̲_k  [unit] — weighted total across all periods
+    maximum_per_period: float | None = None  # Φ̄_{k,p}  [unit] — each period independently
+    minimum_per_period: float | None = None  # Φ̲_{k,p}  [unit] — each period independently
+    maximum_per_hour: TimeSeries | None = None  # Φ̄_{k,t}  [unit/h] — rate, scaled by dt
+    minimum_per_hour: TimeSeries | None = None  # Φ̲_{k,t}  [unit/h] — rate, scaled by dt
     contribution_from: dict[str, TimeSeries] = field(default_factory=dict)
     contribution_from_per_hour: dict[str, TimeSeries] = field(default_factory=dict)
     period_weights_periodic: list[float] | None = None  # ω_periodic[p] — scales temporal+periodic

--- a/src/fluxopt/elements.py
+++ b/src/fluxopt/elements.py
@@ -161,8 +161,7 @@ class Effect:
     maximum_per_hour: TimeSeries | None = None  # Φ̄_{k,t}  [unit/h] — rate, scaled by dt
     minimum_per_hour: TimeSeries | None = None  # Φ̲_{k,t}  [unit/h] — rate, scaled by dt
     contribution_from: dict[str, TimeSeries] = field(default_factory=dict)
-    period_weights_periodic: list[float] | None = None  # ω_periodic[p] — scales temporal+periodic
-    period_weights_once: list[float] | None = None  # ω_once[p] — scales once
+    period_weights: list[float] | None = None  # ω[p] — scales total across periods
 
 
 @dataclass

--- a/src/fluxopt/elements.py
+++ b/src/fluxopt/elements.py
@@ -153,7 +153,6 @@ class Flow:
 class Effect:
     id: str
     unit: str = ''
-    is_objective: bool = False
     maximum: float | None = None  # Φ̄_k  [unit] — weighted total across all periods
     minimum: float | None = None  # Φ̲_k  [unit] — weighted total across all periods
     maximum_per_period: float | None = None  # Φ̄_{k,p}  [unit] — each period independently

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -35,8 +35,7 @@ class FlowSystem:
     storage_level: Variable | None = None
     prior_storage_level: Variable | None = None
 
-    # Effect variables — set during build
-    effect_once: Variable | None = None
+    # Effect variables — set during build (no class-level defaults needed for temporal/lump/total)
 
     # Status variables — None when no status is configured
     flow_on: Variable | None = None
@@ -726,7 +725,7 @@ class FlowSystem:
         self.m.add_constraints(lhs == 0, name='conversion', mask=mask_3d)
 
     def _create_effects(self) -> None:
-        """Effect tracking: temporal, periodic, and one-time domains."""
+        """Effect tracking: temporal and lump domains."""
         d = self.data
         ds = d.effects
 
@@ -785,12 +784,13 @@ class FlowSystem:
         if has_max_ph.any():
             self.m.add_constraints(self.effect_temporal <= max_ph, name='effect_max_ph', mask=has_max_ph)
 
-        # --- Periodic domain: effect_periodic[effect(, period)] ---
+        # --- Lump domain: effect_lump[effect(, period)] ---
+        # Combines all non-temporal contributions (sizing, investment recurring, investment at-build)
         pc = self.data.dims.coords(period=True)
-        self.effect_periodic = self.m.add_variables(coords={'effect': effect_ids, **pc}, name='effect--periodic')
+        self.effect_lump = self.m.add_variables(coords={'effect': effect_ids, **pc}, name='effect--lump')
 
-        # Accumulate direct investment contributions per effect
-        periodic_direct: Any = 0
+        # Accumulate direct lump contributions per effect
+        lump_direct: Any = 0
 
         # Flow sizing: per-size costs (Sizing only, not Investment)
         if d.flows.sizing_effects_per_size is not None:
@@ -798,7 +798,7 @@ class FlowSystem:
             eps = d.flows.sizing_effects_per_size.rename({'sizing_flow': 'flow'})
             if (eps != 0).any():
                 assert self.flow_size is not None
-                periodic_direct = periodic_direct + (eps * self.flow_size.sel(flow=sizing_ids)).sum('flow')
+                lump_direct = lump_direct + (eps * self.flow_size.sel(flow=sizing_ids)).sum('flow')
 
         # Flow sizing: fixed costs — optional (binary * cost), mandatory (constant)
         if self.flow_size_indicator is not None:
@@ -806,7 +806,7 @@ class FlowSystem:
             opt_ids = list(self.flow_size_indicator.coords['flow'].values)
             ef = d.flows.sizing_effects_fixed.rename({'sizing_flow': 'flow'}).sel(flow=opt_ids)
             if (ef != 0).any():
-                periodic_direct = periodic_direct + (ef * self.flow_size_indicator).sum('flow')
+                lump_direct = lump_direct + (ef * self.flow_size_indicator).sum('flow')
         if (
             self.flow_size is not None
             and d.flows.sizing_effects_fixed is not None
@@ -817,7 +817,7 @@ class FlowSystem:
                 mand_ids = list(d.flows.sizing_mandatory.coords['sizing_flow'].values[mand_mask])
                 ef_mand = d.flows.sizing_effects_fixed.sel(sizing_flow=mand_ids)
                 if (ef_mand != 0).any():
-                    periodic_direct = periodic_direct + ef_mand.sum('sizing_flow')
+                    lump_direct = lump_direct + ef_mand.sum('sizing_flow')
 
         # Storage sizing: per-size costs
         if (
@@ -827,7 +827,7 @@ class FlowSystem:
         ):
             eps = d.storages.sizing_effects_per_size.rename({'sizing_storage': 'storage'})
             if (eps != 0).any():
-                periodic_direct = periodic_direct + (eps * self.storage_capacity).sum('storage')
+                lump_direct = lump_direct + (eps * self.storage_capacity).sum('storage')
 
         # Storage sizing: fixed costs — optional (binary * cost), mandatory (constant)
         if (
@@ -838,7 +838,7 @@ class FlowSystem:
             opt_ids = list(self.storage_capacity_indicator.coords['storage'].values)
             ef = d.storages.sizing_effects_fixed.rename({'sizing_storage': 'storage'}).sel(storage=opt_ids)
             if (ef != 0).any():
-                periodic_direct = periodic_direct + (ef * self.storage_capacity_indicator).sum('storage')
+                lump_direct = lump_direct + (ef * self.storage_capacity_indicator).sum('storage')
         if (
             self.storage_capacity is not None
             and d.storages is not None
@@ -850,54 +850,47 @@ class FlowSystem:
                 mand_ids = list(d.storages.sizing_mandatory.coords['sizing_storage'].values[mand_mask])
                 ef_mand = d.storages.sizing_effects_fixed.sel(sizing_storage=mand_ids)
                 if (ef_mand != 0).any():
-                    periodic_direct = periodic_direct + ef_mand.sum('sizing_storage')
+                    lump_direct = lump_direct + ef_mand.sum('sizing_storage')
 
-        # Investment: recurring per-size costs → effect_periodic
+        # Investment: recurring per-size costs
         if self.invest_active is not None and d.flows.invest_effects_per_size_recurring is not None:
             eps_p = d.flows.invest_effects_per_size_recurring.rename({'invest_flow': 'flow'})
             if (eps_p != 0).any():
                 assert self.flow_size is not None
                 invest_ids = list(d.flows.invest_effects_per_size_recurring.coords['invest_flow'].values)
-                periodic_direct = periodic_direct + (eps_p * self.flow_size.sel(flow=invest_ids)).sum('flow')
+                lump_direct = lump_direct + (eps_p * self.flow_size.sel(flow=invest_ids)).sum('flow')
 
-        # Investment: recurring fixed costs → effect_periodic
+        # Investment: recurring fixed costs
         if self.invest_active is not None and d.flows.invest_effects_fixed_recurring is not None:
             ef_p = d.flows.invest_effects_fixed_recurring.rename({'invest_flow': 'flow'})
             if (ef_p != 0).any():
-                periodic_direct = periodic_direct + (ef_p * self.invest_active).sum('flow')
+                lump_direct = lump_direct + (ef_p * self.invest_active).sum('flow')
 
-        # Cross-effect periodic: cf_periodic[k,j] * effect_periodic[j]
-        periodic_rhs: Any = periodic_direct
-        if ds.cf_periodic is not None:
-            source_p = self.effect_periodic.rename({'effect': 'source_effect'})
-            cross = (ds.cf_periodic * source_p).sum('source_effect')
-            periodic_rhs = cross + periodic_direct  # linopy expr must be left operand
-
-        self.m.add_constraints(self.effect_periodic == periodic_rhs, name='effect_periodic_eq')
-
-        # --- One-time domain: effect_once[effect(, period)] ---
-        self.effect_once = self.m.add_variables(coords={'effect': effect_ids, **pc}, name='effect--once')
-
-        once_direct: Any = 0
-
-        # Investment: one-time per-size costs (charged in build period)
+        # Investment: at-build per-size costs (charged in build period)
         if self.invest_size_at_build is not None and d.flows.invest_effects_per_size_at_build is not None:
             eps_once = d.flows.invest_effects_per_size_at_build.rename({'invest_flow': 'flow'})
             if (eps_once != 0).any():
-                once_direct = once_direct + (eps_once * self.invest_size_at_build).sum('flow')
+                lump_direct = lump_direct + (eps_once * self.invest_size_at_build).sum('flow')
 
-        # Investment: one-time fixed costs (charged in build period)
+        # Investment: at-build fixed costs (charged in build period)
         if self.invest_build is not None and d.flows.invest_effects_fixed_at_build is not None:
             ef_once = d.flows.invest_effects_fixed_at_build.rename({'invest_flow': 'flow'})
             if (ef_once != 0).any():
-                once_direct = once_direct + (ef_once * self.invest_build).sum('flow')
+                lump_direct = lump_direct + (ef_once * self.invest_build).sum('flow')
 
-        self.m.add_constraints(self.effect_once == once_direct, name='effect_once_eq')
+        # Cross-effect lump: cf_periodic[k,j] * effect_lump[j]
+        lump_rhs: Any = lump_direct
+        if ds.cf_periodic is not None:
+            source_p = self.effect_lump.rename({'effect': 'source_effect'})
+            cross = (ds.cf_periodic * source_p).sum('source_effect')
+            lump_rhs = cross + lump_direct  # linopy expr must be left operand
+
+        self.m.add_constraints(self.effect_lump == lump_rhs, name='effect_lump_eq')
 
         # --- Total: effect_total[effect(, period)] ---
         self.effect_total = self.m.add_variables(coords={'effect': effect_ids, **pc}, name='effect--total')
         temporal_sum = (self.effect_temporal * d.dims.weights).sum('time')
-        rhs = temporal_sum + self.effect_periodic + self.effect_once
+        rhs = temporal_sum + self.effect_lump
         self.m.add_constraints(self.effect_total == rhs, name='effect_total_eq')
 
         # Per-period bounds on effect_total
@@ -1056,20 +1049,11 @@ class FlowSystem:
     def _set_objective(self) -> None:
         """Set objective: minimize the (period-weighted) objective effect total.
 
-        Objective = sum_p( ω_periodic[k*,p] * (temporal_sum + periodic) + ω_once[k*,p] * once )
+        Objective = sum_p( ω[k*,p] * effect_total[k*,p] )
 
-        ω_periodic defaults to global period_weights (or 1 in single-period).
-        ω_once defaults to 1.
+        ω defaults to global period_weights (or 1 in single-period).
         """
         k = self.data.effects.objective_effect
-        w_periodic, w_once = self.data.effects.objective_weights(self.data.dims.period_weights)
+        w_periodic, _w_once = self.data.effects.objective_weights(self.data.dims.period_weights)
 
-        assert self.effect_temporal is not None
-        assert self.effect_periodic is not None
-        assert self.effect_once is not None
-
-        temporal_sum = (self.effect_temporal.sel(effect=k) * self.data.dims.weights).sum('time')
-        recurring = temporal_sum + self.effect_periodic.sel(effect=k)
-        once = self.effect_once.sel(effect=k)
-
-        self.m.add_objective((w_periodic * recurring + w_once * once).sum())
+        self.m.add_objective((w_periodic * self.effect_total.sel(effect=k)).sum())

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -730,7 +730,7 @@ class FlowSystem:
         d = self.data
         ds = d.effects
 
-        effect_ids = ds.min_total.coords['effect']
+        effect_ids = ds.min_bound.coords['effect']
 
         if len(effect_ids) == 0:
             return
@@ -900,17 +900,28 @@ class FlowSystem:
         rhs = temporal_sum + self.effect_periodic + self.effect_once
         self.m.add_constraints(self.effect_total == rhs, name='effect_total_eq')
 
-        # Bounds on effect_total (per-period when multi-period)
-        min_total = ds.min_total  # (effect,) — NaN = unbounded
-        max_total = ds.max_total
+        # Per-period bounds on effect_total
+        min_pp = ds.min_per_period  # (effect,) — NaN = unbounded
+        max_pp = ds.max_per_period
+        has_min_pp = min_pp.notnull()
+        if has_min_pp.any():
+            self.m.add_constraints(self.effect_total >= min_pp, name='effect_min_per_period', mask=has_min_pp)
+        has_max_pp = max_pp.notnull()
+        if has_max_pp.any():
+            self.m.add_constraints(self.effect_total <= max_pp, name='effect_max_per_period', mask=has_max_pp)
 
-        has_min = min_total.notnull()
+        # Weighted total bounds (across all periods)
+        # In single-period: effect_total has no period dim, bound applies directly
+        # In multi-period: sum across periods first
+        min_bound = ds.min_bound  # (effect,) — NaN = unbounded
+        max_bound = ds.max_bound
+        total_sum = self.effect_total.sum('period') if 'period' in self.effect_total.dims else self.effect_total
+        has_min = min_bound.notnull()
         if has_min.any():
-            self.m.add_constraints(self.effect_total >= min_total, name='effect_min_total', mask=has_min)
-
-        has_max = max_total.notnull()
+            self.m.add_constraints(total_sum >= min_bound, name='effect_min_bound', mask=has_min)
+        has_max = max_bound.notnull()
         if has_max.any():
-            self.m.add_constraints(self.effect_total <= max_total, name='effect_max_total', mask=has_max)
+            self.m.add_constraints(total_sum <= max_bound, name='effect_max_bound', mask=has_max)
 
     def _create_storage(self) -> None:
         """Create storage variables, level balance, and prior/cyclic conditions."""

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -853,16 +853,16 @@ class FlowSystem:
                     periodic_direct = periodic_direct + ef_mand.sum('sizing_storage')
 
         # Investment: recurring per-size costs → effect_periodic
-        if self.invest_active is not None and d.flows.invest_effects_per_size_periodic is not None:
-            eps_p = d.flows.invest_effects_per_size_periodic.rename({'invest_flow': 'flow'})
+        if self.invest_active is not None and d.flows.invest_effects_per_size_recurring is not None:
+            eps_p = d.flows.invest_effects_per_size_recurring.rename({'invest_flow': 'flow'})
             if (eps_p != 0).any():
                 assert self.flow_size is not None
-                invest_ids = list(d.flows.invest_effects_per_size_periodic.coords['invest_flow'].values)
+                invest_ids = list(d.flows.invest_effects_per_size_recurring.coords['invest_flow'].values)
                 periodic_direct = periodic_direct + (eps_p * self.flow_size.sel(flow=invest_ids)).sum('flow')
 
         # Investment: recurring fixed costs → effect_periodic
-        if self.invest_active is not None and d.flows.invest_effects_fixed_periodic is not None:
-            ef_p = d.flows.invest_effects_fixed_periodic.rename({'invest_flow': 'flow'})
+        if self.invest_active is not None and d.flows.invest_effects_fixed_recurring is not None:
+            ef_p = d.flows.invest_effects_fixed_recurring.rename({'invest_flow': 'flow'})
             if (ef_p != 0).any():
                 periodic_direct = periodic_direct + (ef_p * self.invest_active).sum('flow')
 
@@ -881,14 +881,14 @@ class FlowSystem:
         once_direct: Any = 0
 
         # Investment: one-time per-size costs (charged in build period)
-        if self.invest_size_at_build is not None and d.flows.invest_effects_per_size is not None:
-            eps_once = d.flows.invest_effects_per_size.rename({'invest_flow': 'flow'})
+        if self.invest_size_at_build is not None and d.flows.invest_effects_per_size_at_build is not None:
+            eps_once = d.flows.invest_effects_per_size_at_build.rename({'invest_flow': 'flow'})
             if (eps_once != 0).any():
                 once_direct = once_direct + (eps_once * self.invest_size_at_build).sum('flow')
 
         # Investment: one-time fixed costs (charged in build period)
-        if self.invest_build is not None and d.flows.invest_effects_fixed is not None:
-            ef_once = d.flows.invest_effects_fixed.rename({'invest_flow': 'flow'})
+        if self.invest_build is not None and d.flows.invest_effects_fixed_at_build is not None:
+            ef_once = d.flows.invest_effects_fixed_at_build.rename({'invest_flow': 'flow'})
             if (ef_once != 0).any():
                 once_direct = once_direct + (ef_once * self.invest_build).sum('flow')
 

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -50,7 +50,7 @@ class FlowSystem:
         """
         self.data = data
         self.m = Model()
-        self._objective_effects: list[str] = ['cost']
+        self._objective_effects: list[str] = []
 
     def _add_variables(
         self,
@@ -104,7 +104,7 @@ class FlowSystem:
 
     def optimize(
         self,
-        objective: str | list[str] = 'cost',
+        objective_effects: str | list[str],
         customize: Callable[[FlowSystem], None] | None = None,
         *,
         solver: str = 'highs',
@@ -113,13 +113,13 @@ class FlowSystem:
         """Build, optionally customize, and solve the model.
 
         Args:
-            objective: Effect name(s) to minimize. Sum of named effect totals.
+            objective_effects: Effect name(s) to minimize. Sum of named effect totals.
             customize: Optional callback to modify the linopy model between build and solve.
                 Receives ``self``; use ``model.m`` to add variables/constraints.
             solver: Solver backend name.
             **kwargs: Passed through to ``linopy.Model.solve()``.
         """
-        self._objective_effects = [objective] if isinstance(objective, str) else objective
+        self._objective_effects = [objective_effects] if isinstance(objective_effects, str) else objective_effects
         self.build()
         if customize is not None:
             customize(self)

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -1055,6 +1055,13 @@ class FlowSystem:
         ω defaults to global period_weights (or 1 in single-period).
         """
         k = self.data.effects.objective_effect
-        w_periodic, _w_once = self.data.effects.objective_weights(self.data.dims.period_weights)
+        ds = self.data.effects
 
-        self.m.add_objective((w_periodic * self.effect_total.sel(effect=k)).sum())
+        # Resolve per-effect weight, falling back to global period_weights, then 1
+        w: xr.DataArray | int = 1
+        if ds.period_weights is not None and not ds.period_weights.sel(effect=k).isnull().all():
+            w = ds.period_weights.sel(effect=k)
+        elif self.data.dims.period_weights is not None:
+            w = self.data.dims.period_weights
+
+        self.m.add_objective((w * self.effect_total.sel(effect=k)).sum())

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -878,11 +878,12 @@ class FlowSystem:
             if (ef_once != 0).any():
                 lump_direct = lump_direct + (ef_once * self.invest_build).sum('flow')
 
-        # Cross-effect lump: cf_periodic[k,j] * effect_lump[j]
+        # Cross-effect lump: mean(cf_temporal, 'time')[k,j] * effect_lump[j]
         lump_rhs: Any = lump_direct
-        if ds.cf_periodic is not None:
+        if ds.cf_temporal is not None:
+            cf_lump = ds.cf_temporal.mean('time')
             source_p = self.effect_lump.rename({'effect': 'source_effect'})
-            cross = (ds.cf_periodic * source_p).sum('source_effect')
+            cross = (cf_lump * source_p).sum('source_effect')
             lump_rhs = cross + lump_direct  # linopy expr must be left operand
 
         self.m.add_constraints(self.effect_lump == lump_rhs, name='effect_lump_eq')

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -927,16 +927,14 @@ class FlowSystem:
         max_bound = ds.max_bound
         total_sum: Any
         if 'period' in self.effect_total.dims:
-            # Per-effect weights override global; default to 1 (unweighted)
+            # Multi-period: weighted sum across periods.
+            # Per-effect weights override global; both are always set in multi-period.
+            assert d.dims.period_weights is not None
             if ds.period_weights is not None:
-                # Use per-effect weights where available, fall back to global or 1
-                global_w = d.dims.period_weights if d.dims.period_weights is not None else 1
-                w_per_effect = ds.period_weights.fillna(global_w)
+                w_per_effect = ds.period_weights.fillna(d.dims.period_weights)
                 total_sum = (self.effect_total * w_per_effect).sum('period')
-            elif d.dims.period_weights is not None:
-                total_sum = (self.effect_total * d.dims.period_weights).sum('period')
             else:
-                total_sum = self.effect_total.sum('period')
+                total_sum = (self.effect_total * d.dims.period_weights).sum('period')
         else:
             total_sum = self.effect_total
         has_min = min_bound.notnull()

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -883,9 +883,20 @@ class FlowSystem:
                 lump_direct = lump_direct + (ef_once * self.invest_build).sum('flow')
 
         # Cross-effect lump: mean(cf_temporal, 'time')[k,j] * effect_lump[j]
+        # Time-varying contribution_from values are averaged over time for the
+        # lump domain. Warn when this could surprise the user.
         lump_rhs: Any = lump_direct
         if ds.cf_temporal is not None:
             cf_lump = ds.cf_temporal.mean('time')
+            time_varying = (ds.cf_temporal != ds.cf_temporal.mean('time')).any().item()
+            if time_varying and not isinstance(lump_direct, int):
+                import warnings
+
+                warnings.warn(
+                    'Time-varying contribution_from is averaged over time for the lump domain. '
+                    "If this isn't what you want, split into separate effects.",
+                    stacklevel=2,
+                )
             source_p = self.effect_lump.rename({'effect': 'source_effect'})
             cross = (cf_lump * source_p).sum('source_effect')
             lump_rhs = cross + lump_direct  # linopy expr must be left operand
@@ -909,11 +920,25 @@ class FlowSystem:
             self.m.add_constraints(self.effect_total <= max_pp, name='effect_max_per_period', mask=has_max_pp)
 
         # Weighted total bounds (across all periods)
-        # In single-period: effect_total has no period dim, bound applies directly
-        # In multi-period: sum across periods first
+        # Single-period: effect_total has no period dim, bound applies directly.
+        # Multi-period: weighted sum across periods, using per-effect period_weights
+        # if set, else global period_weights, else unweighted.
         min_bound = ds.min_bound  # (effect,) — NaN = unbounded
         max_bound = ds.max_bound
-        total_sum = self.effect_total.sum('period') if 'period' in self.effect_total.dims else self.effect_total
+        total_sum: Any
+        if 'period' in self.effect_total.dims:
+            # Per-effect weights override global; default to 1 (unweighted)
+            if ds.period_weights is not None:
+                # Use per-effect weights where available, fall back to global or 1
+                global_w = d.dims.period_weights if d.dims.period_weights is not None else 1
+                w_per_effect = ds.period_weights.fillna(global_w)
+                total_sum = (self.effect_total * w_per_effect).sum('period')
+            elif d.dims.period_weights is not None:
+                total_sum = (self.effect_total * d.dims.period_weights).sum('period')
+            else:
+                total_sum = self.effect_total.sum('period')
+        else:
+            total_sum = self.effect_total
         has_min = min_bound.notnull()
         if has_min.any():
             self.m.add_constraints(total_sum >= min_bound, name='effect_min_bound', mask=has_min)

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -884,16 +884,23 @@ class FlowSystem:
 
         # Cross-effect lump: mean(cf_temporal, 'time')[k,j] * effect_lump[j]
         # Time-varying contribution_from values are averaged over time for the
-        # lump domain. Warn when this could surprise the user.
+        # lump domain. Warn per-(k,j) where the factor varies and the mean
+        # is non-zero (i.e. the cross-effect actually contributes).
         lump_rhs: Any = lump_direct
         if ds.cf_temporal is not None:
             cf_lump = ds.cf_temporal.mean('time')
-            time_varying = (ds.cf_temporal != ds.cf_temporal.mean('time')).any().item()
-            if time_varying and not isinstance(lump_direct, int):
+            varying = (ds.cf_temporal != cf_lump).any('time')  # (effect, source_effect)
+            non_trivial = varying & (cf_lump != 0)
+            if bool(non_trivial.any().item()) and not isinstance(lump_direct, int):
                 import warnings
 
+                pairs = [
+                    (str(non_trivial.coords['effect'].values[i]), str(non_trivial.coords['source_effect'].values[j]))
+                    for i, j in zip(*non_trivial.values.nonzero(), strict=True)
+                ]
+                pair_str = ', '.join(f'{k}<-{j}' for k, j in pairs)
                 warnings.warn(
-                    'Time-varying contribution_from is averaged over time for the lump domain. '
+                    f'Time-varying contribution_from for {pair_str} is averaged over time for the lump domain. '
                     "If this isn't what you want, split into separate effects.",
                     stacklevel=2,
                 )

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -35,7 +35,7 @@ class FlowSystem:
     storage_level: Variable | None = None
     prior_storage_level: Variable | None = None
 
-    # Effect variables — set during build (no class-level defaults needed for temporal/lump/total)
+    # Effect / objective — set via optimize() or defaults to ['cost']
 
     # Status variables — None when no status is configured
     flow_on: Variable | None = None
@@ -50,6 +50,7 @@ class FlowSystem:
         """
         self.data = data
         self.m = Model()
+        self._objective_effects: list[str] = ['cost']
 
     def _add_variables(
         self,
@@ -103,6 +104,7 @@ class FlowSystem:
 
     def optimize(
         self,
+        objective: str | list[str] = 'cost',
         customize: Callable[[FlowSystem], None] | None = None,
         *,
         solver: str = 'highs',
@@ -111,11 +113,13 @@ class FlowSystem:
         """Build, optionally customize, and solve the model.
 
         Args:
+            objective: Effect name(s) to minimize. Sum of named effect totals.
             customize: Optional callback to modify the linopy model between build and solve.
                 Receives ``self``; use ``model.m`` to add variables/constraints.
             solver: Solver backend name.
             **kwargs: Passed through to ``linopy.Model.solve()``.
         """
+        self._objective_effects = [objective] if isinstance(objective, str) else objective
         self.build()
         if customize is not None:
             customize(self)
@@ -1048,20 +1052,27 @@ class FlowSystem:
             )
 
     def _set_objective(self) -> None:
-        """Set objective: minimize the (period-weighted) objective effect total.
+        """Set objective: minimize the sum of (period-weighted) effect totals.
 
-        Objective = sum_p( ω[k*,p] * effect_total[k*,p] )
+        Objective = sum_k sum_p( ω[k,p] * effect_total[k,p] )
 
-        ω defaults to global period_weights (or 1 in single-period).
+        ω falls back to global period_weights (or 1 in single-period).
         """
-        k = self.data.effects.objective_effect
         ds = self.data.effects
+        obj_expr: Any = 0
 
-        # Resolve per-effect weight, falling back to global period_weights, then 1
-        w: xr.DataArray | int = 1
-        if ds.period_weights is not None and not ds.period_weights.sel(effect=k).isnull().all():
-            w = ds.period_weights.sel(effect=k)
-        elif self.data.dims.period_weights is not None:
-            w = self.data.dims.period_weights
+        for k in self._objective_effects:
+            effect_ids = list(ds.min_bound.coords['effect'].values)
+            if k not in effect_ids:
+                raise ValueError(f'Objective effect {k!r} not found. Available: {effect_ids}')
 
-        self.m.add_objective((w * self.effect_total.sel(effect=k)).sum())
+            # Resolve per-effect weight, falling back to global period_weights, then 1
+            w: xr.DataArray | int = 1
+            if ds.period_weights is not None and not ds.period_weights.sel(effect=k).isnull().all():
+                w = ds.period_weights.sel(effect=k)
+            elif self.data.dims.period_weights is not None:
+                w = self.data.dims.period_weights
+
+            obj_expr = obj_expr + (w * self.effect_total.sel(effect=k)).sum()
+
+        self.m.add_objective(obj_expr)

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -175,10 +175,10 @@ class _InvestmentArrays:
     mandatory: xr.DataArray | None = None  # (invest_dim,)
     lifetime: xr.DataArray | None = None  # (invest_dim,) — NaN = forever
     prior_size: xr.DataArray | None = None  # (invest_dim,)
-    effects_per_size: xr.DataArray | None = None  # (invest_dim, effect, period?) — once
-    effects_fixed: xr.DataArray | None = None  # (invest_dim, effect, period?) — once
-    effects_per_size_periodic: xr.DataArray | None = None  # (invest_dim, effect, period?)
-    effects_fixed_periodic: xr.DataArray | None = None  # (invest_dim, effect, period?)
+    effects_per_size_at_build: xr.DataArray | None = None  # (invest_dim, effect, period?) — once
+    effects_fixed_at_build: xr.DataArray | None = None  # (invest_dim, effect, period?) — once
+    effects_per_size_recurring: xr.DataArray | None = None  # (invest_dim, effect, period?)
+    effects_fixed_recurring: xr.DataArray | None = None  # (invest_dim, effect, period?)
 
     @classmethod
     def build(
@@ -231,10 +231,10 @@ class _InvestmentArrays:
             prior_sizes.append(inv.prior_size)
 
             for label, src_dict, dest_key in [
-                ('Investment.effects_per_size', inv.effects_per_size, 'eps'),
-                ('Investment.effects_fixed', inv.effects_fixed, 'ef'),
-                ('Investment.effects_per_size_periodic', inv.effects_per_size_periodic, 'eps_p'),
-                ('Investment.effects_fixed_periodic', inv.effects_fixed_periodic, 'ef_p'),
+                ('Investment.effects_per_size_at_build', inv.effects_per_size_at_build, 'eps'),
+                ('Investment.effects_fixed_at_build', inv.effects_fixed_at_build, 'ef'),
+                ('Investment.effects_per_size_recurring', inv.effects_per_size_recurring, 'eps_p'),
+                ('Investment.effects_fixed_recurring', inv.effects_fixed_recurring, 'ef_p'),
             ]:
                 arr = tmpl.zeros()
                 for ek, ev in src_dict.items():
@@ -251,10 +251,10 @@ class _InvestmentArrays:
             mandatory=xr.DataArray(np.array(mandatories), dims=[dim], coords=coords),
             lifetime=xr.DataArray(np.array(lifetimes), dims=[dim], coords=coords),
             prior_size=xr.DataArray(np.array(prior_sizes), dims=[dim], coords=coords),
-            effects_per_size=fast_concat(all_slices['eps'], invest_idx),
-            effects_fixed=fast_concat(all_slices['ef'], invest_idx),
-            effects_per_size_periodic=fast_concat(all_slices['eps_p'], invest_idx),
-            effects_fixed_periodic=fast_concat(all_slices['ef_p'], invest_idx),
+            effects_per_size_at_build=fast_concat(all_slices['eps'], invest_idx),
+            effects_fixed_at_build=fast_concat(all_slices['ef'], invest_idx),
+            effects_per_size_recurring=fast_concat(all_slices['eps_p'], invest_idx),
+            effects_fixed_recurring=fast_concat(all_slices['ef_p'], invest_idx),
         )
 
 
@@ -420,10 +420,10 @@ class FlowsData:
     invest_mandatory: xr.DataArray | None = None  # (invest_flow,)
     invest_lifetime: xr.DataArray | None = None  # (invest_flow,) — NaN = forever
     invest_prior_size: xr.DataArray | None = None  # (invest_flow,)
-    invest_effects_per_size: xr.DataArray | None = None  # (invest_flow, effect, period?) — once
-    invest_effects_fixed: xr.DataArray | None = None  # (invest_flow, effect, period?) — once
-    invest_effects_per_size_periodic: xr.DataArray | None = None  # (invest_flow, effect, period?)
-    invest_effects_fixed_periodic: xr.DataArray | None = None  # (invest_flow, effect, period?)
+    invest_effects_per_size_at_build: xr.DataArray | None = None  # (invest_flow, effect, period?) — once
+    invest_effects_fixed_at_build: xr.DataArray | None = None  # (invest_flow, effect, period?) — once
+    invest_effects_per_size_recurring: xr.DataArray | None = None  # (invest_flow, effect, period?)
+    invest_effects_fixed_recurring: xr.DataArray | None = None  # (invest_flow, effect, period?)
 
     def __post_init__(self) -> None:
         """Validate relative bounds: non-negative and lb <= ub."""
@@ -573,10 +573,10 @@ class FlowsData:
             invest_mandatory=inv.mandatory,
             invest_lifetime=inv.lifetime,
             invest_prior_size=inv.prior_size,
-            invest_effects_per_size=inv.effects_per_size,
-            invest_effects_fixed=inv.effects_fixed,
-            invest_effects_per_size_periodic=inv.effects_per_size_periodic,
-            invest_effects_fixed_periodic=inv.effects_fixed_periodic,
+            invest_effects_per_size_at_build=inv.effects_per_size_at_build,
+            invest_effects_fixed_at_build=inv.effects_fixed_at_build,
+            invest_effects_per_size_recurring=inv.effects_per_size_recurring,
+            invest_effects_fixed_recurring=inv.effects_fixed_recurring,
         )
 
 
@@ -1030,10 +1030,10 @@ class StoragesData:
     invest_mandatory: xr.DataArray | None = None  # (invest_storage,)
     invest_lifetime: xr.DataArray | None = None  # (invest_storage,) — NaN = forever
     invest_prior_size: xr.DataArray | None = None  # (invest_storage,)
-    invest_effects_per_size: xr.DataArray | None = None  # (invest_storage, effect, period?) — once
-    invest_effects_fixed: xr.DataArray | None = None  # (invest_storage, effect, period?) — once
-    invest_effects_per_size_periodic: xr.DataArray | None = None  # (invest_storage, effect, period?)
-    invest_effects_fixed_periodic: xr.DataArray | None = None  # (invest_storage, effect, period?)
+    invest_effects_per_size_at_build: xr.DataArray | None = None  # (invest_storage, effect, period?) — once
+    invest_effects_fixed_at_build: xr.DataArray | None = None  # (invest_storage, effect, period?) — once
+    invest_effects_per_size_recurring: xr.DataArray | None = None  # (invest_storage, effect, period?)
+    invest_effects_fixed_recurring: xr.DataArray | None = None  # (invest_storage, effect, period?)
 
     def __post_init__(self) -> None:
         """Validate capacity, efficiencies, and loss rates."""
@@ -1153,10 +1153,10 @@ class StoragesData:
             invest_mandatory=inv.mandatory,
             invest_lifetime=inv.lifetime,
             invest_prior_size=inv.prior_size,
-            invest_effects_per_size=inv.effects_per_size,
-            invest_effects_fixed=inv.effects_fixed,
-            invest_effects_per_size_periodic=inv.effects_per_size_periodic,
-            invest_effects_fixed_periodic=inv.effects_fixed_periodic,
+            invest_effects_per_size_at_build=inv.effects_per_size_at_build,
+            invest_effects_fixed_at_build=inv.effects_fixed_at_build,
+            invest_effects_per_size_recurring=inv.effects_per_size_recurring,
+            invest_effects_fixed_recurring=inv.effects_fixed_recurring,
         )
 
 

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -804,20 +804,8 @@ class EffectsData:
     max_per_period: xr.DataArray  # (effect,) — per-period bound
     min_per_hour: xr.DataArray  # (effect, time)
     max_per_hour: xr.DataArray  # (effect, time)
-    is_objective: xr.DataArray  # (effect,)
-    objective_effect: str
     cf_temporal: xr.DataArray | None = None  # (effect, source_effect, time, period?)
     period_weights: xr.DataArray | None = None  # (effect, period)
-
-    def __post_init__(self) -> None:
-        """Validate exactly one objective effect exists."""
-        n_obj = int(self.is_objective.sum())
-        if n_obj == 0:
-            raise ValueError('No objective effect found. Include an Effect with is_objective=True.')
-        if n_obj > 1:
-            raise ValueError(
-                f'Multiple objective effects: {list(self.is_objective.coords["effect"][self.is_objective].values)}. Only one is allowed.'
-            )
 
     def to_dataset(self) -> xr.Dataset:
         """Serialize to xr.Dataset."""
@@ -837,7 +825,7 @@ class EffectsData:
             elif f.name in ds.attrs:
                 kwargs[f.name] = ds.attrs[f.name]
             # else: rely on dataclass default (e.g. None for optional fields)
-        return cls(**kwargs)  # type: ignore[arg-type]
+        return cls(**kwargs)
 
     @classmethod
     def build(
@@ -857,20 +845,12 @@ class EffectsData:
         effect_set = set(effect_ids)
         n = len(effects)
         n_time = len(time)
-        objective_effect = next(
-            (e.id for e in effects if e.is_objective),
-            None,
-        )
-        if objective_effect is None:
-            raise ValueError('No objective effect found. Include an Effect with is_objective=True.')
-
         min_bound = np.full(n, np.nan)
         max_bound = np.full(n, np.nan)
         min_per_period = np.full(n, np.nan)
         max_per_period = np.full(n, np.nan)
         min_per_hours: list[xr.DataArray] = []
         max_per_hours: list[xr.DataArray] = []
-        is_objective = np.zeros(n, dtype=bool)
 
         nan_time = xr.DataArray(np.full(n_time, np.nan), dims=['time'], coords={'time': time})
 
@@ -890,7 +870,6 @@ class EffectsData:
             max_per_hours.append(
                 as_dataarray(e.maximum_per_hour, {'time': time}) if e.maximum_per_hour is not None else nan_time
             )
-            is_objective[i] = e.is_objective
             if e.contribution_from:
                 has_contributions = True
 
@@ -951,8 +930,6 @@ class EffectsData:
             max_per_period=xr.DataArray(max_per_period, dims=['effect'], coords={'effect': effect_ids}),
             min_per_hour=fast_concat(min_per_hours, effect_idx),
             max_per_hour=fast_concat(max_per_hours, effect_idx),
-            is_objective=xr.DataArray(is_objective, dims=['effect'], coords={'effect': effect_ids}),
-            objective_effect=objective_effect,
             cf_temporal=cf_temporal,
             period_weights=pw,
         )

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -807,8 +807,7 @@ class EffectsData:
     is_objective: xr.DataArray  # (effect,)
     objective_effect: str
     cf_temporal: xr.DataArray | None = None  # (effect, source_effect, time, period?)
-    period_weights_periodic: xr.DataArray | None = None  # (effect, period)
-    period_weights_once: xr.DataArray | None = None  # (effect, period)
+    period_weights: xr.DataArray | None = None  # (effect, period)
 
     def __post_init__(self) -> None:
         """Validate exactly one objective effect exists."""
@@ -819,35 +818,6 @@ class EffectsData:
             raise ValueError(
                 f'Multiple objective effects: {list(self.is_objective.coords["effect"][self.is_objective].values)}. Only one is allowed.'
             )
-
-    def objective_weights(
-        self,
-        global_period_weights: xr.DataArray | None,
-    ) -> tuple[xr.DataArray | int, xr.DataArray | int]:
-        """Resolve period weights for the objective effect's two domains.
-
-        Args:
-            global_period_weights: Default period weights from Dims (or None).
-
-        Returns:
-            (w_periodic, w_once) — weights for recurring and one-time domains.
-            Falls back to global_period_weights / 1 when no per-effect override.
-        """
-        k = self.objective_effect
-
-        if self.period_weights_periodic is not None and not self.period_weights_periodic.sel(effect=k).isnull().all():
-            w_periodic: xr.DataArray | int = self.period_weights_periodic.sel(effect=k)
-        elif global_period_weights is not None:
-            w_periodic = global_period_weights
-        else:
-            w_periodic = 1
-
-        if self.period_weights_once is not None and not self.period_weights_once.sel(effect=k).isnull().all():
-            w_once: xr.DataArray | int = self.period_weights_once.sel(effect=k)
-        else:
-            w_once = 1
-
-        return w_periodic, w_once
 
     def to_dataset(self) -> xr.Dataset:
         """Serialize to xr.Dataset."""
@@ -956,40 +926,23 @@ class EffectsData:
         effect_idx = pd.Index(effect_ids, name='effect')
 
         # Per-effect period weights
-        pw_periodic: xr.DataArray | None = None
-        pw_once: xr.DataArray | None = None
+        pw: xr.DataArray | None = None
         if period is not None:
-            has_pw_periodic = any(e.period_weights_periodic is not None for e in effects)
-            has_pw_once = any(e.period_weights_once is not None for e in effects)
+            has_pw = any(e.period_weights is not None for e in effects)
             n_periods = len(period)
-            if has_pw_periodic:
+            if has_pw:
                 mat = np.full((n, n_periods), np.nan)
                 for i, e in enumerate(effects):
-                    if e.period_weights_periodic is not None:
-                        if len(e.period_weights_periodic) != n_periods:
-                            msg = f'Effect {e.id!r}: period_weights_periodic has {len(e.period_weights_periodic)} entries, expected {n_periods}'
+                    if e.period_weights is not None:
+                        if len(e.period_weights) != n_periods:
+                            msg = f'Effect {e.id!r}: period_weights has {len(e.period_weights)} entries, expected {n_periods}'
                             raise ValueError(msg)
-                        vals = np.asarray(e.period_weights_periodic, dtype=float)
+                        vals = np.asarray(e.period_weights, dtype=float)
                         if not np.all(np.isfinite(vals)) or not np.all(vals > 0):
-                            msg = f'Effect {e.id!r}: period_weights_periodic must be positive and finite, got {vals}'
+                            msg = f'Effect {e.id!r}: period_weights must be positive and finite, got {vals}'
                             raise ValueError(msg)
                         mat[i] = vals
-                pw_periodic = xr.DataArray(
-                    mat, dims=['effect', 'period'], coords={'effect': effect_ids, 'period': period}
-                )
-            if has_pw_once:
-                mat = np.full((n, n_periods), np.nan)
-                for i, e in enumerate(effects):
-                    if e.period_weights_once is not None:
-                        if len(e.period_weights_once) != n_periods:
-                            msg = f'Effect {e.id!r}: period_weights_once has {len(e.period_weights_once)} entries, expected {n_periods}'
-                            raise ValueError(msg)
-                        vals = np.asarray(e.period_weights_once, dtype=float)
-                        if not np.all(np.isfinite(vals)) or not np.all(vals > 0):
-                            msg = f'Effect {e.id!r}: period_weights_once must be positive and finite, got {vals}'
-                            raise ValueError(msg)
-                        mat[i] = vals
-                pw_once = xr.DataArray(mat, dims=['effect', 'period'], coords={'effect': effect_ids, 'period': period})
+                pw = xr.DataArray(mat, dims=['effect', 'period'], coords={'effect': effect_ids, 'period': period})
 
         return cls(
             min_bound=xr.DataArray(min_bound, dims=['effect'], coords={'effect': effect_ids}),
@@ -1001,8 +954,7 @@ class EffectsData:
             is_objective=xr.DataArray(is_objective, dims=['effect'], coords={'effect': effect_ids}),
             objective_effect=objective_effect,
             cf_temporal=cf_temporal,
-            period_weights_periodic=pw_periodic,
-            period_weights_once=pw_once,
+            period_weights=pw,
         )
 
 

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -798,8 +798,10 @@ def _detect_contribution_cycle(adjacency: dict[str, list[str]]) -> list[str] | N
 
 @dataclass
 class EffectsData:
-    min_total: xr.DataArray  # (effect,)
-    max_total: xr.DataArray  # (effect,)
+    min_bound: xr.DataArray  # (effect,) — weighted total bound
+    max_bound: xr.DataArray  # (effect,) — weighted total bound
+    min_per_period: xr.DataArray  # (effect,) — per-period bound
+    max_per_period: xr.DataArray  # (effect,) — per-period bound
     min_per_hour: xr.DataArray  # (effect, time)
     max_per_hour: xr.DataArray  # (effect, time)
     is_objective: xr.DataArray  # (effect,)
@@ -893,8 +895,10 @@ class EffectsData:
         if objective_effect is None:
             raise ValueError('No objective effect found. Include an Effect with is_objective=True.')
 
-        min_total = np.full(n, np.nan)
-        max_total = np.full(n, np.nan)
+        min_bound = np.full(n, np.nan)
+        max_bound = np.full(n, np.nan)
+        min_per_period = np.full(n, np.nan)
+        max_per_period = np.full(n, np.nan)
         min_per_hours: list[xr.DataArray] = []
         max_per_hours: list[xr.DataArray] = []
         is_objective = np.zeros(n, dtype=bool)
@@ -903,10 +907,14 @@ class EffectsData:
 
         has_contributions = False
         for i, e in enumerate(effects):
-            if e.minimum_total is not None:
-                min_total[i] = e.minimum_total
-            if e.maximum_total is not None:
-                max_total[i] = e.maximum_total
+            if e.minimum is not None:
+                min_bound[i] = e.minimum
+            if e.maximum is not None:
+                max_bound[i] = e.maximum
+            if e.minimum_per_period is not None:
+                min_per_period[i] = e.minimum_per_period
+            if e.maximum_per_period is not None:
+                max_per_period[i] = e.maximum_per_period
             min_per_hours.append(
                 as_dataarray(e.minimum_per_hour, {'time': time}) if e.minimum_per_hour is not None else nan_time
             )
@@ -995,8 +1003,10 @@ class EffectsData:
                 pw_once = xr.DataArray(mat, dims=['effect', 'period'], coords={'effect': effect_ids, 'period': period})
 
         return cls(
-            min_total=xr.DataArray(min_total, dims=['effect'], coords={'effect': effect_ids}),
-            max_total=xr.DataArray(max_total, dims=['effect'], coords={'effect': effect_ids}),
+            min_bound=xr.DataArray(min_bound, dims=['effect'], coords={'effect': effect_ids}),
+            max_bound=xr.DataArray(max_bound, dims=['effect'], coords={'effect': effect_ids}),
+            min_per_period=xr.DataArray(min_per_period, dims=['effect'], coords={'effect': effect_ids}),
+            max_per_period=xr.DataArray(max_per_period, dims=['effect'], coords={'effect': effect_ids}),
             min_per_hour=fast_concat(min_per_hours, effect_idx),
             max_per_hour=fast_concat(max_per_hours, effect_idx),
             is_objective=xr.DataArray(is_objective, dims=['effect'], coords={'effect': effect_ids}),

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -806,7 +806,6 @@ class EffectsData:
     max_per_hour: xr.DataArray  # (effect, time)
     is_objective: xr.DataArray  # (effect,)
     objective_effect: str
-    cf_periodic: xr.DataArray | None = None  # (effect, source_effect, period?)
     cf_temporal: xr.DataArray | None = None  # (effect, source_effect, time, period?)
     period_weights_periodic: xr.DataArray | None = None  # (effect, period)
     period_weights_once: xr.DataArray | None = None  # (effect, period)
@@ -922,23 +921,22 @@ class EffectsData:
                 as_dataarray(e.maximum_per_hour, {'time': time}) if e.maximum_per_hour is not None else nan_time
             )
             is_objective[i] = e.is_objective
-            if e.contribution_from or e.contribution_from_per_hour:
+            if e.contribution_from:
                 has_contributions = True
 
         # Build cross-effect contribution arrays
-        cf_periodic: xr.DataArray | None = None
         cf_temporal: xr.DataArray | None = None
         if has_contributions:
             # Self-reference check
             for e in effects:
-                for src_id in (*e.contribution_from, *e.contribution_from_per_hour):
+                for src_id in e.contribution_from:
                     if src_id == e.id:
                         raise ValueError(f'Effect {e.id!r} cannot reference itself in contribution_from')
 
             # Cycle check
             adjacency: dict[str, list[str]] = {eid: [] for eid in effect_ids}
             for e in effects:
-                for src_id in {*e.contribution_from, *e.contribution_from_per_hour}:
+                for src_id in e.contribution_from:
                     if src_id not in effect_set:
                         raise ValueError(f'Unknown effect {src_id!r} in contribution_from on {e.id!r}')
                     adjacency[e.id].append(src_id)
@@ -946,22 +944,13 @@ class EffectsData:
             if cycle is not None:
                 raise ValueError(f'Circular contribution_from dependency: {" -> ".join(cycle)}')
 
-            tmpl_p = _effect_template({'effect': effect_ids, 'source_effect': effect_ids}, period)
             tmpl_t = _effect_template({'effect': effect_ids, 'source_effect': effect_ids, 'time': time}, period)
-
-            periodic_mat = tmpl_p.zeros()
             temporal_mat = tmpl_t.zeros()
             for e in effects:
                 for src_id, factor in e.contribution_from.items():
                     if src_id not in effect_set:
                         raise ValueError(f'Unknown effect {src_id!r} in Effect.contribution_from on {e.id!r}')
-                    periodic_mat.loc[e.id, src_id] = as_dataarray(factor, tmpl_p.as_da_coords)
                     temporal_mat.loc[e.id, src_id] = as_dataarray(factor, tmpl_t.as_da_coords)
-                for src_id, factor_ts in e.contribution_from_per_hour.items():
-                    if src_id not in effect_set:
-                        raise ValueError(f'Unknown effect {src_id!r} in Effect.contribution_from_per_hour on {e.id!r}')
-                    temporal_mat.loc[e.id, src_id] = as_dataarray(factor_ts, tmpl_t.as_da_coords)
-            cf_periodic = periodic_mat
             cf_temporal = temporal_mat
 
         effect_idx = pd.Index(effect_ids, name='effect')
@@ -1011,7 +1000,6 @@ class EffectsData:
             max_per_hour=fast_concat(max_per_hours, effect_idx),
             is_objective=xr.DataArray(is_objective, dims=['effect'], coords={'effect': effect_ids}),
             objective_effect=objective_effect,
-            cf_periodic=cf_periodic,
             cf_temporal=cf_temporal,
             period_weights_periodic=pw_periodic,
             period_weights_once=pw_once,

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -825,7 +825,7 @@ class EffectsData:
             elif f.name in ds.attrs:
                 kwargs[f.name] = ds.attrs[f.name]
             # else: rely on dataclass default (e.g. None for optional fields)
-        return cls(**kwargs)
+        return cls(**kwargs)  # type: ignore[arg-type, unused-ignore]
 
     @classmethod
     def build(

--- a/src/fluxopt/results.py
+++ b/src/fluxopt/results.py
@@ -60,14 +60,9 @@ class Result:
         return self.solution['effect--temporal']
 
     @property
-    def effects_periodic(self) -> xr.DataArray:
-        """Per-period (investment) effect values as (effect,) DataArray."""
-        return self.solution['effect--periodic']
-
-    @property
-    def effects_once(self) -> xr.DataArray:
-        """One-time effect values as (effect,) DataArray."""
-        return self.solution['effect--once']
+    def effects_lump(self) -> xr.DataArray:
+        """Non-temporal effect values as (effect,) DataArray."""
+        return self.solution['effect--lump']
 
     def flow_rate(self, flow_id: str) -> xr.DataArray:
         """Get flow rate time series for a single flow.
@@ -172,10 +167,8 @@ class Result:
             'flow--rate': model.flow_rate.solution,
             'effect--total': model.effect_total.solution,
             'effect--temporal': model.effect_temporal.solution,
-            'effect--periodic': model.effect_periodic.solution,
+            'effect--lump': model.effect_lump.solution,
         }
-        if model.effect_once is not None:
-            sol_vars['effect--once'] = model.effect_once.solution
 
         if model.storage_level is not None:
             sol_vars['storage--level'] = model.storage_level.solution

--- a/src/fluxopt/stats.py
+++ b/src/fluxopt/stats.py
@@ -57,7 +57,7 @@ class StatsAccessor:
 
         Returns:
             Dataset with ``temporal`` (contributor, effect, time),
-            ``periodic`` (contributor, effect), and ``total``
+            ``lump`` (contributor, effect), and ``total``
             (contributor, effect).
         """
         from fluxopt.contributions import compute_effect_contributions

--- a/tests/math/test_bus_balance.py
+++ b/tests/math/test_bus_balance.py
@@ -17,7 +17,7 @@ class TestBusBalance:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('grid', imports=[source_flow]), Port('demand', exports=[sink_flow])],
         )
 
@@ -34,7 +34,7 @@ class TestBusBalance:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('grid', imports=[source_flow]), Port('demand', exports=[sink_flow])],
         )
 
@@ -51,7 +51,7 @@ class TestBusBalance:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('cheap_src', imports=[cheap_flow]),
                 Port('exp_src', imports=[expensive_flow]),

--- a/tests/math/test_bus_balance.py
+++ b/tests/math/test_bus_balance.py
@@ -18,6 +18,7 @@ class TestBusBalance:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source_flow]), Port('demand', exports=[sink_flow])],
         )
 
@@ -35,6 +36,7 @@ class TestBusBalance:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source_flow]), Port('demand', exports=[sink_flow])],
         )
 
@@ -52,6 +54,7 @@ class TestBusBalance:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('cheap_src', imports=[cheap_flow]),
                 Port('exp_src', imports=[expensive_flow]),

--- a/tests/math/test_contributions.py
+++ b/tests/math/test_contributions.py
@@ -19,6 +19,7 @@ class TestSumToTotal:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
@@ -38,6 +39,7 @@ class TestSumToTotal:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('cheap_src', imports=[cheap]),
                 Port('exp_src', imports=[expensive]),
@@ -60,6 +62,7 @@ class TestSumToTotal:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
@@ -81,6 +84,7 @@ class TestProportionalSplit:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('cheap_src', imports=[cheap]),
                 Port('exp_src', imports=[expensive]),
@@ -111,6 +115,7 @@ class TestCrossEffects:
                 Effect('cost', contribution_from={'co2': 50}),
                 Effect('co2', unit='kg'),
             ],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
@@ -143,6 +148,7 @@ class TestCrossEffects:
                 Effect('cost', contribution_from={'co2': 50}),
                 Effect('co2', maximum=co2_limit),
             ],
+            objective_effects='cost',
             ports=[
                 Port('dirty_src', imports=[dirty]),
                 Port('clean_src', imports=[clean]),
@@ -174,6 +180,7 @@ class TestCrossEffects:
                 Effect('co2', unit='kg', contribution_from={'pe': 0.3}),
                 Effect('pe', unit='kWh'),
             ],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
@@ -202,6 +209,7 @@ class TestSizing:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
@@ -231,6 +239,7 @@ class TestSizing:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
@@ -259,6 +268,7 @@ class TestSizing:
                 Effect('cost', contribution_from={'co2': 50}),
                 Effect('co2', unit='kg'),
             ],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
@@ -291,6 +301,7 @@ class TestStatus:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
@@ -321,6 +332,7 @@ class TestConverter:
             timesteps=ts(3),
             carriers=[Carrier('gas'), Carrier('heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[Port('gas_grid', imports=[gas_supply]), Port('demand', exports=[heat_sink])],
             converters=[Converter.boiler('boiler', thermal_efficiency=0.9, fuel_flow=fuel, thermal_flow=heat_flow)],
         )
@@ -351,6 +363,7 @@ class TestStorage:
             timesteps=ts(4),
             carriers=[Carrier('elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
             storages=[
                 Storage(
@@ -388,6 +401,7 @@ class TestStorage:
                 Effect('cost', contribution_from={'co2': 50}),
                 Effect('co2', unit='kg'),
             ],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
             storages=[
                 Storage(
@@ -423,6 +437,7 @@ class TestEdgeCases:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
@@ -439,6 +454,7 @@ class TestEdgeCases:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[Effect('cost'), Effect('co2', unit='kg')],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
@@ -458,6 +474,7 @@ class TestEdgeCases:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 

--- a/tests/math/test_contributions.py
+++ b/tests/math/test_contributions.py
@@ -18,7 +18,7 @@ class TestSumToTotal:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
@@ -37,7 +37,7 @@ class TestSumToTotal:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('cheap_src', imports=[cheap]),
                 Port('exp_src', imports=[expensive]),
@@ -59,7 +59,7 @@ class TestSumToTotal:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
@@ -80,7 +80,7 @@ class TestProportionalSplit:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('cheap_src', imports=[cheap]),
                 Port('exp_src', imports=[expensive]),
@@ -108,7 +108,7 @@ class TestCrossEffects:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('cost', contribution_from={'co2': 50}),
                 Effect('co2', unit='kg'),
             ],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
@@ -140,7 +140,7 @@ class TestCrossEffects:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('cost', contribution_from={'co2': 50}),
                 Effect('co2', maximum=co2_limit),
             ],
             ports=[
@@ -170,7 +170,7 @@ class TestCrossEffects:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('cost', contribution_from={'co2': 50}),
                 Effect('co2', unit='kg', contribution_from={'pe': 0.3}),
                 Effect('pe', unit='kWh'),
             ],
@@ -201,7 +201,7 @@ class TestSizing:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
@@ -230,7 +230,7 @@ class TestSizing:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
@@ -256,7 +256,7 @@ class TestSizing:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('cost', contribution_from={'co2': 50}),
                 Effect('co2', unit='kg'),
             ],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
@@ -290,7 +290,7 @@ class TestStatus:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
@@ -320,7 +320,7 @@ class TestConverter:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('gas'), Carrier('heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('gas_grid', imports=[gas_supply]), Port('demand', exports=[heat_sink])],
             converters=[Converter.boiler('boiler', thermal_efficiency=0.9, fuel_flow=fuel, thermal_flow=heat_flow)],
         )
@@ -350,7 +350,7 @@ class TestStorage:
         result = optimize(
             timesteps=ts(4),
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
             storages=[
                 Storage(
@@ -385,7 +385,7 @@ class TestStorage:
             timesteps=ts(4),
             carriers=[Carrier('elec')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('cost', contribution_from={'co2': 50}),
                 Effect('co2', unit='kg'),
             ],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
@@ -422,7 +422,7 @@ class TestEdgeCases:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
@@ -438,7 +438,7 @@ class TestEdgeCases:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True), Effect('co2', unit='kg')],
+            effects=[Effect('cost'), Effect('co2', unit='kg')],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
@@ -457,7 +457,7 @@ class TestEdgeCases:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 

--- a/tests/math/test_contributions.py
+++ b/tests/math/test_contributions.py
@@ -206,8 +206,8 @@ class TestSizing:
         )
 
         contrib = result.stats.effect_contributions
-        grid_inv = float(contrib['periodic'].sel(contributor='grid(elec)', effect='cost').values)
-        demand_inv = float(contrib['periodic'].sel(contributor='demand(elec)', effect='cost').values)
+        grid_inv = float(contrib['lump'].sel(contributor='grid(elec)', effect='cost').values)
+        demand_inv = float(contrib['lump'].sel(contributor='demand(elec)', effect='cost').values)
         # size=50 (min to meet demand) * effects_per_size=100
         expected_inv = 50 * 100
         assert grid_inv == pytest.approx(expected_inv, abs=1e-6)
@@ -239,7 +239,7 @@ class TestSizing:
         assert total_from_contrib == pytest.approx(float(result.effect_totals.sel(effect='cost').values), abs=1e-6)
 
         # Grid has investment cost from fixed costs
-        grid_periodic = float(contrib['periodic'].sel(contributor='grid(elec)', effect='cost').values)
+        grid_periodic = float(contrib['lump'].sel(contributor='grid(elec)', effect='cost').values)
         assert grid_periodic == pytest.approx(1000, abs=1e-6)
 
     def test_sizing_cross_effect_investment(self):
@@ -267,7 +267,7 @@ class TestSizing:
         assert total_from_contrib == pytest.approx(float(result.effect_totals.sel(effect='cost').values), abs=1e-6)
 
         # Grid flow gets the investment cost (including cross-effect from CO2)
-        grid_inv_cost = float(contrib['periodic'].sel(contributor='grid(elec)', effect='cost').values)
+        grid_inv_cost = float(contrib['lump'].sel(contributor='grid(elec)', effect='cost').values)
         invest_size = float(result.sizes.sel(flow='grid(elec)').values)
         invest_co2 = invest_size * 10
         expected_inv_cost = invest_co2 * 50
@@ -364,7 +364,7 @@ class TestStorage:
 
         contrib = result.stats.effect_contributions
         # Storage appears as a contributor in periodic
-        bat_inv = float(contrib['periodic'].sel(contributor='battery', effect='cost').values)
+        bat_inv = float(contrib['lump'].sel(contributor='battery', effect='cost').values)
         bat_capacity = float(result.storage_capacities.sel(storage='battery').values)
         assert bat_inv == pytest.approx(bat_capacity * 50, abs=1e-5)
 
@@ -405,7 +405,7 @@ class TestStorage:
         assert total_from_contrib == pytest.approx(solver_total, abs=1e-6)
 
         # Storage has CO2 investment cost that gets priced into cost via cross-effect
-        bat_periodic_cost = float(contrib['periodic'].sel(contributor='battery', effect='cost').values)
+        bat_periodic_cost = float(contrib['lump'].sel(contributor='battery', effect='cost').values)
         bat_capacity = float(result.storage_capacities.sel(storage='battery').values)
         expected_co2_inv = bat_capacity * 5
         expected_cost_inv = expected_co2_inv * 50

--- a/tests/math/test_contributions.py
+++ b/tests/math/test_contributions.py
@@ -141,7 +141,7 @@ class TestCrossEffects:
             carriers=[Carrier('elec')],
             effects=[
                 Effect('cost', is_objective=True, contribution_from={'co2': 50}),
-                Effect('co2', maximum_total=co2_limit),
+                Effect('co2', maximum=co2_limit),
             ],
             ports=[
                 Port('dirty_src', imports=[dirty]),

--- a/tests/math/test_converter.py
+++ b/tests/math/test_converter.py
@@ -20,7 +20,7 @@ class TestBoiler:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('gas'), Carrier('heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('grid', imports=[gas_flow]),
                 Port('demand', exports=[demand_flow]),
@@ -44,7 +44,7 @@ class TestBoiler:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('gas'), Carrier('heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('grid', imports=[gas_flow]),
                 Port('demand', exports=[demand_flow]),
@@ -72,7 +72,7 @@ class TestCHP:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('gas'), Carrier('elec'), Carrier('heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('grid', imports=[gas_source]),
                 Port('elec_demand', exports=[elec_demand]),

--- a/tests/math/test_converter.py
+++ b/tests/math/test_converter.py
@@ -21,6 +21,7 @@ class TestBoiler:
             timesteps=ts(3),
             carriers=[Carrier('gas'), Carrier('heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('grid', imports=[gas_flow]),
                 Port('demand', exports=[demand_flow]),
@@ -45,6 +46,7 @@ class TestBoiler:
             timesteps=ts(3),
             carriers=[Carrier('gas'), Carrier('heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('grid', imports=[gas_flow]),
                 Port('demand', exports=[demand_flow]),
@@ -73,6 +75,7 @@ class TestCHP:
             timesteps=ts(3),
             carriers=[Carrier('gas'), Carrier('elec'), Carrier('heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('grid', imports=[gas_source]),
                 Port('elec_demand', exports=[elec_demand]),

--- a/tests/math/test_custom.py
+++ b/tests/math/test_custom.py
@@ -17,6 +17,7 @@ class TestCustomize:
             'timesteps': ts(3),
             'carriers': [Carrier('elec')],
             'effects': [Effect('cost')],
+            'objective_effects': 'cost',
             'ports': [
                 Port('grid', imports=[Flow('elec', size=100, effects_per_flow_hour={'cost': 1.0})]),
                 Port('demand', exports=[Flow('elec', size=100, fixed_relative_profile=[0.5, 0.5, 0.5])]),
@@ -81,6 +82,7 @@ class TestCustomize:
             simple_system['ports'],
         )
         model = FlowSystem(data)
+        model._objective_effects = ['cost']
         model.build()
 
         # Add custom variable and constraint

--- a/tests/math/test_custom.py
+++ b/tests/math/test_custom.py
@@ -16,7 +16,7 @@ class TestCustomize:
         return {
             'timesteps': ts(3),
             'carriers': [Carrier('elec')],
-            'effects': [Effect('cost', is_objective=True)],
+            'effects': [Effect('cost')],
             'ports': [
                 Port('grid', imports=[Flow('elec', size=100, effects_per_flow_hour={'cost': 1.0})]),
                 Port('demand', exports=[Flow('elec', size=100, fixed_relative_profile=[0.5, 0.5, 0.5])]),

--- a/tests/math/test_effects.py
+++ b/tests/math/test_effects.py
@@ -211,8 +211,8 @@ class TestContributionFrom:
         assert float(result.effect_totals.sel(effect='co2').values) == pytest.approx(co2_total, abs=1e-6)
         assert result.objective == pytest.approx(cost_total, abs=1e-6)
 
-    def test_contribution_from_per_hour(self):
-        """Time-varying carbon price overrides scalar for per-timestep."""
+    def test_contribution_from_time_varying(self):
+        """Time-varying contribution_from uses per-timestep values for temporal."""
         demand = [50.0, 80.0, 60.0]
 
         source = Flow(
@@ -230,8 +230,7 @@ class TestContributionFrom:
                 Effect(
                     'cost',
                     is_objective=True,
-                    contribution_from={'co2': 50},  # scalar for invest
-                    contribution_from_per_hour={'co2': carbon_prices},  # time-varying for ops
+                    contribution_from={'co2': carbon_prices},  # time-varying
                 ),
                 Effect('co2', unit='kg'),
             ],
@@ -240,7 +239,7 @@ class TestContributionFrom:
 
         # per_ts[co2, t] = demand[t] * 0.5 (dt=1)
         # per_ts[cost, t] = carbon_price[t] * per_ts[co2, t]
-        # total[cost] = sum(per_ts[cost, t])  (no invest here)
+        # total[cost] = sum(per_ts[cost, t])  (no lump costs)
         expected = sum(d * 0.5 * p for d, p in zip(demand, carbon_prices, strict=True))
         assert result.objective == pytest.approx(expected, abs=1e-6)
 

--- a/tests/math/test_effects.py
+++ b/tests/math/test_effects.py
@@ -17,7 +17,7 @@ class TestEffects:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('grid', imports=[source_flow]), Port('demand', exports=[sink_flow])],
         )
 
@@ -41,7 +41,7 @@ class TestEffects:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True), Effect('co2', unit='kg')],
+            effects=[Effect('cost'), Effect('co2', unit='kg')],
             ports=[Port('grid', imports=[source_flow]), Port('demand', exports=[sink_flow])],
         )
 
@@ -65,7 +65,7 @@ class TestEffects:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True), Effect('co2', maximum=co2_limit)],
+            effects=[Effect('cost'), Effect('co2', maximum=co2_limit)],
             ports=[
                 Port('cheap_src', imports=[cheap_dirty]),
                 Port('clean_src', imports=[expensive_clean]),
@@ -86,7 +86,7 @@ class TestEffects:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('grid', imports=[source_flow]), Port('demand', exports=[sink_flow])],
         )
 
@@ -105,7 +105,7 @@ class TestContributionFrom:
             optimize(
                 timesteps=ts(3),
                 carriers=[Carrier('elec')],
-                effects=[Effect('cost', is_objective=True, contribution_from={'cost': 0.5})],
+                effects=[Effect('cost', contribution_from={'cost': 0.5})],
                 ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
             )
 
@@ -120,7 +120,7 @@ class TestContributionFrom:
                 timesteps=ts(3),
                 carriers=[Carrier('elec')],
                 effects=[
-                    Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                    Effect('cost', contribution_from={'co2': 50}),
                     Effect('co2', unit='kg', contribution_from={'cost': 0.01}),
                 ],
                 ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
@@ -141,7 +141,7 @@ class TestContributionFrom:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('cost', contribution_from={'co2': 50}),
                 Effect('co2', unit='kg'),
             ],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
@@ -169,7 +169,7 @@ class TestContributionFrom:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('cost', contribution_from={'co2': 50}),
                 Effect('co2', unit='kg'),
             ],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
@@ -195,7 +195,7 @@ class TestContributionFrom:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('cost', contribution_from={'co2': 50}),
                 Effect('co2', unit='kg', contribution_from={'pe': 0.3}),  # 0.3 kg_CO2/kWh_PE
                 Effect('pe', unit='kWh'),
             ],
@@ -229,7 +229,6 @@ class TestContributionFrom:
             effects=[
                 Effect(
                     'cost',
-                    is_objective=True,
                     contribution_from={'co2': carbon_prices},  # time-varying
                 ),
                 Effect('co2', unit='kg'),
@@ -258,7 +257,7 @@ class TestContributionFrom:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('cost', contribution_from={'co2': 50}),
                 Effect('co2', unit='kg'),
             ],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
@@ -292,7 +291,7 @@ class TestContributionFrom:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('cost', contribution_from={'co2': 50}),
                 Effect('co2', unit='kg', contribution_from={'pe': 0.3}),
                 Effect('pe', unit='kWh'),
             ],

--- a/tests/math/test_effects.py
+++ b/tests/math/test_effects.py
@@ -18,6 +18,7 @@ class TestEffects:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source_flow]), Port('demand', exports=[sink_flow])],
         )
 
@@ -42,6 +43,7 @@ class TestEffects:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[Effect('cost'), Effect('co2', unit='kg')],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source_flow]), Port('demand', exports=[sink_flow])],
         )
 
@@ -66,6 +68,7 @@ class TestEffects:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[Effect('cost'), Effect('co2', maximum=co2_limit)],
+            objective_effects='cost',
             ports=[
                 Port('cheap_src', imports=[cheap_dirty]),
                 Port('clean_src', imports=[expensive_clean]),
@@ -87,6 +90,7 @@ class TestEffects:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source_flow]), Port('demand', exports=[sink_flow])],
         )
 
@@ -106,6 +110,7 @@ class TestContributionFrom:
                 timesteps=ts(3),
                 carriers=[Carrier('elec')],
                 effects=[Effect('cost', contribution_from={'cost': 0.5})],
+                objective_effects='cost',
                 ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
             )
 
@@ -123,6 +128,7 @@ class TestContributionFrom:
                     Effect('cost', contribution_from={'co2': 50}),
                     Effect('co2', unit='kg', contribution_from={'cost': 0.01}),
                 ],
+                objective_effects='cost',
                 ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
             )
 
@@ -144,6 +150,7 @@ class TestContributionFrom:
                 Effect('cost', contribution_from={'co2': 50}),
                 Effect('co2', unit='kg'),
             ],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
@@ -172,6 +179,7 @@ class TestContributionFrom:
                 Effect('cost', contribution_from={'co2': 50}),
                 Effect('co2', unit='kg'),
             ],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
@@ -199,6 +207,7 @@ class TestContributionFrom:
                 Effect('co2', unit='kg', contribution_from={'pe': 0.3}),  # 0.3 kg_CO2/kWh_PE
                 Effect('pe', unit='kWh'),
             ],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
@@ -233,6 +242,7 @@ class TestContributionFrom:
                 ),
                 Effect('co2', unit='kg'),
             ],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
@@ -260,6 +270,7 @@ class TestContributionFrom:
                 Effect('cost', contribution_from={'co2': 50}),
                 Effect('co2', unit='kg'),
             ],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 
@@ -295,6 +306,7 @@ class TestContributionFrom:
                 Effect('co2', unit='kg', contribution_from={'pe': 0.3}),
                 Effect('pe', unit='kWh'),
             ],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
 

--- a/tests/math/test_effects.py
+++ b/tests/math/test_effects.py
@@ -53,7 +53,7 @@ class TestEffects:
         co2_total = float(result.effect_totals.sel(effect='co2').values)
         assert co2_total == pytest.approx(expected_co2, abs=1e-6)
 
-    def test_effect_maximum_total(self):
+    def test_effect_maximum(self):
         """Effect max_total constraint limits total emissions."""
 
         sink_flow = Flow('elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])
@@ -65,7 +65,7 @@ class TestEffects:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True), Effect('co2', maximum_total=co2_limit)],
+            effects=[Effect('cost', is_objective=True), Effect('co2', maximum=co2_limit)],
             ports=[
                 Port('cheap_src', imports=[cheap_dirty]),
                 Port('clean_src', imports=[expensive_clean]),

--- a/tests/math/test_end_to_end.py
+++ b/tests/math/test_end_to_end.py
@@ -31,7 +31,7 @@ class TestEndToEnd:
         result = optimize(
             timesteps=ts(4),
             carriers=[Carrier('gas'), Carrier('heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('grid', imports=[gas_source]),
                 Port('demand', exports=[demand_flow]),
@@ -67,7 +67,7 @@ class TestEndToEnd:
         result = optimize(
             timesteps=ts(4),
             carriers=[Carrier('gas'), Carrier('heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('grid', imports=[gas_source]),
                 Port('demand', exports=[demand_flow]),
@@ -89,7 +89,7 @@ class TestEndToEnd:
         data = ModelData.build(
             ts(3),
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('grid', imports=[source_flow]), Port('demand', exports=[sink_flow])],
         )
 
@@ -113,7 +113,7 @@ class TestEndToEnd:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('grid', imports=[source_flow]), Port('demand', exports=[sink_flow])],
         )
 
@@ -145,7 +145,7 @@ class TestEndToEnd:
         result = optimize(
             timesteps=timesteps,
             carriers=[Carrier('gas'), Carrier('heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('grid', imports=[gas_source]),
                 Port('demand', exports=[demand_flow]),

--- a/tests/math/test_end_to_end.py
+++ b/tests/math/test_end_to_end.py
@@ -32,6 +32,7 @@ class TestEndToEnd:
             timesteps=ts(4),
             carriers=[Carrier('gas'), Carrier('heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('grid', imports=[gas_source]),
                 Port('demand', exports=[demand_flow]),
@@ -68,6 +69,7 @@ class TestEndToEnd:
             timesteps=ts(4),
             carriers=[Carrier('gas'), Carrier('heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('grid', imports=[gas_source]),
                 Port('demand', exports=[demand_flow]),
@@ -97,8 +99,7 @@ class TestEndToEnd:
         data.flows.fixed_profile.loc[{'flow': 'demand(elec)'}] = 0.7
 
         model = FlowSystem(data)
-        model.build()
-        result = model.solve()
+        result = model.optimize(objective_effects='cost')
 
         source_rates = result.flow_rate('grid(elec)').values
         for rate in source_rates:
@@ -114,6 +115,7 @@ class TestEndToEnd:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source_flow]), Port('demand', exports=[sink_flow])],
         )
 
@@ -146,6 +148,7 @@ class TestEndToEnd:
             timesteps=timesteps,
             carriers=[Carrier('gas'), Carrier('heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('grid', imports=[gas_source]),
                 Port('demand', exports=[demand_flow]),

--- a/tests/math/test_end_to_end.py
+++ b/tests/math/test_end_to_end.py
@@ -129,8 +129,8 @@ class TestEndToEnd:
         assert 'effect' in result.effects_temporal.dims
         assert 'time' in result.effects_temporal.dims
 
-        # effects_periodic
-        assert 'effect' in result.effects_periodic.dims
+        # effects_lump
+        assert 'effect' in result.effects_lump.dims
 
     def test_int_timesteps(self):
         """Smoke test: int timesteps work end-to-end."""

--- a/tests/math/test_math.py
+++ b/tests/math/test_math.py
@@ -279,6 +279,117 @@ class TestEffects:
         assert_allclose(co2, 25.0, rtol=1e-5)
         assert_allclose(result.objective, 25.0, rtol=1e-5)
 
+    def test_effect_maximum_per_period(self):
+        """CO2 maximum_per_period=8 caps each period independently.
+
+        2 periods (weights=1), demand=10 per ts. Per-period: Dirty<=8 (CO2 cap),
+        Clean>=12. cost per period = 8+60 = 68. Objective = 2*68 = 136.
+        """
+        from fluxopt import Carrier, Effect, Flow, Port, optimize
+
+        result = optimize(
+            ts(2),
+            carriers=[Carrier('Heat')],
+            effects=[Effect('cost'), Effect('CO2', maximum_per_period=8)],
+            objective_effects='cost',
+            ports=[
+                Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10, 10])]),
+                Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'cost': 1, 'CO2': 1})]),
+                Port('Clean', imports=[Flow('Heat', effects_per_flow_hour={'cost': 5, 'CO2': 0})]),
+            ],
+            periods=[2020, 2025],
+            period_weights=[1, 1],
+        )
+        # Each period: total demand 20, Dirty<=8, Clean=12. cost = 8 + 60 = 68 per period.
+        assert_allclose(result.objective, 136.0, rtol=1e-5)
+
+    def test_effect_minimum_per_period(self):
+        """CO2 minimum_per_period=15 forces minimum emission each period.
+
+        2 periods (weights=1), demand=5 per ts. Each period needs >=15 CO2.
+        Dirty >= 15 per period, demand = 10 per period -> 5 excess to waste.
+        cost = 15 per period, total = 30.
+        """
+        from fluxopt import Carrier, Effect, Flow, Port, optimize
+
+        result = optimize(
+            ts(2),
+            carriers=[Carrier('Heat')],
+            effects=[Effect('cost'), Effect('CO2', minimum_per_period=15)],
+            objective_effects='cost',
+            ports=[
+                Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[5, 5])]),
+                Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'cost': 1, 'CO2': 1})]),
+                waste('Heat'),
+            ],
+            periods=[2020, 2025],
+            period_weights=[1, 1],
+        )
+        assert_allclose(result.objective, 30.0, rtol=1e-5)
+
+    def test_effect_maximum_multi_period_weighted(self):
+        """maximum bound across multi-period uses period_weights for the weighted sum.
+
+        2 periods, weights=[1,1], Effect.maximum=20. 3 timesteps x demand=5 per period.
+        Total CO2 cap = 1*co2[0] + 1*co2[1] <= 20.
+        Per-period demand = 15 → all Dirty would give CO2=15 per period, sum=30.
+        Capped at 20: Dirty=20 total, Clean=10. cost = 20*1 + 10*5 = 70.
+        """
+        from fluxopt import Carrier, Effect, Flow, Port, optimize
+
+        result = optimize(
+            ts(3),
+            carriers=[Carrier('Heat')],
+            effects=[Effect('cost'), Effect('CO2', maximum=20)],
+            objective_effects='cost',
+            ports=[
+                Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[5, 5, 5])]),
+                Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'cost': 1, 'CO2': 1})]),
+                Port('Clean', imports=[Flow('Heat', effects_per_flow_hour={'cost': 5, 'CO2': 0})]),
+            ],
+            periods=[2020, 2025],
+            period_weights=[1, 1],
+        )
+        co2 = float(result.effect_totals.sel(effect='CO2').sum().item())
+        # Total CO2 (weighted by [1,1]) <= 20.
+        assert co2 <= 20 + 1e-5
+        assert_allclose(result.objective, 70.0, rtol=1e-5)
+
+    def test_effect_time_varying_contribution_warns(self):
+        """Time-varying contribution_from with non-trivial lump warns about mean('time')."""
+        import warnings
+
+        from fluxopt import Carrier, Effect, Flow, Port, Sizing, optimize
+
+        # Sizing on the source creates a non-trivial lump contribution to co2.
+        # Time-varying contribution_from on cost causes the warning.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            optimize(
+                ts(2),
+                carriers=[Carrier('Heat')],
+                effects=[
+                    Effect('cost', contribution_from={'co2': [1.0, 2.0]}),
+                    Effect('co2'),
+                ],
+                objective_effects='cost',
+                ports=[
+                    Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[5, 5])]),
+                    Port(
+                        'Source',
+                        imports=[
+                            Flow(
+                                'Heat',
+                                effects_per_flow_hour={'co2': 1},
+                                size=Sizing(min_size=10, max_size=10, mandatory=True, effects_per_size={'co2': 1.0}),
+                            ),
+                        ],
+                    ),
+                ],
+            )
+        msgs = [str(w.message) for w in caught]
+        assert any('averaged over time' in m for m in msgs), f'Expected warning, got: {msgs}'
+
 
 # ---------------------------------------------------------------------------
 # Flow constraints

--- a/tests/math/test_math.py
+++ b/tests/math/test_math.py
@@ -38,6 +38,7 @@ class TestBusBalance:
             ts(2),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[30, 30])]),
                 Port('Src1', imports=[Flow('Heat', effects_per_flow_hour={'cost': 1}, size=20)]),
@@ -69,6 +70,7 @@ class TestConversionEfficiency:
             ts(3),
             carriers=[Carrier('Gas'), Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10, 20, 10])]),
                 Port('GasSrc', imports=[Flow('Gas', effects_per_flow_hour={'cost': 1})]),
@@ -89,6 +91,7 @@ class TestConversionEfficiency:
             ts(2),
             carriers=[Carrier('Gas'), Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10, 10])]),
                 Port('GasSrc', imports=[Flow('Gas', effects_per_flow_hour={'cost': 1})]),
@@ -111,6 +114,7 @@ class TestConversionEfficiency:
             ts(2),
             carriers=[Carrier('Gas'), Carrier('Heat'), Carrier('Elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('HeatDemand', exports=[Flow('Heat', size=1, fixed_relative_profile=[50, 50])]),
                 Port('ElecGrid', exports=[Flow('Elec', effects_per_flow_hour={'cost': -2})]),
@@ -137,6 +141,7 @@ class TestEffects:
             ts(2),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost'), Effect('CO2')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10, 20])]),
                 Port('HeatSrc', imports=[Flow('Heat', effects_per_flow_hour={'cost': 2, 'CO2': 0.5})]),
@@ -156,6 +161,7 @@ class TestEffects:
             ts(2),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost'), Effect('CO2', maximum=15)],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10, 10])]),
                 Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'cost': 1, 'CO2': 1})]),
@@ -176,6 +182,7 @@ class TestEffects:
             ts(2),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost'), Effect('CO2', minimum=25)],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10, 10])]),
                 Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'cost': 1, 'CO2': 1})]),
@@ -198,6 +205,7 @@ class TestEffects:
             ts(2),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost'), Effect('CO2', maximum_per_hour=8)],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[15, 5])]),
                 Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'cost': 1, 'CO2': 1})]),
@@ -217,6 +225,7 @@ class TestEffects:
             ts(2),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost'), Effect('CO2', minimum_per_hour=10)],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[5, 5])]),
                 Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'cost': 1, 'CO2': 1})]),
@@ -238,6 +247,7 @@ class TestEffects:
             ts(2),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost'), Effect('CO2', maximum=12)],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10, 10])]),
                 Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'cost': 1, 'CO2': 1})]),
@@ -258,6 +268,7 @@ class TestEffects:
             ts(2),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost'), Effect('CO2', minimum=25)],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10, 10])]),
                 Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'cost': 1, 'CO2': 1})]),
@@ -288,6 +299,7 @@ class TestFlowConstraints:
             ts(2),
             carriers=[Carrier('Gas'), Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[30, 30])]),
                 Port('GasSrc', imports=[Flow('Gas', effects_per_flow_hour={'cost': 1})]),
@@ -309,6 +321,7 @@ class TestFlowConstraints:
             ts(2),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[60, 60])]),
                 Port(
@@ -340,6 +353,7 @@ class TestStorage:
             ts(3),
             carriers=[Carrier('Elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Elec', size=1, fixed_relative_profile=[0, 0, 20])]),
                 Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'cost': [10, 1, 10]})]),
@@ -371,6 +385,7 @@ class TestStorage:
             ts(2),
             carriers=[Carrier('Elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Elec', size=1, fixed_relative_profile=[0, 90])]),
                 Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'cost': [1, 1000]})]),
@@ -403,6 +418,7 @@ class TestStorage:
             ts(2),
             carriers=[Carrier('Elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Elec', size=1, fixed_relative_profile=[0, 72])]),
                 Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'cost': [1, 1000]})]),
@@ -434,6 +450,7 @@ class TestStorage:
             ts(2),
             carriers=[Carrier('Elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Elec', size=1, fixed_relative_profile=[0, 60])]),
                 Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'cost': [1, 100]})]),
@@ -466,6 +483,7 @@ class TestStorage:
             ts(2),
             carriers=[Carrier('Elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Elec', size=1, fixed_relative_profile=[0, 50])]),
                 Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'cost': [1, 100]})]),
@@ -497,6 +515,7 @@ class TestStorage:
             ts(3),
             carriers=[Carrier('Elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Elec', size=1, fixed_relative_profile=[0, 80, 0])]),
                 Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'cost': [1, 100, 1]})]),

--- a/tests/math/test_math.py
+++ b/tests/math/test_math.py
@@ -8,7 +8,7 @@ API mapping (flixopt -> fluxopt):
     fx.Source('name', outputs=[...])     -> Port('name', imports=[...])
     fx.Sink('name', inputs=[...])        -> Port('name', exports=[...])
     fx.Flow('label', bus=..., ...)       -> Flow(carrier, ...)
-    effects_per_flow_hour=<scalar>       -> effects_per_flow_hour={'costs': <scalar>}
+    effects_per_flow_hour=<scalar>       -> effects_per_flow_hour={'cost': <scalar>}
     capacity_in_flow_hours=X             -> capacity=X
     initial_charge_state='equals_final'  -> cyclic=True
     imbalance_penalty_per_flow_hour=0    -> waste Port (absorbs excess at zero cost)
@@ -37,11 +37,11 @@ class TestBusBalance:
         result = optimize(
             ts(2),
             carriers=[Carrier('Heat')],
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[30, 30])]),
-                Port('Src1', imports=[Flow('Heat', effects_per_flow_hour={'costs': 1}, size=20)]),
-                Port('Src2', imports=[Flow('Heat', effects_per_flow_hour={'costs': 2}, size=20)]),
+                Port('Src1', imports=[Flow('Heat', effects_per_flow_hour={'cost': 1}, size=20)]),
+                Port('Src2', imports=[Flow('Heat', effects_per_flow_hour={'cost': 2}, size=20)]),
             ],
         )
         assert_allclose(result.objective, 80.0, rtol=1e-5)
@@ -68,10 +68,10 @@ class TestConversionEfficiency:
         result = optimize(
             ts(3),
             carriers=[Carrier('Gas'), Carrier('Heat')],
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10, 20, 10])]),
-                Port('GasSrc', imports=[Flow('Gas', effects_per_flow_hour={'costs': 1})]),
+                Port('GasSrc', imports=[Flow('Gas', effects_per_flow_hour={'cost': 1})]),
             ],
             converters=[Converter.boiler('Boiler', 0.8, fuel, thermal)],
         )
@@ -88,10 +88,10 @@ class TestConversionEfficiency:
         result = optimize(
             ts(2),
             carriers=[Carrier('Gas'), Carrier('Heat')],
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10, 10])]),
-                Port('GasSrc', imports=[Flow('Gas', effects_per_flow_hour={'costs': 1})]),
+                Port('GasSrc', imports=[Flow('Gas', effects_per_flow_hour={'cost': 1})]),
             ],
             converters=[Converter.boiler('Boiler', [0.5, 1.0], fuel, thermal)],
         )
@@ -110,11 +110,11 @@ class TestConversionEfficiency:
         result = optimize(
             ts(2),
             carriers=[Carrier('Gas'), Carrier('Heat'), Carrier('Elec')],
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('HeatDemand', exports=[Flow('Heat', size=1, fixed_relative_profile=[50, 50])]),
-                Port('ElecGrid', exports=[Flow('Elec', effects_per_flow_hour={'costs': -2})]),
-                Port('GasSrc', imports=[Flow('Gas', effects_per_flow_hour={'costs': 1})]),
+                Port('ElecGrid', exports=[Flow('Elec', effects_per_flow_hour={'cost': -2})]),
+                Port('GasSrc', imports=[Flow('Gas', effects_per_flow_hour={'cost': 1})]),
             ],
             converters=[Converter.chp('CHP', 0.4, 0.5, fuel, electrical, thermal)],
         )
@@ -136,10 +136,10 @@ class TestEffects:
         result = optimize(
             ts(2),
             carriers=[Carrier('Heat')],
-            effects=[Effect('costs', is_objective=True), Effect('CO2')],
+            effects=[Effect('cost'), Effect('CO2')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10, 20])]),
-                Port('HeatSrc', imports=[Flow('Heat', effects_per_flow_hour={'costs': 2, 'CO2': 0.5})]),
+                Port('HeatSrc', imports=[Flow('Heat', effects_per_flow_hour={'cost': 2, 'CO2': 0.5})]),
             ],
         )
         assert_allclose(result.objective, 60.0, rtol=1e-5)
@@ -155,11 +155,11 @@ class TestEffects:
         result = optimize(
             ts(2),
             carriers=[Carrier('Heat')],
-            effects=[Effect('costs', is_objective=True), Effect('CO2', maximum=15)],
+            effects=[Effect('cost'), Effect('CO2', maximum=15)],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10, 10])]),
-                Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'costs': 1, 'CO2': 1})]),
-                Port('Clean', imports=[Flow('Heat', effects_per_flow_hour={'costs': 10, 'CO2': 0})]),
+                Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'cost': 1, 'CO2': 1})]),
+                Port('Clean', imports=[Flow('Heat', effects_per_flow_hour={'cost': 10, 'CO2': 0})]),
             ],
         )
         assert_allclose(result.objective, 65.0, rtol=1e-5)
@@ -175,11 +175,11 @@ class TestEffects:
         result = optimize(
             ts(2),
             carriers=[Carrier('Heat')],
-            effects=[Effect('costs', is_objective=True), Effect('CO2', minimum=25)],
+            effects=[Effect('cost'), Effect('CO2', minimum=25)],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10, 10])]),
-                Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'costs': 1, 'CO2': 1})]),
-                Port('Clean', imports=[Flow('Heat', effects_per_flow_hour={'costs': 1, 'CO2': 0})]),
+                Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'cost': 1, 'CO2': 1})]),
+                Port('Clean', imports=[Flow('Heat', effects_per_flow_hour={'cost': 1, 'CO2': 0})]),
                 waste('Heat'),
             ],
         )
@@ -197,11 +197,11 @@ class TestEffects:
         result = optimize(
             ts(2),
             carriers=[Carrier('Heat')],
-            effects=[Effect('costs', is_objective=True), Effect('CO2', maximum_per_hour=8)],
+            effects=[Effect('cost'), Effect('CO2', maximum_per_hour=8)],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[15, 5])]),
-                Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'costs': 1, 'CO2': 1})]),
-                Port('Clean', imports=[Flow('Heat', effects_per_flow_hour={'costs': 5, 'CO2': 0})]),
+                Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'cost': 1, 'CO2': 1})]),
+                Port('Clean', imports=[Flow('Heat', effects_per_flow_hour={'cost': 5, 'CO2': 0})]),
             ],
         )
         assert_allclose(result.objective, 48.0, rtol=1e-5)
@@ -216,10 +216,10 @@ class TestEffects:
         result = optimize(
             ts(2),
             carriers=[Carrier('Heat')],
-            effects=[Effect('costs', is_objective=True), Effect('CO2', minimum_per_hour=10)],
+            effects=[Effect('cost'), Effect('CO2', minimum_per_hour=10)],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[5, 5])]),
-                Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'costs': 1, 'CO2': 1})]),
+                Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'cost': 1, 'CO2': 1})]),
                 waste('Heat'),
             ],
         )
@@ -237,11 +237,11 @@ class TestEffects:
         result = optimize(
             ts(2),
             carriers=[Carrier('Heat')],
-            effects=[Effect('costs', is_objective=True), Effect('CO2', maximum=12)],
+            effects=[Effect('cost'), Effect('CO2', maximum=12)],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10, 10])]),
-                Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'costs': 1, 'CO2': 1})]),
-                Port('Clean', imports=[Flow('Heat', effects_per_flow_hour={'costs': 5, 'CO2': 0})]),
+                Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'cost': 1, 'CO2': 1})]),
+                Port('Clean', imports=[Flow('Heat', effects_per_flow_hour={'cost': 5, 'CO2': 0})]),
             ],
         )
         assert_allclose(result.objective, 52.0, rtol=1e-5)
@@ -257,10 +257,10 @@ class TestEffects:
         result = optimize(
             ts(2),
             carriers=[Carrier('Heat')],
-            effects=[Effect('costs', is_objective=True), Effect('CO2', minimum=25)],
+            effects=[Effect('cost'), Effect('CO2', minimum=25)],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10, 10])]),
-                Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'costs': 1, 'CO2': 1})]),
+                Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'cost': 1, 'CO2': 1})]),
                 waste('Heat'),
             ],
         )
@@ -287,10 +287,10 @@ class TestFlowConstraints:
         result = optimize(
             ts(2),
             carriers=[Carrier('Gas'), Carrier('Heat')],
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[30, 30])]),
-                Port('GasSrc', imports=[Flow('Gas', effects_per_flow_hour={'costs': 1})]),
+                Port('GasSrc', imports=[Flow('Gas', effects_per_flow_hour={'cost': 1})]),
                 waste('Heat'),
             ],
             converters=[Converter.boiler('Boiler', 1.0, fuel, thermal)],
@@ -308,14 +308,14 @@ class TestFlowConstraints:
         result = optimize(
             ts(2),
             carriers=[Carrier('Heat')],
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[60, 60])]),
                 Port(
                     'CheapSrc',
-                    imports=[Flow('Heat', size=100, relative_maximum=0.5, effects_per_flow_hour={'costs': 1})],
+                    imports=[Flow('Heat', size=100, relative_maximum=0.5, effects_per_flow_hour={'cost': 1})],
                 ),
-                Port('ExpensiveSrc', imports=[Flow('Heat', effects_per_flow_hour={'costs': 5})]),
+                Port('ExpensiveSrc', imports=[Flow('Heat', effects_per_flow_hour={'cost': 5})]),
             ],
         )
         assert_allclose(result.objective, 200.0, rtol=1e-5)
@@ -339,10 +339,10 @@ class TestStorage:
         result = optimize(
             ts(3),
             carriers=[Carrier('Elec')],
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Elec', size=1, fixed_relative_profile=[0, 0, 20])]),
-                Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'costs': [10, 1, 10]})]),
+                Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'cost': [10, 1, 10]})]),
             ],
             storages=[
                 Storage(
@@ -370,10 +370,10 @@ class TestStorage:
         result = optimize(
             ts(2),
             carriers=[Carrier('Elec')],
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Elec', size=1, fixed_relative_profile=[0, 90])]),
-                Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'costs': [1, 1000]})]),
+                Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'cost': [1, 1000]})]),
             ],
             storages=[
                 Storage(
@@ -402,10 +402,10 @@ class TestStorage:
         result = optimize(
             ts(2),
             carriers=[Carrier('Elec')],
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Elec', size=1, fixed_relative_profile=[0, 72])]),
-                Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'costs': [1, 1000]})]),
+                Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'cost': [1, 1000]})]),
             ],
             storages=[
                 Storage(
@@ -433,10 +433,10 @@ class TestStorage:
         result = optimize(
             ts(2),
             carriers=[Carrier('Elec')],
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Elec', size=1, fixed_relative_profile=[0, 60])]),
-                Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'costs': [1, 100]})]),
+                Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'cost': [1, 100]})]),
             ],
             storages=[
                 Storage(
@@ -465,10 +465,10 @@ class TestStorage:
         result = optimize(
             ts(2),
             carriers=[Carrier('Elec')],
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Elec', size=1, fixed_relative_profile=[0, 50])]),
-                Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'costs': [1, 100]})]),
+                Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'cost': [1, 100]})]),
             ],
             storages=[
                 Storage(
@@ -496,10 +496,10 @@ class TestStorage:
         result = optimize(
             ts(3),
             carriers=[Carrier('Elec')],
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Elec', size=1, fixed_relative_profile=[0, 80, 0])]),
-                Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'costs': [1, 100, 1]})]),
+                Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'cost': [1, 100, 1]})]),
             ],
             storages=[
                 Storage(

--- a/tests/math/test_math.py
+++ b/tests/math/test_math.py
@@ -146,7 +146,7 @@ class TestEffects:
         co2 = float(result.effect_totals.sel(effect='CO2').values)
         assert_allclose(co2, 15.0, rtol=1e-5)
 
-    def test_effect_maximum_total(self):
+    def test_effect_maximum(self):
         """CO2 capped at 15. Dirty: 1EUR+1kgCO2/kWh. Clean: 10EUR+0kgCO2.
         Demand=20. Split: 15 Dirty + 5 Clean -> cost=65.
 
@@ -155,7 +155,7 @@ class TestEffects:
         result = optimize(
             ts(2),
             carriers=[Carrier('Heat')],
-            effects=[Effect('costs', is_objective=True), Effect('CO2', maximum_total=15)],
+            effects=[Effect('costs', is_objective=True), Effect('CO2', maximum=15)],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10, 10])]),
                 Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'costs': 1, 'CO2': 1})]),
@@ -166,16 +166,16 @@ class TestEffects:
         co2 = float(result.effect_totals.sel(effect='CO2').values)
         assert_allclose(co2, 15.0, rtol=1e-5)
 
-    def test_effect_minimum_total(self):
+    def test_effect_minimum(self):
         """CO2 floor at 25. Dirty: 1EUR+1kgCO2. Demand=20. Must overproduce.
         Dirty=25 (5 excess absorbed by waste port). cost=25.
 
-        Sensitivity: Without minimum_total, Dirty=20 -> cost=20.
+        Sensitivity: Without minimum, Dirty=20 -> cost=20.
         """
         result = optimize(
             ts(2),
             carriers=[Carrier('Heat')],
-            effects=[Effect('costs', is_objective=True), Effect('CO2', minimum_total=25)],
+            effects=[Effect('costs', is_objective=True), Effect('CO2', minimum=25)],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10, 10])]),
                 Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'costs': 1, 'CO2': 1})]),
@@ -228,7 +228,7 @@ class TestEffects:
         assert_allclose(co2, 20.0, rtol=1e-5)
 
     def test_effect_maximum_temporal(self):
-        """CO2 maximum_total=12 (= maximum_temporal when no periodic effects).
+        """CO2 maximum=12 (= maximum_temporal when no periodic effects).
         Dirty: 1EUR+1kgCO2. Clean: 5EUR+0kgCO2. Demand=[10,10].
         Dirty=12, Clean=8 -> cost=52.
 
@@ -237,7 +237,7 @@ class TestEffects:
         result = optimize(
             ts(2),
             carriers=[Carrier('Heat')],
-            effects=[Effect('costs', is_objective=True), Effect('CO2', maximum_total=12)],
+            effects=[Effect('costs', is_objective=True), Effect('CO2', maximum=12)],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10, 10])]),
                 Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'costs': 1, 'CO2': 1})]),
@@ -249,7 +249,7 @@ class TestEffects:
         assert_allclose(co2, 12.0, rtol=1e-5)
 
     def test_effect_minimum_temporal(self):
-        """CO2 minimum_total=25 (= minimum_temporal). Dirty: 1EUR+1kgCO2.
+        """CO2 minimum=25 (= minimum_temporal). Dirty: 1EUR+1kgCO2.
         Demand=[10,10]. Dirty >=25 -> 5 excess. cost=25.
 
         Sensitivity: Without floor, Dirty=20 -> cost=20.
@@ -257,7 +257,7 @@ class TestEffects:
         result = optimize(
             ts(2),
             carriers=[Carrier('Heat')],
-            effects=[Effect('costs', is_objective=True), Effect('CO2', minimum_total=25)],
+            effects=[Effect('costs', is_objective=True), Effect('CO2', minimum=25)],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10, 10])]),
                 Port('Dirty', imports=[Flow('Heat', effects_per_flow_hour={'costs': 1, 'CO2': 1})]),

--- a/tests/math/test_math.py
+++ b/tests/math/test_math.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from conftest import ts, waste
 from numpy.testing import assert_allclose
 
-from fluxopt import Carrier, Converter, Effect, Flow, Port, Storage, optimize
+from fluxopt import Carrier, Converter, Effect, Flow, Port, Sizing, Storage, optimize
 
 # ---------------------------------------------------------------------------
 # Bus balance & dispatch
@@ -285,7 +285,6 @@ class TestEffects:
         2 periods (weights=1), demand=10 per ts. Per-period: Dirty<=8 (CO2 cap),
         Clean>=12. cost per period = 8+60 = 68. Objective = 2*68 = 136.
         """
-        from fluxopt import Carrier, Effect, Flow, Port, optimize
 
         result = optimize(
             ts(2),
@@ -310,7 +309,6 @@ class TestEffects:
         Dirty >= 15 per period, demand = 10 per period -> 5 excess to waste.
         cost = 15 per period, total = 30.
         """
-        from fluxopt import Carrier, Effect, Flow, Port, optimize
 
         result = optimize(
             ts(2),
@@ -335,7 +333,6 @@ class TestEffects:
         Per-period demand = 15 → all Dirty would give CO2=15 per period, sum=30.
         Capped at 20: Dirty=20 total, Clean=10. cost = 20*1 + 10*5 = 70.
         """
-        from fluxopt import Carrier, Effect, Flow, Port, optimize
 
         result = optimize(
             ts(3),
@@ -358,8 +355,6 @@ class TestEffects:
     def test_effect_time_varying_contribution_warns(self):
         """Time-varying contribution_from with non-trivial lump warns about mean('time')."""
         import warnings
-
-        from fluxopt import Carrier, Effect, Flow, Port, Sizing, optimize
 
         # Sizing on the source creates a non-trivial lump contribution to co2.
         # Time-varying contribution_from on cost causes the warning.

--- a/tests/math/test_sizing.py
+++ b/tests/math/test_sizing.py
@@ -26,6 +26,7 @@ class TestFlowSizing:
             ts(2),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[50, 50])]),
                 Port(
@@ -58,6 +59,7 @@ class TestFlowSizing:
             ts(2),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[50, 50])]),
                 Port(
@@ -89,6 +91,7 @@ class TestFlowSizing:
             ts(2),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[50, 50])]),
                 Port(
@@ -120,6 +123,7 @@ class TestFlowSizing:
             ts(2),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[50, 50])]),
                 Port(
@@ -148,6 +152,7 @@ class TestFlowSizing:
             ts(2),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[25, 50])]),
                 Port(
@@ -179,6 +184,7 @@ class TestFlowSizing:
             ts(2),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[60, 60])]),
                 Port(
@@ -222,6 +228,7 @@ class TestStorageSizing:
             ts(3),
             carriers=_elec,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Elec', size=1, fixed_relative_profile=[0, 50, 0])]),
                 Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'cost': [1, 10, 1]})]),

--- a/tests/math/test_sizing.py
+++ b/tests/math/test_sizing.py
@@ -25,7 +25,7 @@ class TestFlowSizing:
         result = optimize(
             ts(2),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[50, 50])]),
                 Port(
@@ -34,7 +34,7 @@ class TestFlowSizing:
                         Flow(
                             'Heat',
                             size=Sizing(10, 200, mandatory=True),
-                            effects_per_flow_hour={'costs': 1},
+                            effects_per_flow_hour={'cost': 1},
                         )
                     ],
                 ),
@@ -47,7 +47,7 @@ class TestFlowSizing:
     def test_optional_sizing_with_fixed_cost(self):
         """Optional invest with fixed cost.
 
-        Src: Sizing(10, 100, effects_fixed={'costs': 200}), 1€/MWh operational.
+        Src: Sizing(10, 100, effects_fixed={'cost': 200}), 1€/MWh operational.
         Backup: 5€/MWh, unsized.
         Demand = 50/ts * 2ts.
 
@@ -57,7 +57,7 @@ class TestFlowSizing:
         result = optimize(
             ts(2),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[50, 50])]),
                 Port(
@@ -65,12 +65,12 @@ class TestFlowSizing:
                     imports=[
                         Flow(
                             'Heat',
-                            size=Sizing(10, 100, mandatory=False, effects_fixed={'costs': 200}),
-                            effects_per_flow_hour={'costs': 1},
+                            size=Sizing(10, 100, mandatory=False, effects_fixed={'cost': 200}),
+                            effects_per_flow_hour={'cost': 1},
                         )
                     ],
                 ),
-                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'costs': 5})]),
+                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'cost': 5})]),
             ],
         )
         assert_allclose(result.objective, 300.0, rtol=1e-5)
@@ -78,7 +78,7 @@ class TestFlowSizing:
         assert_allclose(indicator, 1.0, atol=1e-5)
 
     def test_fixed_size_binary_invest(self):
-        """Binary invest at fixed size: Sizing(80, 80, effects_fixed={'costs': 10}).
+        """Binary invest at fixed size: Sizing(80, 80, effects_fixed={'cost': 10}).
 
         Demand=50. Src operational=1€/MWh. Backup=2€/MWh.
         With invest: 10 + 50*1*2 = 110.
@@ -88,7 +88,7 @@ class TestFlowSizing:
         result = optimize(
             ts(2),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[50, 50])]),
                 Port(
@@ -96,12 +96,12 @@ class TestFlowSizing:
                     imports=[
                         Flow(
                             'Heat',
-                            size=Sizing(80, 80, mandatory=False, effects_fixed={'costs': 10}),
-                            effects_per_flow_hour={'costs': 1},
+                            size=Sizing(80, 80, mandatory=False, effects_fixed={'cost': 10}),
+                            effects_per_flow_hour={'cost': 1},
                         )
                     ],
                 ),
-                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'costs': 2})]),
+                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'cost': 2})]),
             ],
         )
         assert_allclose(result.objective, 110.0, rtol=1e-5)
@@ -111,7 +111,7 @@ class TestFlowSizing:
     def test_per_size_effects(self):
         """Per-size investment cost.
 
-        Sizing(0, 200, mandatory=True, effects_per_size={'costs': 5}).
+        Sizing(0, 200, mandatory=True, effects_per_size={'cost': 5}).
         Demand=50/ts * 2ts. Operational=1€/MWh.
         Total = 5*size + 50*1*2. Solver minimizes → size=50.
         Total = 5*50 + 100 = 350.
@@ -119,7 +119,7 @@ class TestFlowSizing:
         result = optimize(
             ts(2),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[50, 50])]),
                 Port(
@@ -127,8 +127,8 @@ class TestFlowSizing:
                     imports=[
                         Flow(
                             'Heat',
-                            size=Sizing(0, 200, mandatory=True, effects_per_size={'costs': 5}),
-                            effects_per_flow_hour={'costs': 1},
+                            size=Sizing(0, 200, mandatory=True, effects_per_size={'cost': 5}),
+                            effects_per_flow_hour={'cost': 1},
                         )
                     ],
                 ),
@@ -147,7 +147,7 @@ class TestFlowSizing:
         result = optimize(
             ts(2),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[25, 50])]),
                 Port(
@@ -157,7 +157,7 @@ class TestFlowSizing:
                             'Heat',
                             size=Sizing(0, 200, mandatory=True),
                             fixed_relative_profile=[0.5, 1.0],
-                            effects_per_flow_hour={'costs': 1},
+                            effects_per_flow_hour={'cost': 1},
                         )
                     ],
                 ),
@@ -170,15 +170,15 @@ class TestFlowSizing:
     def test_multiple_investable_merit_order(self):
         """Two investable sources with per-size cost, merit order picks cheapest.
 
-        Cheap: Sizing(0, 100, mandatory=True, effects_per_size={'costs': 0.01}), 1€/MWh.
-        Expensive: Sizing(0, 100, mandatory=True, effects_per_size={'costs': 0.01}), 5€/MWh.
+        Cheap: Sizing(0, 100, mandatory=True, effects_per_size={'cost': 0.01}), 1€/MWh.
+        Expensive: Sizing(0, 100, mandatory=True, effects_per_size={'cost': 0.01}), 5€/MWh.
         Demand=60. Cheap covers all → size=60, operational=120, invest=0.6 → total=120.6.
         Per-size cost incentivizes minimal size.
         """
         result = optimize(
             ts(2),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[60, 60])]),
                 Port(
@@ -186,8 +186,8 @@ class TestFlowSizing:
                     imports=[
                         Flow(
                             'Heat',
-                            size=Sizing(0, 100, mandatory=True, effects_per_size={'costs': 0.01}),
-                            effects_per_flow_hour={'costs': 1},
+                            size=Sizing(0, 100, mandatory=True, effects_per_size={'cost': 0.01}),
+                            effects_per_flow_hour={'cost': 1},
                         )
                     ],
                 ),
@@ -196,8 +196,8 @@ class TestFlowSizing:
                     imports=[
                         Flow(
                             'Heat',
-                            size=Sizing(0, 100, mandatory=True, effects_per_size={'costs': 0.01}),
-                            effects_per_flow_hour={'costs': 5},
+                            size=Sizing(0, 100, mandatory=True, effects_per_size={'cost': 0.01}),
+                            effects_per_flow_hour={'cost': 5},
                         )
                     ],
                 ),
@@ -221,10 +221,10 @@ class TestStorageSizing:
         result = optimize(
             ts(3),
             carriers=_elec,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Elec', size=1, fixed_relative_profile=[0, 50, 0])]),
-                Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'costs': [1, 10, 1]})]),
+                Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'cost': [1, 10, 1]})]),
             ],
             storages=[
                 Storage(

--- a/tests/math/test_stats.py
+++ b/tests/math/test_stats.py
@@ -14,7 +14,7 @@ class TestFlowHours:
         result = optimize(
             timesteps=ts(3),
             carriers=_elec,
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('grid', imports=[Flow('elec', size=200, effects_per_flow_hour={'cost': 0.04})]),
                 Port('demand', exports=[Flow('elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])]),
@@ -28,7 +28,7 @@ class TestFlowHours:
         result = optimize(
             timesteps=ts(3),
             carriers=_elec,
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('grid', imports=[Flow('elec', size=200, effects_per_flow_hour={'cost': 0.04})]),
                 Port('demand', exports=[Flow('elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])]),
@@ -44,7 +44,7 @@ class TestCaching:
         result = optimize(
             timesteps=ts(3),
             carriers=_elec,
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('grid', imports=[Flow('elec', size=100, effects_per_flow_hour={'cost': 0.04})]),
                 Port('demand', exports=[Flow('elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])]),

--- a/tests/math/test_stats.py
+++ b/tests/math/test_stats.py
@@ -15,6 +15,7 @@ class TestFlowHours:
             timesteps=ts(3),
             carriers=_elec,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('grid', imports=[Flow('elec', size=200, effects_per_flow_hour={'cost': 0.04})]),
                 Port('demand', exports=[Flow('elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])]),
@@ -29,6 +30,7 @@ class TestFlowHours:
             timesteps=ts(3),
             carriers=_elec,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('grid', imports=[Flow('elec', size=200, effects_per_flow_hour={'cost': 0.04})]),
                 Port('demand', exports=[Flow('elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])]),
@@ -45,6 +47,7 @@ class TestCaching:
             timesteps=ts(3),
             carriers=_elec,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('grid', imports=[Flow('elec', size=100, effects_per_flow_hour={'cost': 0.04})]),
                 Port('demand', exports=[Flow('elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])]),

--- a/tests/math/test_status.py
+++ b/tests/math/test_status.py
@@ -35,6 +35,7 @@ class TestSemiContinuous:
             ts(3),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[30, 60, 0])]),
                 Port(
@@ -84,6 +85,7 @@ class TestSemiContinuous:
             ts(2),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10, 80])]),
                 Port(
@@ -120,6 +122,7 @@ class TestStartupCosts:
             ts(2),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[60, 60])]),
                 Port(
@@ -155,6 +158,7 @@ class TestStartupCosts:
             ts(3),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[80, 0, 80])]),
                 Port(
@@ -198,6 +202,7 @@ class TestPrior:
             ts(2),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[50, 50])]),
                 Port(
@@ -233,6 +238,7 @@ class TestPrior:
             ts(3),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[80, 0, 0])]),
                 Port(
@@ -272,6 +278,7 @@ class TestPrior:
             ts(3),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[80, 80, 80])]),
                 Port(
@@ -310,6 +317,7 @@ class TestPrior:
             ts(2),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[50, 50])]),
                 Port(
@@ -348,6 +356,7 @@ class TestStatusSizing:
             ts(3),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[30, 80, 0])]),
                 Port(
@@ -403,6 +412,7 @@ class TestStatusSizing:
             ts(2),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[5, 50])]),
                 Port(
@@ -447,6 +457,7 @@ class TestStatusSizing:
             ts(3),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10] * 3)]),
                 Port(
@@ -490,6 +501,7 @@ class TestStatusSizing:
             ts(3),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[50] * 3)]),
                 Port(
@@ -534,6 +546,7 @@ class TestStatusSizing:
             ts(4),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[80, 0, 0, 80])]),
                 Port(
@@ -586,6 +599,7 @@ class TestMaxUptime:
             ts(5),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10] * 5)]),
                 Port(
@@ -631,6 +645,7 @@ class TestMaxDowntime:
             ts(4),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10] * 4)]),
                 Port(
@@ -675,6 +690,7 @@ class TestDurationCombinations:
             ts(5),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[5, 10, 20, 18, 12])]),
                 Port(
@@ -713,6 +729,7 @@ class TestDurationCombinations:
             ts(6),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[20] * 6)]),
                 Port(
@@ -758,6 +775,7 @@ class TestDurationCombinations:
             ts(5),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10] * 5)]),
                 Port(
@@ -804,6 +822,7 @@ class TestDurationCombinations:
             ts(5),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10] * 5)]),
                 Port(
@@ -849,6 +868,7 @@ class TestDurationCombinations:
             ts(4),
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10] * 4)]),
                 Port(
@@ -904,6 +924,7 @@ class TestDurationCombinations:
             half_hour_ts,
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[80] * 8)]),
                 Port(
@@ -944,6 +965,7 @@ class TestDurationCombinations:
             half_hour_ts,
             carriers=_heat,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10] * 6)]),
                 Port(

--- a/tests/math/test_status.py
+++ b/tests/math/test_status.py
@@ -34,7 +34,7 @@ class TestSemiContinuous:
         result = optimize(
             ts(3),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[30, 60, 0])]),
                 Port(
@@ -44,12 +44,12 @@ class TestSemiContinuous:
                             'Heat',
                             size=100,
                             relative_minimum=0.5,
-                            effects_per_flow_hour={'costs': 1},
+                            effects_per_flow_hour={'cost': 1},
                             status=Status(),
                         )
                     ],
                 ),
-                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'costs': 10})]),
+                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'cost': 10})]),
                 waste('Heat'),
             ],
         )
@@ -83,7 +83,7 @@ class TestSemiContinuous:
         result = optimize(
             ts(2),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10, 80])]),
                 Port(
@@ -93,12 +93,12 @@ class TestSemiContinuous:
                             'Heat',
                             size=100,
                             relative_minimum=0.4,
-                            effects_per_flow_hour={'costs': 1},
+                            effects_per_flow_hour={'cost': 1},
                             status=Status(),
                         )
                     ],
                 ),
-                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'costs': 0.5})]),
+                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'cost': 0.5})]),
             ],
         )
         assert_allclose(result.objective, 45.0, rtol=1e-5)
@@ -110,7 +110,7 @@ class TestStartupCosts:
     def test_startup_cost_added_to_objective(self):
         """Startup cost is charged per event.
 
-        Source: size=100, prior_rates=[0] (was off), effects_per_startup={'costs': 50}, 1€/MWh.
+        Source: size=100, prior_rates=[0] (was off), effects_per_startup={'cost': 50}, 1€/MWh.
         Demand: [60, 60] (constant). No backup.
 
         Source runs both hours: 1 startup event at t=0 (was off).
@@ -119,7 +119,7 @@ class TestStartupCosts:
         result = optimize(
             ts(2),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[60, 60])]),
                 Port(
@@ -129,8 +129,8 @@ class TestStartupCosts:
                             'Heat',
                             size=100,
                             relative_minimum=0.1,
-                            effects_per_flow_hour={'costs': 1},
-                            status=Status(effects_per_startup={'costs': 50}),
+                            effects_per_flow_hour={'cost': 1},
+                            status=Status(effects_per_startup={'cost': 50}),
                             prior_rates=[0],
                         )
                     ],
@@ -143,7 +143,7 @@ class TestStartupCosts:
         """High startup cost keeps unit running rather than cycling.
 
         Source: size=100, rel_min=0.3, prior_rates=[0] (was off),
-                Status(effects_per_startup={'costs': 200}), 0.1€/MWh.
+                Status(effects_per_startup={'cost': 200}), 0.1€/MWh.
         Backup: 5€/MWh.
         Demand: [80, 0, 80].
 
@@ -154,7 +154,7 @@ class TestStartupCosts:
         result = optimize(
             ts(3),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[80, 0, 80])]),
                 Port(
@@ -164,13 +164,13 @@ class TestStartupCosts:
                             'Heat',
                             size=100,
                             relative_minimum=0.3,
-                            effects_per_flow_hour={'costs': 0.1},
-                            status=Status(effects_per_startup={'costs': 200}),
+                            effects_per_flow_hour={'cost': 0.1},
+                            status=Status(effects_per_startup={'cost': 200}),
                             prior_rates=[0],
                         )
                     ],
                 ),
-                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'costs': 5})]),
+                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'cost': 5})]),
                 waste('Heat'),
             ],
         )
@@ -187,7 +187,7 @@ class TestPrior:
     def test_prior_none_gives_free_initial(self):
         """Flow.prior=None with Status() leaves initial state free.
 
-        Source: size=100, Status(effects_per_startup={'costs': 1000}), no prior.
+        Source: size=100, Status(effects_per_startup={'cost': 1000}), no prior.
         Demand: [50, 50]. No backup, so source must run.
 
         Solver is free to assume on at t=-1 (no startup cost) or off (startup cost).
@@ -197,7 +197,7 @@ class TestPrior:
         result = optimize(
             ts(2),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[50, 50])]),
                 Port(
@@ -207,7 +207,7 @@ class TestPrior:
                             'Heat',
                             size=100,
                             relative_minimum=0.1,
-                            status=Status(effects_per_startup={'costs': 1000}),
+                            status=Status(effects_per_startup={'cost': 1000}),
                         )
                     ],
                 ),
@@ -232,7 +232,7 @@ class TestPrior:
         result = optimize(
             ts(3),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[80, 0, 0])]),
                 Port(
@@ -242,13 +242,13 @@ class TestPrior:
                             'Heat',
                             size=100,
                             relative_minimum=0.1,
-                            effects_per_flow_hour={'costs': 1},
+                            effects_per_flow_hour={'cost': 1},
                             status=Status(min_uptime=3),
                             prior_rates=[50, 60],
                         )
                     ],
                 ),
-                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'costs': 0.5})]),
+                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'cost': 0.5})]),
                 waste('Heat'),
             ],
         )
@@ -271,7 +271,7 @@ class TestPrior:
         result = optimize(
             ts(3),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[80, 80, 80])]),
                 Port(
@@ -281,13 +281,13 @@ class TestPrior:
                             'Heat',
                             size=100,
                             relative_minimum=0.1,
-                            effects_per_flow_hour={'costs': 1},
+                            effects_per_flow_hour={'cost': 1},
                             status=Status(min_downtime=3),
                             prior_rates=[0, 0],
                         )
                     ],
                 ),
-                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'costs': 10})]),
+                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'cost': 10})]),
             ],
         )
         on = result.solution['flow--on'].sel(flow='Src(Heat)').values
@@ -300,7 +300,7 @@ class TestPrior:
     def test_running_cost_per_hour(self):
         """Running cost is charged per hour the unit is on.
 
-        Source: size=100, Status(effects_per_running_hour={'costs': 10}), 1€/MWh.
+        Source: size=100, Status(effects_per_running_hour={'cost': 10}), 1€/MWh.
         Demand: [50, 50].
 
         Operational: 50*1*2 = 100. Running: 10*1*2 = 20.
@@ -309,7 +309,7 @@ class TestPrior:
         result = optimize(
             ts(2),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[50, 50])]),
                 Port(
@@ -319,8 +319,8 @@ class TestPrior:
                             'Heat',
                             size=100,
                             relative_minimum=0.1,
-                            effects_per_flow_hour={'costs': 1},
-                            status=Status(effects_per_running_hour={'costs': 10}),
+                            effects_per_flow_hour={'cost': 1},
+                            status=Status(effects_per_running_hour={'cost': 10}),
                         )
                     ],
                 ),
@@ -347,7 +347,7 @@ class TestStatusSizing:
         result = optimize(
             ts(3),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[30, 80, 0])]),
                 Port(
@@ -357,12 +357,12 @@ class TestStatusSizing:
                             'Heat',
                             size=Sizing(20, 200, mandatory=True),
                             relative_minimum=0.5,
-                            effects_per_flow_hour={'costs': 1},
+                            effects_per_flow_hour={'cost': 1},
                             status=Status(),
                         )
                     ],
                 ),
-                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'costs': 10})]),
+                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'cost': 10})]),
                 waste('Heat'),
             ],
         )
@@ -386,7 +386,7 @@ class TestStatusSizing:
     def test_sizing_rel_min_forces_off_at_low_demand(self):
         """Sizing + Status + relative_minimum forces off when demand < min_load.
 
-        Src: Sizing(0, 100, mandatory=True, effects_per_size={'costs': 0.5}),
+        Src: Sizing(0, 100, mandatory=True, effects_per_size={'cost': 0.5}),
              rel_min=0.5, Status(), 1€/MWh.
         Backup: 10€/MWh.
         Demand: [5, 50].
@@ -402,7 +402,7 @@ class TestStatusSizing:
         result = optimize(
             ts(2),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[5, 50])]),
                 Port(
@@ -410,14 +410,14 @@ class TestStatusSizing:
                     imports=[
                         Flow(
                             'Heat',
-                            size=Sizing(0, 100, mandatory=True, effects_per_size={'costs': 0.5}),
+                            size=Sizing(0, 100, mandatory=True, effects_per_size={'cost': 0.5}),
                             relative_minimum=0.5,
-                            effects_per_flow_hour={'costs': 1},
+                            effects_per_flow_hour={'cost': 1},
                             status=Status(),
                         )
                     ],
                 ),
-                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'costs': 10})]),
+                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'cost': 10})]),
             ],
         )
         size = float(result.sizes.sel(flow='Src(Heat)').values)
@@ -433,7 +433,7 @@ class TestStatusSizing:
     def test_optional_sizing_not_invested_means_off(self):
         """Optional Sizing + Status: if not invested, on=0 and flow rate=0.
 
-        Src: Sizing(50, 100, mandatory=False, effects_fixed={'costs': 1000}),
+        Src: Sizing(50, 100, mandatory=False, effects_fixed={'cost': 1000}),
              Status(), 1€/MWh. High fixed cost discourages investment.
         Backup: 2€/MWh.
         Demand: [10]*3.
@@ -446,7 +446,7 @@ class TestStatusSizing:
         result = optimize(
             ts(3),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10] * 3)]),
                 Port(
@@ -454,14 +454,14 @@ class TestStatusSizing:
                     imports=[
                         Flow(
                             'Heat',
-                            size=Sizing(50, 100, mandatory=False, effects_fixed={'costs': 1000}),
+                            size=Sizing(50, 100, mandatory=False, effects_fixed={'cost': 1000}),
                             relative_minimum=0.1,
-                            effects_per_flow_hour={'costs': 1},
+                            effects_per_flow_hour={'cost': 1},
                             status=Status(),
                         )
                     ],
                 ),
-                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'costs': 2})]),
+                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'cost': 2})]),
             ],
         )
         indicator = float(result.solution['flow--size_indicator'].sel(flow='Src(Heat)').values)
@@ -478,7 +478,7 @@ class TestStatusSizing:
     def test_sizing_with_startup_costs(self):
         """Sizing + Status + startup cost: invest decision includes startup penalty.
 
-        Src: Sizing(0, 200, mandatory=True), Status(effects_per_startup={'costs': 100}),
+        Src: Sizing(0, 200, mandatory=True), Status(effects_per_startup={'cost': 100}),
              prior_rates=[0], 1€/MWh.
         Backup: 5€/MWh.
         Demand: [50, 50, 50].
@@ -489,7 +489,7 @@ class TestStatusSizing:
         result = optimize(
             ts(3),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[50] * 3)]),
                 Port(
@@ -499,13 +499,13 @@ class TestStatusSizing:
                             'Heat',
                             size=Sizing(0, 200, mandatory=True),
                             relative_minimum=0.1,
-                            effects_per_flow_hour={'costs': 1},
-                            status=Status(effects_per_startup={'costs': 100}),
+                            effects_per_flow_hour={'cost': 1},
+                            status=Status(effects_per_startup={'cost': 100}),
                             prior_rates=[0],
                         )
                     ],
                 ),
-                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'costs': 5})]),
+                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'cost': 5})]),
             ],
         )
         startup = result.solution['flow--startup'].sel(flow='Src(Heat)').values
@@ -533,7 +533,7 @@ class TestStatusSizing:
         result = optimize(
             ts(4),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[80, 0, 0, 80])]),
                 Port(
@@ -543,13 +543,13 @@ class TestStatusSizing:
                             'Heat',
                             size=Sizing(0, 200, mandatory=True),
                             relative_minimum=0.3,
-                            effects_per_flow_hour={'costs': 1},
+                            effects_per_flow_hour={'cost': 1},
                             status=Status(min_uptime=3),
                             prior_rates=[0],
                         )
                     ],
                 ),
-                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'costs': 0.5})]),
+                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'cost': 0.5})]),
                 waste('Heat'),
             ],
         )
@@ -585,7 +585,7 @@ class TestMaxUptime:
         result = optimize(
             ts(5),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10] * 5)]),
                 Port(
@@ -595,13 +595,13 @@ class TestMaxUptime:
                             'Heat',
                             size=100,
                             relative_minimum=0.1,
-                            effects_per_flow_hour={'costs': 1},
+                            effects_per_flow_hour={'cost': 1},
                             status=Status(max_uptime=2),
                             prior_rates=[0],
                         )
                     ],
                 ),
-                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'costs': 10})]),
+                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'cost': 10})]),
             ],
         )
         on = result.solution['flow--on'].sel(flow='Src(Heat)').values
@@ -630,7 +630,7 @@ class TestMaxDowntime:
         result = optimize(
             ts(4),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10] * 4)]),
                 Port(
@@ -640,13 +640,13 @@ class TestMaxDowntime:
                             'Heat',
                             size=100,
                             relative_minimum=0.5,
-                            effects_per_flow_hour={'costs': 10},
+                            effects_per_flow_hour={'cost': 10},
                             status=Status(max_downtime=1),
                             prior_rates=[10],
                         )
                     ],
                 ),
-                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'costs': 1})]),
+                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'cost': 1})]),
                 waste('Heat'),
             ],
         )
@@ -674,7 +674,7 @@ class TestDurationCombinations:
         result = optimize(
             ts(5),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[5, 10, 20, 18, 12])]),
                 Port(
@@ -684,13 +684,13 @@ class TestDurationCombinations:
                             'Heat',
                             size=100,
                             relative_minimum=0.01,
-                            effects_per_flow_hour={'costs': 1},
+                            effects_per_flow_hour={'cost': 1},
                             status=Status(min_uptime=2, max_uptime=2),
                             prior_rates=[0],
                         )
                     ],
                 ),
-                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'costs': 5})]),
+                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'cost': 5})]),
             ],
         )
         on = result.solution['flow--on'].sel(flow='Src(Heat)').values
@@ -712,7 +712,7 @@ class TestDurationCombinations:
         result = optimize(
             ts(6),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[20] * 6)]),
                 Port(
@@ -722,13 +722,13 @@ class TestDurationCombinations:
                             'Heat',
                             size=100,
                             relative_minimum=0.1,
-                            effects_per_flow_hour={'costs': 1},
+                            effects_per_flow_hour={'cost': 1},
                             status=Status(min_uptime=2, min_downtime=2),
                             prior_rates=[0],
                         )
                     ],
                 ),
-                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'costs': 5})]),
+                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'cost': 5})]),
                 waste('Heat'),
             ],
         )
@@ -757,7 +757,7 @@ class TestDurationCombinations:
         result = optimize(
             ts(5),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10] * 5)]),
                 Port(
@@ -767,13 +767,13 @@ class TestDurationCombinations:
                             'Heat',
                             size=100,
                             relative_minimum=0.1,
-                            effects_per_flow_hour={'costs': 1},
+                            effects_per_flow_hour={'cost': 1},
                             status=Status(max_uptime=3),
                             prior_rates=[50, 50],
                         )
                     ],
                 ),
-                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'costs': 10})]),
+                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'cost': 10})]),
             ],
         )
         on = result.solution['flow--on'].sel(flow='Src(Heat)').values
@@ -790,7 +790,7 @@ class TestDurationCombinations:
     def test_max_uptime_with_startup_costs(self):
         """max_uptime forces shutdowns which incur startup costs on restart.
 
-        Src: size=100, Status(max_uptime=2, effects_per_startup={'costs': 50}),
+        Src: size=100, Status(max_uptime=2, effects_per_startup={'cost': 50}),
              prior_rates=[0], 1€/MWh.
         Backup: 10€/MWh.
         Demand: [10]*5.
@@ -803,7 +803,7 @@ class TestDurationCombinations:
         result = optimize(
             ts(5),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10] * 5)]),
                 Port(
@@ -813,13 +813,13 @@ class TestDurationCombinations:
                             'Heat',
                             size=100,
                             relative_minimum=0.1,
-                            effects_per_flow_hour={'costs': 1},
-                            status=Status(max_uptime=2, effects_per_startup={'costs': 50}),
+                            effects_per_flow_hour={'cost': 1},
+                            status=Status(max_uptime=2, effects_per_startup={'cost': 50}),
                             prior_rates=[0],
                         )
                     ],
                 ),
-                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'costs': 10})]),
+                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'cost': 10})]),
             ],
         )
         on = result.solution['flow--on'].sel(flow='Src(Heat)').values
@@ -848,7 +848,7 @@ class TestDurationCombinations:
         result = optimize(
             ts(4),
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10] * 4)]),
                 Port(
@@ -858,13 +858,13 @@ class TestDurationCombinations:
                             'Heat',
                             size=100,
                             relative_minimum=0.5,
-                            effects_per_flow_hour={'costs': 10},
+                            effects_per_flow_hour={'cost': 10},
                             status=Status(max_downtime=2),
                             prior_rates=[0, 0],
                         )
                     ],
                 ),
-                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'costs': 1})]),
+                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'cost': 1})]),
                 waste('Heat'),
             ],
         )
@@ -903,7 +903,7 @@ class TestDurationCombinations:
         result = optimize(
             half_hour_ts,
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[80] * 8)]),
                 Port(
@@ -913,13 +913,13 @@ class TestDurationCombinations:
                             'Heat',
                             size=100,
                             relative_minimum=0.1,
-                            effects_per_flow_hour={'costs': 1},
+                            effects_per_flow_hour={'cost': 1},
                             status=Status(min_uptime=2),
                             prior_rates=[0],
                         )
                     ],
                 ),
-                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'costs': 5})]),
+                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'cost': 5})]),
             ],
         )
         on = result.solution['flow--on'].sel(flow='Src(Heat)').values
@@ -943,7 +943,7 @@ class TestDurationCombinations:
         result = optimize(
             half_hour_ts,
             carriers=_heat,
-            effects=[Effect('costs', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[10] * 6)]),
                 Port(
@@ -953,13 +953,13 @@ class TestDurationCombinations:
                             'Heat',
                             size=100,
                             relative_minimum=0.1,
-                            effects_per_flow_hour={'costs': 1},
+                            effects_per_flow_hour={'cost': 1},
                             status=Status(max_uptime=1),
                             prior_rates=[0],
                         )
                     ],
                 ),
-                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'costs': 10})]),
+                Port('Backup', imports=[Flow('Heat', effects_per_flow_hour={'cost': 10})]),
             ],
         )
         on = result.solution['flow--on'].sel(flow='Src(Heat)').values

--- a/tests/math/test_storage.py
+++ b/tests/math/test_storage.py
@@ -24,6 +24,7 @@ class TestStorage:
             timesteps=ts(4),
             carriers=_elec,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source_flow]), Port('demand', exports=[demand_flow])],
             storages=[battery],
         )
@@ -63,6 +64,7 @@ class TestStorage:
             timesteps=ts(4),
             carriers=_elec,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source_flow]), Port('demand', exports=[demand_flow])],
             storages=[battery],
         )
@@ -94,6 +96,7 @@ class TestStorage:
             timesteps=ts(2),
             carriers=_elec,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source_flow]), Port('demand', exports=[demand_flow])],
             storages=[battery],
         )
@@ -131,6 +134,7 @@ class TestStorage:
             timesteps=ts(3),
             carriers=_elec,
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source_flow]), Port('demand', exports=[demand_flow])],
             storages=[battery],
         )

--- a/tests/math/test_storage.py
+++ b/tests/math/test_storage.py
@@ -23,7 +23,7 @@ class TestStorage:
         result = optimize(
             timesteps=ts(4),
             carriers=_elec,
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('grid', imports=[source_flow]), Port('demand', exports=[demand_flow])],
             storages=[battery],
         )
@@ -62,7 +62,7 @@ class TestStorage:
         result = optimize(
             timesteps=ts(4),
             carriers=_elec,
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('grid', imports=[source_flow]), Port('demand', exports=[demand_flow])],
             storages=[battery],
         )
@@ -93,7 +93,7 @@ class TestStorage:
         result = optimize(
             timesteps=ts(2),
             carriers=_elec,
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('grid', imports=[source_flow]), Port('demand', exports=[demand_flow])],
             storages=[battery],
         )
@@ -130,7 +130,7 @@ class TestStorage:
         result = optimize(
             timesteps=ts(3),
             carriers=_elec,
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('grid', imports=[source_flow]), Port('demand', exports=[demand_flow])],
             storages=[battery],
         )

--- a/tests/math_port/conftest.py
+++ b/tests/math_port/conftest.py
@@ -37,8 +37,9 @@ def optimize(request, tmp_path):
     """Callable fixture: each test runs 3 pipelines to verify IO roundtrip."""
 
     def _optimize(**kwargs: Any) -> Result:
+        objective = kwargs.pop('objective', 'cost')
         if request.param == 'optimize':
-            return fluxopt_optimize(**kwargs)
+            return fluxopt_optimize(**kwargs, objective=objective)
         if request.param == 'save->reload->optimize':
             data = ModelData.build(
                 kwargs['timesteps'],
@@ -55,10 +56,9 @@ def optimize(request, tmp_path):
             data.to_netcdf(path, mode='w')
             loaded = ModelData.from_netcdf(path)
             model = FlowSystem(loaded)
-            model.build()
-            return model.solve()
+            return model.optimize(objective=objective)
         # optimize->save->reload->validate
-        result = fluxopt_optimize(**kwargs)
+        result = fluxopt_optimize(**kwargs, objective=objective)
         path = tmp_path / 'result.nc'
         result.to_netcdf(path)
         loaded = Result.from_netcdf(path)

--- a/tests/math_port/conftest.py
+++ b/tests/math_port/conftest.py
@@ -37,9 +37,9 @@ def optimize(request, tmp_path):
     """Callable fixture: each test runs 3 pipelines to verify IO roundtrip."""
 
     def _optimize(**kwargs: Any) -> Result:
-        objective = kwargs.pop('objective', 'cost')
+        objective_effects = kwargs.pop('objective_effects', 'cost')
         if request.param == 'optimize':
-            return fluxopt_optimize(**kwargs, objective=objective)
+            return fluxopt_optimize(**kwargs, objective_effects=objective_effects)
         if request.param == 'save->reload->optimize':
             data = ModelData.build(
                 kwargs['timesteps'],
@@ -56,9 +56,9 @@ def optimize(request, tmp_path):
             data.to_netcdf(path, mode='w')
             loaded = ModelData.from_netcdf(path)
             model = FlowSystem(loaded)
-            return model.optimize(objective=objective)
+            return model.optimize(objective_effects=objective_effects)
         # optimize->save->reload->validate
-        result = fluxopt_optimize(**kwargs, objective=objective)
+        result = fluxopt_optimize(**kwargs, objective_effects=objective_effects)
         path = tmp_path / 'result.nc'
         result.to_netcdf(path)
         loaded = Result.from_netcdf(path)

--- a/tests/math_port/test_bus.py
+++ b/tests/math_port/test_bus.py
@@ -14,7 +14,7 @@ class TestCarrierBalance:
         result = optimize(
             timesteps=ts(2),
             carriers=[Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -52,7 +52,7 @@ class TestMultiNodeBalance:
         result = optimize(
             timesteps=ts(2),
             carriers=[Carrier('heat', nodes=['A', 'B'])],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('cheap_a', imports=[Flow('heat', node='A', size=100, effects_per_flow_hour={'cost': 1})]),
                 Port('cheap_b', imports=[Flow('heat', node='B', size=100, effects_per_flow_hour={'cost': 1})]),
@@ -73,7 +73,7 @@ class TestMultiNodeBalance:
         result = optimize(
             timesteps=ts(2),
             carriers=[Carrier('heat', nodes=['A', 'B'])],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('cheap_a', imports=[Flow('heat', node='A', size=200, effects_per_flow_hour={'cost': 1})]),
                 Port('exp_b', imports=[Flow('heat', node='B', size=200, effects_per_flow_hour={'cost': 10})]),
@@ -91,7 +91,7 @@ class TestMultiNodeBalance:
         result = optimize(
             timesteps=ts(2),
             carriers=[Carrier('elec'), Carrier('heat', nodes=['A', 'B'])],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 # Electricity: single-node
                 Port('grid', imports=[Flow('elec', size=200, effects_per_flow_hour={'cost': 0.1})]),

--- a/tests/math_port/test_bus.py
+++ b/tests/math_port/test_bus.py
@@ -15,6 +15,7 @@ class TestCarrierBalance:
             timesteps=ts(2),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -53,6 +54,7 @@ class TestMultiNodeBalance:
             timesteps=ts(2),
             carriers=[Carrier('heat', nodes=['A', 'B'])],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('cheap_a', imports=[Flow('heat', node='A', size=100, effects_per_flow_hour={'cost': 1})]),
                 Port('cheap_b', imports=[Flow('heat', node='B', size=100, effects_per_flow_hour={'cost': 1})]),
@@ -74,6 +76,7 @@ class TestMultiNodeBalance:
             timesteps=ts(2),
             carriers=[Carrier('heat', nodes=['A', 'B'])],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('cheap_a', imports=[Flow('heat', node='A', size=200, effects_per_flow_hour={'cost': 1})]),
                 Port('exp_b', imports=[Flow('heat', node='B', size=200, effects_per_flow_hour={'cost': 10})]),
@@ -92,6 +95,7 @@ class TestMultiNodeBalance:
             timesteps=ts(2),
             carriers=[Carrier('elec'), Carrier('heat', nodes=['A', 'B'])],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 # Electricity: single-node
                 Port('grid', imports=[Flow('elec', size=200, effects_per_flow_hour={'cost': 0.1})]),

--- a/tests/math_port/test_combinations.py
+++ b/tests/math_port/test_combinations.py
@@ -80,7 +80,7 @@ class TestStatusWithEffects:
         result = optimize(
             timesteps=ts(4),
             effects=[
-                Effect('cost', is_objective=True),
+                Effect('cost'),
                 Effect('CO2', maximum=60),
             ],
             ports=[
@@ -133,7 +133,7 @@ class TestStatusWithEffects:
         result = optimize(
             timesteps=ts(2),
             effects=[
-                Effect('cost', is_objective=True),
+                Effect('cost'),
                 Effect('CO2'),
             ],
             ports=[
@@ -182,7 +182,7 @@ class TestInvestWithRelativeMinimum:
 
         result = optimize(
             timesteps=ts(2),
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -245,7 +245,7 @@ class TestConversionWithTimeVaryingEffects:
         result = optimize(
             timesteps=ts(2),
             carriers=[Carrier('Gas'), Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -285,7 +285,7 @@ class TestConversionWithTimeVaryingEffects:
         result = optimize(
             timesteps=ts(2),
             effects=[
-                Effect('cost', is_objective=True),
+                Effect('cost'),
                 Effect('CO2'),
             ],
             ports=[
@@ -352,7 +352,7 @@ class TestStatusWithMultipleConstraints:
 
         result = optimize(
             timesteps=ts(6),
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -422,7 +422,7 @@ class TestEffectsWithConversion:
         result = optimize(
             timesteps=ts(4),
             effects=[
-                Effect('cost', is_objective=True),
+                Effect('cost'),
                 Effect('CO2', maximum=20),
             ],
             ports=[

--- a/tests/math_port/test_combinations.py
+++ b/tests/math_port/test_combinations.py
@@ -70,7 +70,7 @@ class TestStatusWithEffects:
         """Proves: effects_per_startup can contribute to a non-cost effect (CO2),
         and that this correctly interacts with effect constraints.
 
-        CO2 capped at maximum_total=60. Boiler startup emits 50kg CO2.
+        CO2 capped at maximum=60. Boiler startup emits 50kg CO2.
         Demand=[0,20,0,20] → 2 startups = 100kg CO2. Exceeds cap!
         Optimizer must reduce startups by keeping boiler running continuously.
 
@@ -81,7 +81,7 @@ class TestStatusWithEffects:
             timesteps=ts(4),
             effects=[
                 Effect('cost', is_objective=True),
-                Effect('CO2', maximum_total=60),
+                Effect('CO2', maximum=60),
             ],
             ports=[
                 Port(
@@ -409,10 +409,10 @@ class TestEffectsWithConversion:
         """Proves: share_from_periodic works correctly with investment costs."""
 
     def test_effect_maximum_with_status_contribution(self, optimize):
-        """Proves: Effect maximum_total correctly accounts for contributions from
+        """Proves: Effect maximum correctly accounts for contributions from
         StatusParameters (effects_per_startup) when constraining.
 
-        CO2 has maximum_total=20. Boiler startup emits 15 kg CO2.
+        CO2 has maximum=20. Boiler startup emits 15 kg CO2.
         Fuel emits 0.1 kg CO2/kWh. Demand=[0,10,0,10].
         2 startups = 30 kg CO2 (exceeds cap). Forced to 1 startup.
 
@@ -423,7 +423,7 @@ class TestEffectsWithConversion:
             timesteps=ts(4),
             effects=[
                 Effect('cost', is_objective=True),
-                Effect('CO2', maximum_total=20),
+                Effect('CO2', maximum=20),
             ],
             ports=[
                 Port(

--- a/tests/math_port/test_combinations.py
+++ b/tests/math_port/test_combinations.py
@@ -83,6 +83,7 @@ class TestStatusWithEffects:
                 Effect('cost'),
                 Effect('CO2', maximum=60),
             ],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -136,6 +137,7 @@ class TestStatusWithEffects:
                 Effect('cost'),
                 Effect('CO2'),
             ],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -183,6 +185,7 @@ class TestInvestWithRelativeMinimum:
         result = optimize(
             timesteps=ts(2),
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -246,6 +249,7 @@ class TestConversionWithTimeVaryingEffects:
             timesteps=ts(2),
             carriers=[Carrier('Gas'), Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -288,6 +292,7 @@ class TestConversionWithTimeVaryingEffects:
                 Effect('cost'),
                 Effect('CO2'),
             ],
+            objective_effects='cost',
             ports=[
                 Port(
                     'HeatDemand',
@@ -353,6 +358,7 @@ class TestStatusWithMultipleConstraints:
         result = optimize(
             timesteps=ts(6),
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -425,6 +431,7 @@ class TestEffectsWithConversion:
                 Effect('cost'),
                 Effect('CO2', maximum=20),
             ],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',

--- a/tests/math_port/test_components.py
+++ b/tests/math_port/test_components.py
@@ -94,7 +94,7 @@ class TestHeatPump:
         result = optimize(
             timesteps=ts(2),
             carriers=[Carrier('Elec'), Carrier('Env'), Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -126,7 +126,7 @@ class TestHeatPump:
         result = optimize(
             timesteps=ts(2),
             carriers=[Carrier('Elec'), Carrier('Env'), Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',

--- a/tests/math_port/test_components.py
+++ b/tests/math_port/test_components.py
@@ -95,6 +95,7 @@ class TestHeatPump:
             timesteps=ts(2),
             carriers=[Carrier('Elec'), Carrier('Env'), Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -127,6 +128,7 @@ class TestHeatPump:
             timesteps=ts(2),
             carriers=[Carrier('Elec'), Carrier('Env'), Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',

--- a/tests/math_port/test_conversion.py
+++ b/tests/math_port/test_conversion.py
@@ -19,6 +19,7 @@ class TestConversionEfficiency:
             timesteps=ts(3),
             carriers=[Carrier('Gas'), Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -56,6 +57,7 @@ class TestConversionEfficiency:
             timesteps=ts(2),
             carriers=[Carrier('Gas'), Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -94,6 +96,7 @@ class TestConversionEfficiency:
             timesteps=ts(2),
             carriers=[Carrier('Elec'), Carrier('Gas'), Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'HeatDemand',

--- a/tests/math_port/test_conversion.py
+++ b/tests/math_port/test_conversion.py
@@ -18,7 +18,7 @@ class TestConversionEfficiency:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Gas'), Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -55,7 +55,7 @@ class TestConversionEfficiency:
         result = optimize(
             timesteps=ts(2),
             carriers=[Carrier('Gas'), Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -93,7 +93,7 @@ class TestConversionEfficiency:
         result = optimize(
             timesteps=ts(2),
             carriers=[Carrier('Elec'), Carrier('Gas'), Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'HeatDemand',

--- a/tests/math_port/test_effects.py
+++ b/tests/math_port/test_effects.py
@@ -29,7 +29,7 @@ class TestEffects:
             timesteps=ts(2),
             carriers=[Carrier('Heat')],
             effects=[
-                Effect('cost', is_objective=True),
+                Effect('cost'),
                 Effect('CO2'),
             ],
             ports=[
@@ -65,7 +65,7 @@ class TestEffects:
             timesteps=ts(2),
             carriers=[Carrier('Heat')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'CO2': 0.5}),
+                Effect('cost', contribution_from={'CO2': 0.5}),
                 Effect('CO2'),
             ],
             ports=[
@@ -96,7 +96,7 @@ class TestEffects:
             timesteps=ts(2),
             carriers=[Carrier('Heat')],
             effects=[
-                Effect('cost', is_objective=True),
+                Effect('cost'),
                 Effect('CO2', maximum=15),
             ],
             ports=[
@@ -139,7 +139,7 @@ class TestEffects:
             timesteps=ts(2),
             carriers=[Carrier('Heat')],
             effects=[
-                Effect('cost', is_objective=True),
+                Effect('cost'),
                 Effect('CO2', minimum=25),
             ],
             ports=[
@@ -184,7 +184,7 @@ class TestEffects:
             timesteps=ts(2),
             carriers=[Carrier('Heat')],
             effects=[
-                Effect('cost', is_objective=True),
+                Effect('cost'),
                 Effect('CO2', maximum_per_hour=8),
             ],
             ports=[
@@ -226,7 +226,7 @@ class TestEffects:
             timesteps=ts(2),
             carriers=[Carrier('Heat')],
             effects=[
-                Effect('cost', is_objective=True),
+                Effect('cost'),
                 Effect('CO2', minimum_per_hour=10),
             ],
             ports=[
@@ -270,7 +270,7 @@ class TestEffects:
             timesteps=timesteps,
             carriers=[Carrier('Heat')],
             effects=[
-                Effect('cost', is_objective=True),
+                Effect('cost'),
                 Effect('CO2', maximum_per_hour=4),
             ],
             ports=[
@@ -316,7 +316,7 @@ class TestEffects:
             timesteps=timesteps,
             carriers=[Carrier('Heat')],
             effects=[
-                Effect('cost', is_objective=True),
+                Effect('cost'),
                 Effect('CO2', minimum_per_hour=5),
             ],
             ports=[
@@ -381,7 +381,7 @@ class TestEffects:
             timesteps=ts(2),
             carriers=[Carrier('Gas'), Carrier('Heat')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'CO2': 10}),
+                Effect('cost', contribution_from={'CO2': 10}),
                 Effect('CO2'),
             ],
             ports=[

--- a/tests/math_port/test_effects.py
+++ b/tests/math_port/test_effects.py
@@ -82,8 +82,8 @@ class TestEffects:
         assert_allclose(result.effect_totals.sel(effect='cost').item(), 120.0, rtol=1e-5)
         assert_allclose(result.effect_totals.sel(effect='CO2').item(), 200.0, rtol=1e-5)
 
-    def test_effect_maximum_total(self, optimize):
-        """Proves: maximum_total on an effect constrains the optimizer to respect an
+    def test_effect_maximum(self, optimize):
+        """Proves: maximum on an effect constrains the optimizer to respect an
         upper bound on cumulative effect, forcing suboptimal dispatch.
 
         CO2 capped at 15kg. Dirty source: 1€+1kgCO2/kWh. Clean source: 10€+0kgCO2/kWh.
@@ -97,7 +97,7 @@ class TestEffects:
             carriers=[Carrier('Heat')],
             effects=[
                 Effect('cost', is_objective=True),
-                Effect('CO2', maximum_total=15),
+                Effect('CO2', maximum=15),
             ],
             ports=[
                 Port(
@@ -125,22 +125,22 @@ class TestEffects:
         assert_allclose(result.effect_totals.sel(effect='cost').item(), 65.0, rtol=1e-5)
         assert_allclose(result.effect_totals.sel(effect='CO2').item(), 15.0, rtol=1e-5)
 
-    def test_effect_minimum_total(self, optimize):
-        """Proves: minimum_total on an effect forces cumulative effect to reach at least
+    def test_effect_minimum(self, optimize):
+        """Proves: minimum on an effect forces cumulative effect to reach at least
         the specified value, even if it means using a dirtier source.
 
         CO2 floor at 25kg. Dirty source: 1€+1kgCO2/kWh. Clean source: 1€+0kgCO2/kWh.
         Demand=20. Must produce ≥25 CO2 → Dirty ≥ 25 kWh, excess absorbed by dump.
 
-        Sensitivity: Without minimum_total, optimizer could use all Clean → CO2=0.
-        With minimum_total=25, forced to use ≥25 from Dirty → CO2≥25.
+        Sensitivity: Without minimum, optimizer could use all Clean → CO2=0.
+        With minimum=25, forced to use ≥25 from Dirty → CO2≥25.
         """
         result = optimize(
             timesteps=ts(2),
             carriers=[Carrier('Heat')],
             effects=[
                 Effect('cost', is_objective=True),
-                Effect('CO2', minimum_total=25),
+                Effect('CO2', minimum=25),
             ],
             ports=[
                 Port(

--- a/tests/math_port/test_effects.py
+++ b/tests/math_port/test_effects.py
@@ -32,6 +32,7 @@ class TestEffects:
                 Effect('cost'),
                 Effect('CO2'),
             ],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -68,6 +69,7 @@ class TestEffects:
                 Effect('cost', contribution_from={'CO2': 0.5}),
                 Effect('CO2'),
             ],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -99,6 +101,7 @@ class TestEffects:
                 Effect('cost'),
                 Effect('CO2', maximum=15),
             ],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -142,6 +145,7 @@ class TestEffects:
                 Effect('cost'),
                 Effect('CO2', minimum=25),
             ],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -187,6 +191,7 @@ class TestEffects:
                 Effect('cost'),
                 Effect('CO2', maximum_per_hour=8),
             ],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -229,6 +234,7 @@ class TestEffects:
                 Effect('cost'),
                 Effect('CO2', minimum_per_hour=10),
             ],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -273,6 +279,7 @@ class TestEffects:
                 Effect('cost'),
                 Effect('CO2', maximum_per_hour=4),
             ],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -319,6 +326,7 @@ class TestEffects:
                 Effect('cost'),
                 Effect('CO2', minimum_per_hour=5),
             ],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -384,6 +392,7 @@ class TestEffects:
                 Effect('cost', contribution_from={'CO2': 10}),
                 Effect('CO2'),
             ],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',

--- a/tests/math_port/test_flow.py
+++ b/tests/math_port/test_flow.py
@@ -24,7 +24,7 @@ class TestFlowConstraints:
         result = optimize(
             timesteps=ts(2),
             carriers=[Carrier('Gas'), Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -69,7 +69,7 @@ class TestFlowConstraints:
         result = optimize(
             timesteps=ts(2),
             carriers=[Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',

--- a/tests/math_port/test_flow.py
+++ b/tests/math_port/test_flow.py
@@ -25,6 +25,7 @@ class TestFlowConstraints:
             timesteps=ts(2),
             carriers=[Carrier('Gas'), Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -70,6 +71,7 @@ class TestFlowConstraints:
             timesteps=ts(2),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',

--- a/tests/math_port/test_flow_invest.py
+++ b/tests/math_port/test_flow_invest.py
@@ -22,6 +22,7 @@ class TestFlowInvest:
         result = optimize(
             timesteps=ts(3),
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -74,6 +75,7 @@ class TestFlowInvest:
         result = optimize(
             timesteps=ts(2),
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -125,6 +127,7 @@ class TestFlowInvest:
             timesteps=ts(2),
             carriers=[Carrier('Gas'), Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -169,6 +172,7 @@ class TestFlowInvest:
         result = optimize(
             timesteps=ts(2),
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -234,6 +238,7 @@ class TestFlowInvest:
         result = optimize(
             timesteps=ts(2),
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -291,6 +296,7 @@ class TestFlowInvest:
         result = optimize(
             timesteps=ts(2),
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -368,6 +374,7 @@ class TestFlowInvestWithStatus:
         result = optimize(
             timesteps=ts(4),
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -420,6 +427,7 @@ class TestFlowInvestWithStatus:
         result = optimize(
             timesteps=ts(3),
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',

--- a/tests/math_port/test_flow_invest.py
+++ b/tests/math_port/test_flow_invest.py
@@ -21,7 +21,7 @@ class TestFlowInvest:
 
         result = optimize(
             timesteps=ts(3),
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -73,7 +73,7 @@ class TestFlowInvest:
 
         result = optimize(
             timesteps=ts(2),
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -124,7 +124,7 @@ class TestFlowInvest:
         result = optimize(
             timesteps=ts(2),
             carriers=[Carrier('Gas'), Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -168,7 +168,7 @@ class TestFlowInvest:
 
         result = optimize(
             timesteps=ts(2),
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -233,7 +233,7 @@ class TestFlowInvest:
 
         result = optimize(
             timesteps=ts(2),
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -290,7 +290,7 @@ class TestFlowInvest:
 
         result = optimize(
             timesteps=ts(2),
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -367,7 +367,7 @@ class TestFlowInvestWithStatus:
 
         result = optimize(
             timesteps=ts(4),
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -419,7 +419,7 @@ class TestFlowInvestWithStatus:
 
         result = optimize(
             timesteps=ts(3),
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',

--- a/tests/math_port/test_flow_status.py
+++ b/tests/math_port/test_flow_status.py
@@ -24,6 +24,7 @@ class TestFlowStatus:
             timesteps=ts(5),
             carriers=[Carrier('Gas'), Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -78,6 +79,7 @@ class TestFlowStatus:
         result = optimize(
             timesteps=ts(5),
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -137,6 +139,7 @@ class TestFlowStatus:
         result = optimize(
             timesteps=ts(4),
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -190,6 +193,7 @@ class TestFlowStatus:
             timesteps=ts(2),
             carriers=[Carrier('Gas'), Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -244,6 +248,7 @@ class TestFlowStatus:
         result = optimize(
             timesteps=ts(4),
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -308,6 +313,7 @@ class TestFlowStatus:
         result = optimize(
             timesteps=ts(5),
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -366,6 +372,7 @@ class TestPreviousFlowRate:
         result = optimize(
             timesteps=ts(2),
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -409,6 +416,7 @@ class TestPreviousFlowRate:
         result = optimize(
             timesteps=ts(2),
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -452,6 +460,7 @@ class TestPreviousFlowRate:
         result = optimize(
             timesteps=ts(2),
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -498,6 +507,7 @@ class TestPreviousFlowRate:
         result = optimize(
             timesteps=ts(3),
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -546,6 +556,7 @@ class TestPreviousFlowRate:
         result = optimize(
             timesteps=ts(3),
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -601,6 +612,7 @@ class TestPreviousFlowRate:
         result = optimize(
             timesteps=ts(2),
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',

--- a/tests/math_port/test_flow_status.py
+++ b/tests/math_port/test_flow_status.py
@@ -23,7 +23,7 @@ class TestFlowStatus:
         result = optimize(
             timesteps=ts(5),
             carriers=[Carrier('Gas'), Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -77,7 +77,7 @@ class TestFlowStatus:
 
         result = optimize(
             timesteps=ts(5),
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -136,7 +136,7 @@ class TestFlowStatus:
 
         result = optimize(
             timesteps=ts(4),
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -189,7 +189,7 @@ class TestFlowStatus:
         result = optimize(
             timesteps=ts(2),
             carriers=[Carrier('Gas'), Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -243,7 +243,7 @@ class TestFlowStatus:
 
         result = optimize(
             timesteps=ts(4),
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -307,7 +307,7 @@ class TestFlowStatus:
 
         result = optimize(
             timesteps=ts(5),
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -365,7 +365,7 @@ class TestPreviousFlowRate:
 
         result = optimize(
             timesteps=ts(2),
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -408,7 +408,7 @@ class TestPreviousFlowRate:
 
         result = optimize(
             timesteps=ts(2),
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -451,7 +451,7 @@ class TestPreviousFlowRate:
 
         result = optimize(
             timesteps=ts(2),
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -497,7 +497,7 @@ class TestPreviousFlowRate:
 
         result = optimize(
             timesteps=ts(3),
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -545,7 +545,7 @@ class TestPreviousFlowRate:
 
         result = optimize(
             timesteps=ts(3),
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -600,7 +600,7 @@ class TestPreviousFlowRate:
 
         result = optimize(
             timesteps=ts(2),
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',

--- a/tests/math_port/test_multi_period.py
+++ b/tests/math_port/test_multi_period.py
@@ -102,18 +102,18 @@ class TestMultiPeriod:
     def test_invest_linked_periods(self, optimize):
         """Proves: InvestParameters.linked_periods forces equal sizes across periods."""
 
-    def test_effect_period_weights_periodic(self, optimize):
-        """Proves: Effect.period_weights_periodic overrides global period weights.
+    def test_effect_period_weights(self, optimize):
+        """Proves: Effect.period_weights overrides global period weights.
 
         3 timesteps, periods=[2020, 2025], global weights=[5, 5].
-        Per-period cost = 30. With custom periodic weights [1, 2]:
+        Per-period cost = 30. With custom period_weights [1, 2]:
         Objective = 1*30 + 2*30 = 90  (instead of 5*30 + 5*30 = 300).
         """
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
             effects=[
-                Effect('cost', is_objective=True, period_weights_periodic=[1, 2]),
+                Effect('cost', is_objective=True, period_weights=[1, 2]),
             ],
             ports=[
                 Port(

--- a/tests/math_port/test_multi_period.py
+++ b/tests/math_port/test_multi_period.py
@@ -29,7 +29,7 @@ class TestMultiPeriod:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -78,7 +78,7 @@ class TestMultiPeriod:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -113,7 +113,7 @@ class TestMultiPeriod:
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
             effects=[
-                Effect('cost', is_objective=True, period_weights=[1, 2]),
+                Effect('cost', period_weights=[1, 2]),
             ],
             ports=[
                 Port(
@@ -158,7 +158,7 @@ class TestInvestment:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -194,7 +194,7 @@ class TestInvestment:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -227,7 +227,7 @@ class TestInvestment:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -269,7 +269,7 @@ class TestInvestment:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -313,7 +313,7 @@ class TestInvestment:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -348,7 +348,7 @@ class TestInvestment:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -390,7 +390,7 @@ class TestPeriodVaryingEffects:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -425,7 +425,7 @@ class TestPeriodVaryingEffects:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -461,7 +461,7 @@ class TestPeriodVaryingEffects:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -496,7 +496,7 @@ class TestPeriodVaryingEffects:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -532,7 +532,7 @@ class TestPeriodVaryingEffects:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -568,7 +568,7 @@ class TestPeriodVaryingEffects:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -604,7 +604,7 @@ class TestPeriodVaryingEffects:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -641,7 +641,7 @@ class TestPeriodVaryingEffects:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -683,7 +683,7 @@ class TestPeriodVaryingEffects:
             carriers=[Carrier('Heat')],
             effects=[
                 Effect('co2'),
-                Effect('cost', is_objective=True, contribution_from={'co2': carbon_price}),
+                Effect('cost', contribution_from={'co2': carbon_price}),
             ],
             ports=[
                 Port(
@@ -720,7 +720,7 @@ class TestPeriodVaryingEffects:
             carriers=[Carrier('Heat')],
             effects=[
                 Effect('co2'),
-                Effect('cost', is_objective=True, contribution_from={'co2': carbon_price}),
+                Effect('cost', contribution_from={'co2': carbon_price}),
             ],
             ports=[
                 Port(
@@ -753,7 +753,7 @@ class TestPeriodVaryingEffects:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',

--- a/tests/math_port/test_multi_period.py
+++ b/tests/math_port/test_multi_period.py
@@ -30,6 +30,7 @@ class TestMultiPeriod:
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -79,6 +80,7 @@ class TestMultiPeriod:
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -115,6 +117,7 @@ class TestMultiPeriod:
             effects=[
                 Effect('cost', period_weights=[1, 2]),
             ],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -159,6 +162,7 @@ class TestInvestment:
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -195,6 +199,7 @@ class TestInvestment:
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -228,6 +233,7 @@ class TestInvestment:
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -270,6 +276,7 @@ class TestInvestment:
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -314,6 +321,7 @@ class TestInvestment:
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -349,6 +357,7 @@ class TestInvestment:
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -391,6 +400,7 @@ class TestPeriodVaryingEffects:
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -426,6 +436,7 @@ class TestPeriodVaryingEffects:
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -462,6 +473,7 @@ class TestPeriodVaryingEffects:
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -497,6 +509,7 @@ class TestPeriodVaryingEffects:
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -533,6 +546,7 @@ class TestPeriodVaryingEffects:
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -569,6 +583,7 @@ class TestPeriodVaryingEffects:
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -605,6 +620,7 @@ class TestPeriodVaryingEffects:
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -642,6 +658,7 @@ class TestPeriodVaryingEffects:
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -685,6 +702,7 @@ class TestPeriodVaryingEffects:
                 Effect('co2'),
                 Effect('cost', contribution_from={'co2': carbon_price}),
             ],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -722,6 +740,7 @@ class TestPeriodVaryingEffects:
                 Effect('co2'),
                 Effect('cost', contribution_from={'co2': carbon_price}),
             ],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -754,6 +773,7 @@ class TestPeriodVaryingEffects:
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',

--- a/tests/math_port/test_multi_period.py
+++ b/tests/math_port/test_multi_period.py
@@ -170,7 +170,7 @@ class TestInvestment:
                     imports=[
                         Flow(
                             'Heat',
-                            size=Investment(0, 20, effects_per_size={'cost': 10}),
+                            size=Investment(0, 20, effects_per_size_at_build={'cost': 10}),
                             effects_per_flow_hour={'cost': 1},
                         ),
                     ],
@@ -205,7 +205,7 @@ class TestInvestment:
                     imports=[
                         Flow(
                             'Heat',
-                            size=Investment(0, 20, mandatory=False, effects_per_size={'cost': 100}),
+                            size=Investment(0, 20, mandatory=False, effects_per_size_at_build={'cost': 100}),
                         ),
                     ],
                 ),
@@ -239,7 +239,7 @@ class TestInvestment:
                         Flow(
                             'Heat',
                             short_id='cheap',
-                            size=Investment(0, 20, lifetime=1, effects_per_size={'cost': 0}),
+                            size=Investment(0, 20, lifetime=1, effects_per_size_at_build={'cost': 0}),
                             effects_per_flow_hour={'cost': 1},
                         ),
                     ],
@@ -285,7 +285,7 @@ class TestInvestment:
                                 20,
                                 mandatory=False,
                                 prior_size=10,
-                                effects_per_size={'cost': 1000},
+                                effects_per_size_at_build={'cost': 1000},
                             ),
                             effects_per_flow_hour={'cost': 1},
                         ),
@@ -300,7 +300,7 @@ class TestInvestment:
         assert_allclose(result.objective, 300.0, rtol=1e-4)
 
     def test_investment_capex_charged_once(self, optimize):
-        """Proves: effects_per_size goes to effect_once domain, not periodic.
+        """Proves: effects_per_size_at_build goes to effect_once domain, not periodic.
 
         CAPEX = 10/MW, size=10 MW → one-time cost = 100 (unweighted).
         No operational costs. 2 periods, weights=[5, 5].
@@ -323,7 +323,7 @@ class TestInvestment:
                     imports=[
                         Flow(
                             'Heat',
-                            size=Investment(10, 10, effects_per_size={'cost': 10}),
+                            size=Investment(10, 10, effects_per_size_at_build={'cost': 10}),
                         ),
                     ],
                 ),
@@ -337,7 +337,7 @@ class TestInvestment:
         assert_allclose(result.objective, 100.0, rtol=1e-4)
 
     def test_investment_periodic_costs_weighted(self, optimize):
-        """Proves: effects_per_size_periodic goes to effect_periodic, scaled by period weights.
+        """Proves: effects_per_size_recurring goes to effect_periodic, scaled by period weights.
 
         Recurring O&M = 2/MW/period, size=10 MW. 2 periods, weights=[5, 5].
         Periodic cost per period = 2*10 = 20. Weighted: 5*20 + 5*20 = 200.
@@ -362,7 +362,7 @@ class TestInvestment:
                             size=Investment(
                                 10,
                                 10,
-                                effects_per_size_periodic={'cost': 2},
+                                effects_per_size_recurring={'cost': 2},
                             ),
                         ),
                     ],
@@ -447,7 +447,7 @@ class TestPeriodVaryingEffects:
         assert_allclose(result.objective, 20.0, rtol=1e-4)
 
     def test_investment_periodic_costs_vary_by_period(self, optimize):
-        """Proves: Investment.effects_per_size_periodic can vary across periods.
+        """Proves: Investment.effects_per_size_recurring can vary across periods.
 
         Investment(10, 10), recurring O&M varies: 1 in 2020, 3 in 2025.
         Active in both periods. Periodic cost = O&M * size.
@@ -472,7 +472,7 @@ class TestPeriodVaryingEffects:
                     imports=[
                         Flow(
                             'Heat',
-                            size=Investment(10, 10, effects_per_size_periodic={'cost': om_by_period}),
+                            size=Investment(10, 10, effects_per_size_recurring={'cost': om_by_period}),
                         ),
                     ],
                 ),
@@ -483,7 +483,7 @@ class TestPeriodVaryingEffects:
         assert_allclose(result.objective, 40.0, rtol=1e-4)
 
     def test_investment_fixed_periodic_costs_vary_by_period(self, optimize):
-        """Proves: Investment.effects_fixed_periodic can vary across periods.
+        """Proves: Investment.effects_fixed_recurring can vary across periods.
 
         Investment(10, 10), fixed periodic cost varies: 5 in 2020, 15 in 2025.
         Active in both periods. Weights=[1, 1]. Objective = 5 + 15 = 20.
@@ -507,7 +507,7 @@ class TestPeriodVaryingEffects:
                     imports=[
                         Flow(
                             'Heat',
-                            size=Investment(10, 10, effects_fixed_periodic={'cost': cost_by_period}),
+                            size=Investment(10, 10, effects_fixed_recurring={'cost': cost_by_period}),
                         ),
                     ],
                 ),
@@ -518,7 +518,7 @@ class TestPeriodVaryingEffects:
         assert_allclose(result.objective, 20.0, rtol=1e-4)
 
     def test_investment_capex_per_size_varies_by_period(self, optimize):
-        """Proves: Investment.effects_per_size (once) can vary across periods.
+        """Proves: Investment.effects_per_size_at_build (once) can vary across periods.
 
         Investment(10, 10), CAPEX varies: 10 in 2020, 20 in 2025.
         Mandatory build → builds in cheapest period (2020). Once cost = 10*10 = 100.
@@ -543,7 +543,7 @@ class TestPeriodVaryingEffects:
                     imports=[
                         Flow(
                             'Heat',
-                            size=Investment(10, 10, effects_per_size={'cost': capex_by_period}),
+                            size=Investment(10, 10, effects_per_size_at_build={'cost': capex_by_period}),
                         ),
                     ],
                 ),
@@ -554,7 +554,7 @@ class TestPeriodVaryingEffects:
         assert_allclose(result.objective, 100.0, rtol=1e-4)
 
     def test_investment_capex_fixed_varies_by_period(self, optimize):
-        """Proves: Investment.effects_fixed (once) can vary across periods.
+        """Proves: Investment.effects_fixed_at_build (once) can vary across periods.
 
         Investment(10, 10), fixed CAPEX varies: 50 in 2020, 100 in 2025.
         Mandatory build → builds in cheapest period (2020). Once cost = 50.
@@ -579,7 +579,7 @@ class TestPeriodVaryingEffects:
                     imports=[
                         Flow(
                             'Heat',
-                            size=Investment(10, 10, effects_fixed={'cost': capex_by_period}),
+                            size=Investment(10, 10, effects_fixed_at_build={'cost': capex_by_period}),
                         ),
                     ],
                 ),

--- a/tests/math_port/test_multi_period.py
+++ b/tests/math_port/test_multi_period.py
@@ -148,10 +148,11 @@ class TestInvestment:
         """Proves: mandatory Investment builds exactly once across periods.
 
         3 timesteps, 3 periods [2020, 2025, 2030], weights=[5, 5, 5].
-        Grid with Investment(0, 20, mandatory=True), CAPEX=10/MW once.
+        Grid with Investment(0, 20, mandatory=True), CAPEX=10/MW at build.
         Demand=10 MW constant. Cheapest: build in first period, CAPEX=10*10=100.
-        Operational cost per period: 10*3*1=30, weighted=5*30=150.
-        Total recurring: 3*150=450. Total once: 100. Objective=450+100=550.
+        Operational cost per period: 10*3*1=30.
+        total[p=0]=130, total[p=1]=30, total[p=2]=30.
+        Objective = 5*130 + 5*30 + 5*30 = 950.
         """
         _xfail_if_validate(optimize)
         result = optimize(
@@ -179,10 +180,11 @@ class TestInvestment:
             periods=[2020, 2025, 2030],
             period_weights=[5, 5, 5],
         )
-        # CAPEX: 10/MW * 10 MW = 100 (once)
-        # Operational: 10 MW * 3h * 1 cost/MWh = 30 per period, weighted 5*30=150 per period
-        # Total = 3 * 150 + 100 = 550
-        assert_allclose(result.objective, 550.0, rtol=1e-4)
+        # CAPEX: 10/MW * 10 MW = 100 in build period (p=0)
+        # Operational: 10 MW * 3h * 1 cost/MWh = 30 per period
+        # total[p=0]=130, total[p=1]=30, total[p=2]=30
+        # Objective = 5*130 + 5*30 + 5*30 = 950
+        assert_allclose(result.objective, 950.0, rtol=1e-4)
 
     def test_investment_optional_skips_when_expensive(self, optimize):
         """Proves: optional Investment is not built if cost exceeds benefit.
@@ -299,12 +301,13 @@ class TestInvestment:
         # Cost = 2 * 5 * 30 = 300 (operational only, no CAPEX)
         assert_allclose(result.objective, 300.0, rtol=1e-4)
 
-    def test_investment_capex_charged_once(self, optimize):
-        """Proves: effects_per_size_at_build goes to effect_once domain, not periodic.
+    def test_investment_capex_in_lump(self, optimize):
+        """Proves: effects_per_size_at_build goes to lump domain, weighted like all lump costs.
 
-        CAPEX = 10/MW, size=10 MW → one-time cost = 100 (unweighted).
+        CAPEX = 10/MW, size=10 MW → lump cost = 100 per build period.
         No operational costs. 2 periods, weights=[5, 5].
-        Objective = 5*0 + 5*0 + 1*100 = 100  (once costs have ω_once=1 by default).
+        Mandatory build → built in period 0. Lump = 100 in p=0, 0 in p=1.
+        Objective = 5*100 + 5*0 = 500.
         """
         _xfail_if_validate(optimize)
         result = optimize(
@@ -332,9 +335,8 @@ class TestInvestment:
             period_weights=[5, 5],
         )
         # min_size == max_size == 10, so invest_size = 10.
-        # CAPEX: 10 * 10 = 100 (effect_once, ω_once=1 by default)
-        # No flow costs. Objective = 100.
-        assert_allclose(result.objective, 100.0, rtol=1e-4)
+        # CAPEX: 10 * 10 = 100 in build period. Weighted: 5 * 100 = 500.
+        assert_allclose(result.objective, 500.0, rtol=1e-4)
 
     def test_investment_periodic_costs_weighted(self, optimize):
         """Proves: effects_per_size_recurring goes to effect_periodic, scaled by period weights.

--- a/tests/math_port/test_multi_period.py
+++ b/tests/math_port/test_multi_period.py
@@ -722,44 +722,6 @@ class TestPeriodVaryingEffects:
         )
         assert_allclose(result.objective, 4500.0, rtol=1e-4)
 
-    def test_contribution_from_period_varying_carbon_price(self, optimize):
-        """Proves: Effect.contribution_from with period-varying factor.
-
-        CO2 effect tracks emissions. Cost gets contribution_from CO2
-        at rate 50 in 2020, 100 in 2025. Grid emits 1 CO2/MWh, demand=10 for 3 ts.
-        CO2 per period = 30. Cost: 2020→50*30=1500, 2025→100*30=3000.
-        Weights=[1, 1]. Objective = 1500 + 3000 = 4500.
-        """
-        _xfail_if_validate(optimize)
-        periods = [2020, 2025]
-        carbon_price = xr.DataArray([50.0, 100.0], dims=['period'], coords={'period': periods})
-        result = optimize(
-            timesteps=ts(3),
-            carriers=[Carrier('Heat')],
-            effects=[
-                Effect('co2'),
-                Effect('cost', contribution_from={'co2': carbon_price}),
-            ],
-            objective_effects='cost',
-            ports=[
-                Port(
-                    'Demand',
-                    exports=[
-                        Flow('Heat', size=1, fixed_relative_profile=np.array([10, 10, 10])),
-                    ],
-                ),
-                Port(
-                    'Grid',
-                    imports=[
-                        Flow('Heat', effects_per_flow_hour={'co2': 1}),
-                    ],
-                ),
-            ],
-            periods=periods,
-            period_weights=[1, 1],
-        )
-        assert_allclose(result.objective, 4500.0, rtol=1e-4)
-
     def test_storage_sizing_effects_per_size_vary_by_period(self, optimize):
         """Proves: Storage Sizing.effects_per_size can vary across periods.
 

--- a/tests/math_port/test_multi_period.py
+++ b/tests/math_port/test_multi_period.py
@@ -704,10 +704,10 @@ class TestPeriodVaryingEffects:
         )
         assert_allclose(result.objective, 4500.0, rtol=1e-4)
 
-    def test_contribution_from_per_hour_varies_by_period(self, optimize):
-        """Proves: Effect.contribution_from_per_hour can vary across periods.
+    def test_contribution_from_period_varying_carbon_price(self, optimize):
+        """Proves: Effect.contribution_from with period-varying factor.
 
-        CO2 effect tracks emissions. Cost gets contribution_from_per_hour CO2
+        CO2 effect tracks emissions. Cost gets contribution_from CO2
         at rate 50 in 2020, 100 in 2025. Grid emits 1 CO2/MWh, demand=10 for 3 ts.
         CO2 per period = 30. Cost: 2020→50*30=1500, 2025→100*30=3000.
         Weights=[1, 1]. Objective = 1500 + 3000 = 4500.
@@ -720,7 +720,7 @@ class TestPeriodVaryingEffects:
             carriers=[Carrier('Heat')],
             effects=[
                 Effect('co2'),
-                Effect('cost', is_objective=True, contribution_from_per_hour={'co2': carbon_price}),
+                Effect('cost', is_objective=True, contribution_from={'co2': carbon_price}),
             ],
             ports=[
                 Port(

--- a/tests/math_port/test_storage.py
+++ b/tests/math_port/test_storage.py
@@ -19,7 +19,7 @@ class TestStorage:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -59,7 +59,7 @@ class TestStorage:
         result = optimize(
             timesteps=ts(2),
             carriers=[Carrier('Elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -99,7 +99,7 @@ class TestStorage:
         result = optimize(
             timesteps=ts(2),
             carriers=[Carrier('Elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -139,7 +139,7 @@ class TestStorage:
         result = optimize(
             timesteps=ts(2),
             carriers=[Carrier('Elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',
@@ -180,7 +180,7 @@ class TestStorage:
         result = optimize(
             timesteps=ts(2),
             carriers=[Carrier('Elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port(
                     'Demand',

--- a/tests/math_port/test_storage.py
+++ b/tests/math_port/test_storage.py
@@ -20,6 +20,7 @@ class TestStorage:
             timesteps=ts(3),
             carriers=[Carrier('Elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -60,6 +61,7 @@ class TestStorage:
             timesteps=ts(2),
             carriers=[Carrier('Elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -100,6 +102,7 @@ class TestStorage:
             timesteps=ts(2),
             carriers=[Carrier('Elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -140,6 +143,7 @@ class TestStorage:
             timesteps=ts(2),
             carriers=[Carrier('Elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',
@@ -181,6 +185,7 @@ class TestStorage:
             timesteps=ts(2),
             carriers=[Carrier('Elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port(
                     'Demand',

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -14,7 +14,7 @@ class TestFlowsTable:
         data = ModelData.build(
             ts(3),
             carriers=[Carrier('b')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('src', imports=[flow])],
         )
         ds = data.flows
@@ -30,7 +30,7 @@ class TestFlowsTable:
         data = ModelData.build(
             ts(3),
             carriers=[Carrier('b')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('sink', exports=[flow])],
         )
         fixed = data.flows.fixed_profile.sel(flow='sink(b)').values
@@ -42,7 +42,7 @@ class TestFlowsTable:
         data = ModelData.build(
             ts(3),
             carriers=[Carrier('b')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('src', imports=[flow])],
         )
         assert str(data.flows.bound_type.sel(flow='src(b)').values) == 'unsized'
@@ -55,7 +55,7 @@ class TestCarriersData:
         data = ModelData.build(
             ts(3),
             carriers=[Carrier('b')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('src', imports=[out_flow]), Port('sink', exports=[in_flow])],
         )
         coeffs = data.carriers.flow_coeff
@@ -68,7 +68,7 @@ class TestCarriersData:
         data = ModelData.build(
             ts(2),
             carriers=[Carrier('elec', unit='kWh', color='blue', description='Electricity')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('src', imports=[Flow('elec', size=100)])],
         )
         assert str(data.carriers.unit.sel(carrier='elec').values) == 'kWh'
@@ -81,7 +81,7 @@ class TestCarriersData:
         data = ModelData.build(
             ts(2),
             carriers=[Carrier('elec', unit='kWh', color='red', description='Power')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('src', imports=[Flow('elec', size=100)])],
         )
         ds = data.carriers.to_dataset()
@@ -99,7 +99,7 @@ class TestConvertersTable:
         data = ModelData.build(
             ts(3),
             carriers=[Carrier('gas'), Carrier('heat')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('src', imports=[Flow('gas', size=200)])],
             converters=[boiler],
         )
@@ -121,20 +121,11 @@ class TestEffectsTable:
         data = ModelData.build(
             ts(3),
             carriers=[Carrier('b')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('src', imports=[flow])],
         )
         coeff = data.flows.effect_coeff.sel(flow='src(b)', effect='cost')
         assert all(v == 0.04 for v in coeff.values)
-
-    def test_objective_effect(self):
-        data = ModelData.build(
-            ts(3),
-            carriers=[Carrier('b')],
-            effects=[Effect('cost', is_objective=True), Effect('co2')],
-            ports=[Port('src', imports=[Flow('b', size=100)])],
-        )
-        assert data.effects.objective_effect == 'cost'
 
 
 class TestFlowNodeId:
@@ -177,7 +168,7 @@ class TestCarrierValidation:
             optimize(
                 timesteps=ts(2),
                 carriers=[Carrier('gas')],
-                effects=[Effect('cost', is_objective=True)],
+                effects=[Effect('cost')],
                 ports=[Port('grid', imports=[Flow('elec', size=100)])],
             )
 
@@ -187,7 +178,7 @@ class TestCarrierValidation:
             ModelData.build(
                 ts(2),
                 carriers=[Carrier('gas')],
-                effects=[Effect('cost', is_objective=True)],
+                effects=[Effect('cost')],
                 ports=[Port('grid', imports=[Flow('elec', size=100)])],
             )
 
@@ -197,7 +188,7 @@ class TestCarrierValidation:
             ModelData.build(
                 ts(2),
                 carriers=[Carrier('elec'), Carrier('elec')],
-                effects=[Effect('cost', is_objective=True)],
+                effects=[Effect('cost')],
                 ports=[Port('grid', imports=[Flow('elec', size=100)])],
             )
 
@@ -207,7 +198,7 @@ class TestCarrierValidation:
             ModelData.build(
                 ts(2),
                 carriers=[Carrier('heat')],
-                effects=[Effect('cost', is_objective=True)],
+                effects=[Effect('cost')],
                 ports=[Port('src', imports=[Flow('heat', node='A', size=100)])],
             )
 
@@ -217,7 +208,7 @@ class TestCarrierValidation:
             ModelData.build(
                 ts(2),
                 carriers=[Carrier('heat', nodes=['A', 'B'])],
-                effects=[Effect('cost', is_objective=True)],
+                effects=[Effect('cost')],
                 ports=[Port('src', imports=[Flow('heat', node='C', size=100)])],
             )
 
@@ -228,7 +219,7 @@ class TestCarrierBalance:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('src', imports=[Flow('elec', size=100, effects_per_flow_hour={'cost': 0.04})]),
                 Port('sink', exports=[Flow('elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])]),
@@ -249,7 +240,7 @@ class TestMultiNodeCarrier:
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('heat', nodes=['A', 'B'])],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('src_a', imports=[Flow('heat', node='A', size=100, effects_per_flow_hour={'cost': 0.04})]),
                 Port('src_b', imports=[Flow('heat', node='B', size=100, effects_per_flow_hour={'cost': 0.04})]),
@@ -272,7 +263,7 @@ class TestMultiNodeCarrier:
         data = ModelData.build(
             ts(3),
             carriers=[Carrier('heat', nodes=['A', 'B'])],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[
                 Port('src_a', imports=[Flow('heat', node='A', size=100, effects_per_flow_hour={'cost': 0.04})]),
                 Port('src_b', imports=[Flow('heat', node='B', size=100, effects_per_flow_hour={'cost': 0.04})]),

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -169,6 +169,7 @@ class TestCarrierValidation:
                 timesteps=ts(2),
                 carriers=[Carrier('gas')],
                 effects=[Effect('cost')],
+                objective_effects='cost',
                 ports=[Port('grid', imports=[Flow('elec', size=100)])],
             )
 
@@ -220,6 +221,7 @@ class TestCarrierBalance:
             timesteps=ts(3),
             carriers=[Carrier('elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('src', imports=[Flow('elec', size=100, effects_per_flow_hour={'cost': 0.04})]),
                 Port('sink', exports=[Flow('elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])]),
@@ -241,6 +243,7 @@ class TestMultiNodeCarrier:
             timesteps=ts(3),
             carriers=[Carrier('heat', nodes=['A', 'B'])],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[
                 Port('src_a', imports=[Flow('heat', node='A', size=100, effects_per_flow_hour={'cost': 0.04})]),
                 Port('src_b', imports=[Flow('heat', node='B', size=100, effects_per_flow_hour={'cost': 0.04})]),

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -155,16 +155,13 @@ class TestRoundtripContributionFrom:
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
         assert result.data is not None
-        assert result.data.effects.cf_periodic is not None
         assert result.data.effects.cf_temporal is not None
 
         result.to_netcdf(tmp_nc)
         loaded = Result.from_netcdf(tmp_nc)
 
         assert loaded.data is not None
-        assert loaded.data.effects.cf_periodic is not None
         assert loaded.data.effects.cf_temporal is not None
-        xr.testing.assert_equal(loaded.data.effects.cf_periodic, result.data.effects.cf_periodic)
         xr.testing.assert_equal(loaded.data.effects.cf_temporal, result.data.effects.cf_temporal)
 
         # Re-solve gives same objective

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -25,7 +25,7 @@ def _solve_simple(timesteps: list[datetime] | list[int]) -> Result:
     return optimize(
         timesteps=timesteps,
         carriers=[Carrier('elec')],
-        effects=[Effect('cost', is_objective=True)],
+        effects=[Effect('cost')],
         ports=[Port('grid', imports=[source]), Port('demand', exports=[demand])],
     )
 
@@ -42,7 +42,7 @@ def _solve_with_storage(timesteps: list[datetime]) -> Result:
     return optimize(
         timesteps=timesteps,
         carriers=[Carrier('gas'), Carrier('heat')],
-        effects=[Effect('cost', is_objective=True)],
+        effects=[Effect('cost')],
         ports=[Port('grid', imports=[gas_source]), Port('demand', exports=[demand])],
         converters=[Converter.boiler('boiler', 0.9, fuel, heat_out)],
         storages=[storage],
@@ -84,8 +84,6 @@ class TestRoundtrip:
         assert list(loaded.data.flows.rel_lb.coords['flow'].values) == list(
             result.data.flows.rel_lb.coords['flow'].values
         )
-        # Effects attrs preserved
-        assert loaded.data.effects.objective_effect == result.data.effects.objective_effect
         # Storages dataset preserved
         assert loaded.data.storages is not None
         assert result.data.storages is not None
@@ -124,7 +122,7 @@ class TestCarrierMetadataRoundtrip:
         result = optimize(
             timesteps=ts,
             carriers=[Carrier('elec', unit='kWh', color='#ff0000', description='Electrical energy')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[demand])],
         )
         assert result.data is not None
@@ -149,7 +147,7 @@ class TestRoundtripContributionFrom:
             timesteps=ts,
             carriers=[Carrier('elec')],
             effects=[
-                Effect('cost', is_objective=True, contribution_from={'co2': 50}),
+                Effect('cost', contribution_from={'co2': 50}),
                 Effect('co2', unit='kg'),
             ],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -26,6 +26,7 @@ def _solve_simple(timesteps: list[datetime] | list[int]) -> Result:
         timesteps=timesteps,
         carriers=[Carrier('elec')],
         effects=[Effect('cost')],
+        objective_effects='cost',
         ports=[Port('grid', imports=[source]), Port('demand', exports=[demand])],
     )
 
@@ -43,6 +44,7 @@ def _solve_with_storage(timesteps: list[datetime]) -> Result:
         timesteps=timesteps,
         carriers=[Carrier('gas'), Carrier('heat')],
         effects=[Effect('cost')],
+        objective_effects='cost',
         ports=[Port('grid', imports=[gas_source]), Port('demand', exports=[demand])],
         converters=[Converter.boiler('boiler', 0.9, fuel, heat_out)],
         storages=[storage],
@@ -108,8 +110,7 @@ class TestRoundtrip:
         from fluxopt import FlowSystem
 
         model = FlowSystem(loaded.data)
-        model.build()
-        result2 = model.solve()
+        result2 = model.optimize(objective_effects='cost')
         assert result2.objective == pytest.approx(result.objective, abs=1e-6)
 
 
@@ -123,6 +124,7 @@ class TestCarrierMetadataRoundtrip:
             timesteps=ts,
             carriers=[Carrier('elec', unit='kWh', color='#ff0000', description='Electrical energy')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source]), Port('demand', exports=[demand])],
         )
         assert result.data is not None
@@ -150,6 +152,7 @@ class TestRoundtripContributionFrom:
                 Effect('cost', contribution_from={'co2': 50}),
                 Effect('co2', unit='kg'),
             ],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
         )
         assert result.data is not None
@@ -166,8 +169,7 @@ class TestRoundtripContributionFrom:
         from fluxopt import FlowSystem
 
         model = FlowSystem(loaded.data)
-        model.build()
-        result2 = model.solve()
+        result2 = model.optimize(objective_effects='cost')
         assert result2.objective == pytest.approx(result.objective, abs=1e-6)
 
 

--- a/tests/test_result_topology.py
+++ b/tests/test_result_topology.py
@@ -20,7 +20,7 @@ def _solve_with_converter() -> Result:
     return optimize(
         timesteps=[datetime(2024, 1, 1, h) for h in range(3)],
         carriers=[Carrier('gas'), Carrier('heat')],
-        effects=[Effect('cost', is_objective=True)],
+        effects=[Effect('cost')],
         ports=[Port('grid', imports=[gas_source]), Port('demand', exports=[demand])],
         converters=[Converter.boiler('boiler', 0.9, fuel, heat_out)],
         storages=[storage],
@@ -76,7 +76,7 @@ class TestTopology:
         result = optimize(
             timesteps=[datetime(2024, 1, 1, h) for h in range(3)],
             carriers=[Carrier('elec')],
-            effects=[Effect('cost', is_objective=True)],
+            effects=[Effect('cost')],
             ports=[Port('grid', imports=[source]), Port('demand', exports=[demand])],
         )
         topo = result.topology

--- a/tests/test_result_topology.py
+++ b/tests/test_result_topology.py
@@ -21,6 +21,7 @@ def _solve_with_converter() -> Result:
         timesteps=[datetime(2024, 1, 1, h) for h in range(3)],
         carriers=[Carrier('gas'), Carrier('heat')],
         effects=[Effect('cost')],
+        objective_effects='cost',
         ports=[Port('grid', imports=[gas_source]), Port('demand', exports=[demand])],
         converters=[Converter.boiler('boiler', 0.9, fuel, heat_out)],
         storages=[storage],
@@ -77,6 +78,7 @@ class TestTopology:
             timesteps=[datetime(2024, 1, 1, h) for h in range(3)],
             carriers=[Carrier('elec')],
             effects=[Effect('cost')],
+            objective_effects='cost',
             ports=[Port('grid', imports=[source]), Port('demand', exports=[demand])],
         )
         topo = result.topology


### PR DESCRIPTION
## Summary

Redesigns the effect system per the design discussion in #126. Effects become named buckets that users split semantically (opex, capex, co2) instead of understanding internal domain concepts.

### Key changes

- **Two internal domains** instead of three: `temporal` (per-timestep) + `lump` (all non-temporal). Old `periodic` + `once` merged into `lump`
- **Objective at solve time**: `optimize(objective=['opex', 'capex'])` instead of `Effect(is_objective=True)`. Supports multi-effect objectives
- **Simplified Effect**: single `contribution_from` (was two), single `period_weights` (was two), shortened bound names (`maximum`/`minimum`)
- **New per-period bounds**: `maximum_per_period` / `minimum_per_period`
- **Investment field renames**: `effects_per_size` → `effects_per_size_at_build`, `effects_fixed_periodic` → `effects_fixed_recurring`, etc.

### Commits

| Commit | Change |
|---|---|
| `0abc4b8` | Rename Investment fields (`at_build`, `recurring`) |
| `24d4a0d` | Rename Effect bounds + add per-period bounds |
| `af58fbb` | Merge periodic + once → lump domain (3 vars → 4→3) |
| `b9ef5b0` | Merge contribution_from + contribution_from_per_hour |
| `e363242` | Merge period_weights_periodic + period_weights_once |
| `3bf4dae` | Move is_objective to optimize(objective=...) |
| `c1e51ef` | Update all docs and notebooks |

## Test plan

- [x] 380 tests pass, all linting and type checking clean
- [x] All docs and notebooks updated
- [x] IO roundtrip tests pass (NetCDF format changed — expected pre-v0.1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * optimize() gains an objective_effects argument to select which effect(s) are minimized.

* **Breaking Changes**
  * Per-effect objective flag removed; specify objectives via optimize(objective_effects=...).
  * Constraint and investment parameter names changed and multi-domain effects consolidated into a single "lump" domain; result accessors reflect this consolidation.

* **Documentation**
  * Guides, examples, and notebooks updated.

* **Tests**
  * Test suite updated to match the new objective and naming conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->