### PR TITLE
test: prototype structural doc-formula verification

### DIFF
--- a/docs/math/effects.md
+++ b/docs/math/effects.md
@@ -27,6 +27,8 @@ Each effect accumulates contributions from all flows at each timestep:
 \Phi_{k,t}^{\text{temporal}} = \underbrace{\sum_{f \in \mathcal{F}} c_{f,k,t} \cdot P_{f,t} \cdot \Delta t_t}_{\text{direct flow contributions}} + \underbrace{\sum_{j \in \mathcal{K}} \alpha_{k,j,t} \cdot \Phi_{j,t}^{\text{temporal}}}_{\text{cross-effect contributions}} \quad \forall \, k, t
 \]
 
+<!-- verified-by: tests/math/test_doc_formulas.py::TestTemporalEquation::test_effect_temporal_equation -->
+
 The coefficient \(c_{f,k,t}\) specifies how much of effect \(k\) is produced per
 flow-hour of flow \(f\) (e.g., €/MWh for cost, kg/MWh for emissions).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ extend-fixable = ["B", "SIM", "RUF", "C4", "UP"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["S101"]
+"tests/math/test_doc_formulas.py" = ["S101", "N806"]  # uppercase vars mirror LaTeX symbols
 "scripts/**/*.py" = ["T201", "RUF003"]
 "docs/notebooks/*.ipynb" = ["T201", "RUF001", "RUF003"]
 

--- a/tests/math/test_doc_formulas.py
+++ b/tests/math/test_doc_formulas.py
@@ -1,12 +1,14 @@
 """Structural verification of the equations in ``docs/math/``.
 
-Each test corresponds to one equation in the math docs and pins the
-**coefficients** linopy emits — not just the solved objective value.
-Renaming a term or forgetting a ``dt`` factor fails the test with a pointer
-to the equation it verifies.
+Each test pins one equation by comparing the linopy constraint to an
+**expected expression built from the model's own variables** — so the test
+body mirrors the LaTeX line-for-line.
 
-Convention: every equation verified here is annotated in the doc with
-``<!-- verified-by: tests/math/test_doc_formulas.py::<test_name> -->``.
+Convention: every equation verified here carries a sibling comment in the
+doc::
+
+    <!-- verified-by: tests/math/test_doc_formulas.py::<nodeid> -->
+
 ``tests/test_doc_anchors.py`` enforces that the anchor resolves.
 """
 
@@ -23,78 +25,109 @@ from fluxopt.model import FlowSystem
 from fluxopt.model_data import ModelData
 
 
-def _term_coeff(constraint: Any, row: dict[str, Any], var_label: int) -> float:
-    """Return the coefficient on ``var_label`` in a single row of a linopy constraint.
+def _coeff_dict(vars_arr: Any, coeffs_arr: Any) -> dict[int, float]:
+    """Collapse parallel (vars, coeffs) arrays into a ``{label: coeff}`` dict.
 
-    A linopy constraint stores ``coeffs`` and ``vars`` as parallel arrays indexed
-    by ``_term``. This looks up which term slot holds ``var_label`` in the given
-    row and returns the coefficient — or 0.0 if the variable does not appear.
+    Drops zero coefficients and linopy's ``-1`` padding sentinel. Sums
+    duplicate-label slots so expressions that list a variable twice
+    (e.g., after subtraction) canonicalize correctly.
     """
-    vars_row = constraint.vars.sel(row).values
-    coeffs_row = constraint.coeffs.sel(row).values
-    idx = np.where(vars_row == var_label)[0]
-    return float(coeffs_row[idx[0]]) if len(idx) else 0.0
+    result: dict[int, float] = {}
+    for v, c in zip(vars_arr.ravel().tolist(), coeffs_arr.ravel().tolist(), strict=True):
+        label = int(v)
+        if label == -1:
+            continue
+        result[label] = result.get(label, 0.0) + float(c)
+    return {k: v for k, v in result.items() if abs(v) > 1e-12}
 
 
-def _build(dt_hours: float = 2.0, cost_coeff: float = 30.0, co2_to_cost: float = 50.0) -> FlowSystem:
-    """Minimal 2-timestep system with a CO2 → cost cross-effect."""
-    timesteps = [datetime(2024, 1, 1, h * int(dt_hours)) for h in range(2)]
+def _label_names(model: Any) -> dict[int, str]:
+    """Build ``{label: human_name}`` map across all variables in the linopy model."""
+    names: dict[int, str] = {}
+    for vname, var in model.variables.items():
+        labels = var.labels
+        for flat_idx, label in enumerate(labels.values.ravel()):
+            if label == -1:
+                continue
+            # Recover the coord tuple for this flat index
+            multi_idx = np.unravel_index(flat_idx, labels.shape)
+            coord_str = ', '.join(
+                f'{d}={labels.coords[d].values[i]}' for d, i in zip(labels.dims, multi_idx, strict=True)
+            )
+            names[int(label)] = f'{vname}[{coord_str}]'
+    return names
+
+
+def _pretty(d: dict[int, float], name_map: dict[int, str]) -> str:
+    return '{' + ', '.join(f'{name_map.get(k, k)}: {v:g}' for k, v in sorted(d.items(), key=lambda kv: kv[0])) + '}'
+
+
+def assert_row_equation(constraint: Any, *, row: dict[str, Any], lhs: Any, rhs: Any = 0) -> None:
+    """Assert ``constraint`` at ``row`` represents the equation ``lhs = rhs``.
+
+    ``lhs`` and ``rhs`` are linopy expressions (or scalars) built from the same
+    model's variables. Both sides are rearranged to ``lhs - rhs = 0`` and
+    compared coefficient-by-coefficient against the stored constraint — so
+    the test body can mirror the equation as written in the docs, with no
+    manual sign-flipping.
+    """
+    expected_expr = lhs - rhs
+    expected = _coeff_dict(expected_expr.vars.values, expected_expr.coeffs.values)
+    actual = _coeff_dict(constraint.vars.sel(row).values, constraint.coeffs.sel(row).values)
+
+    if actual != pytest.approx(expected):
+        names = _label_names(constraint.model)
+        raise AssertionError(
+            f'Constraint row {row} does not match equation:\n'
+            f'  expected: {_pretty(expected, names)}\n'
+            f'  actual:   {_pretty(actual, names)}'
+        )
+    assert constraint.sign.sel(row).item() == '=', (
+        f'Expected equality constraint, got sign {constraint.sign.sel(row).item()!r}'
+    )
+    assert float(constraint.rhs.sel(row)) == pytest.approx(0.0)
+
+
+@pytest.fixture
+def model() -> FlowSystem:
+    """Two-timestep system: Src -> Demand, 30 EUR/MWh, 0.2 kg CO2/MWh, CO2 priced at 50 EUR/kg."""
+    timesteps = [datetime(2024, 1, 1, h * 2) for h in range(2)]
     data = ModelData.build(
         timesteps=timesteps,
         carriers=[Carrier('Heat')],
         effects=[
-            Effect('cost', contribution_from={'co2': co2_to_cost}),
+            Effect('cost', contribution_from={'co2': 50}),
             Effect('co2'),
         ],
         ports=[
             Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[5, 5])]),
-            Port('Src', imports=[Flow('Heat', effects_per_flow_hour={'cost': cost_coeff, 'co2': 0.2})]),
+            Port('Src', imports=[Flow('Heat', effects_per_flow_hour={'cost': 30, 'co2': 0.2})]),
         ],
     )
-    model = FlowSystem(data)
-    model._objective_effects = ['cost']
-    model.build()
-    return model
+    m = FlowSystem(data)
+    m._objective_effects = ['cost']
+    m.build()
+    return m
 
 
 class TestTemporalEquation:
-    """Verifies ``docs/math/effects.md`` -- Phi^temporal_{k,t} equation.
+    """docs/math/effects.md — Temporal Domain.
 
     Phi^temporal_{k,t} = sum_f c_{f,k,t} * P_{f,t} * dt_t
                        + sum_j alpha_{k,j,t} * Phi^temporal_{j,t}
-
-    linopy rearranges this to ``effect_temporal - (sum_f c*dt*P + sum_j alpha*Phi_j) = 0``,
-    so LHS coefficients are ``+1`` on Phi_k, ``-c*dt`` on flows, ``-alpha`` on
-    source-effect variables; RHS is 0.
     """
 
-    def test_effect_temporal_equation(self) -> None:
-        dt = 2.0
-        cost_coeff = 30.0
-        alpha = 50.0
-        model = _build(dt_hours=dt, cost_coeff=cost_coeff, co2_to_cost=alpha)
+    def test_effect_temporal_equation(self, model: FlowSystem) -> None:
+        Phi = model.effect_temporal
+        P = model.flow_rate
+        t = model.data.dims.time.values[0]
+        dt = 2  # timestep duration [h]
+        c = 30  # Src cost coefficient [EUR/MWh]
+        alpha = 50  # carbon price [EUR/kg]
 
-        constraint = model.m.constraints['effect_temporal_eq']
-        t0 = model.data.dims.time.values[0]
-        row = {'effect': 'cost', 'time': t0}
-
-        et_cost = int(model.effect_temporal.labels.sel(effect='cost', time=t0).item())
-        et_co2 = int(model.effect_temporal.labels.sel(effect='co2', time=t0).item())
-        src = int(model.flow_rate.labels.sel(flow='Src(Heat)', time=t0).item())
-        demand = int(model.flow_rate.labels.sel(flow='Demand(Heat)', time=t0).item())
-
-        # Phi^temporal_{cost, t0}: coefficient on itself is +1
-        assert _term_coeff(constraint, row, et_cost) == pytest.approx(1.0)
-
-        # Flow term: -c_{Src,cost} * dt
-        assert _term_coeff(constraint, row, src) == pytest.approx(-cost_coeff * dt)
-
-        # Cross-effect term: -alpha_{cost,co2}
-        assert _term_coeff(constraint, row, et_co2) == pytest.approx(-alpha)
-
-        # Demand flow has no cost coefficient -- should not contribute
-        assert _term_coeff(constraint, row, demand) == pytest.approx(0.0)
-
-        # Equality constraint with RHS = 0
-        assert constraint.sign.sel(row).item() == '='
-        assert float(constraint.rhs.sel(row)) == pytest.approx(0.0)
+        assert_row_equation(
+            model.m.constraints['effect_temporal_eq'],
+            row={'effect': 'cost', 'time': t},
+            lhs=Phi.sel(effect='cost', time=t),
+            rhs=c * dt * P.sel(flow='Src(Heat)', time=t) + alpha * Phi.sel(effect='co2', time=t),
+        )

--- a/tests/math/test_doc_formulas.py
+++ b/tests/math/test_doc_formulas.py
@@ -1,0 +1,100 @@
+"""Structural verification of the equations in ``docs/math/``.
+
+Each test corresponds to one equation in the math docs and pins the
+**coefficients** linopy emits — not just the solved objective value.
+Renaming a term or forgetting a ``dt`` factor fails the test with a pointer
+to the equation it verifies.
+
+Convention: every equation verified here is annotated in the doc with
+``<!-- verified-by: tests/math/test_doc_formulas.py::<test_name> -->``.
+``tests/test_doc_anchors.py`` enforces that the anchor resolves.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import numpy as np
+import pytest
+
+from fluxopt import Carrier, Effect, Flow, Port
+from fluxopt.model import FlowSystem
+from fluxopt.model_data import ModelData
+
+
+def _term_coeff(constraint: Any, row: dict[str, Any], var_label: int) -> float:
+    """Return the coefficient on ``var_label`` in a single row of a linopy constraint.
+
+    A linopy constraint stores ``coeffs`` and ``vars`` as parallel arrays indexed
+    by ``_term``. This looks up which term slot holds ``var_label`` in the given
+    row and returns the coefficient — or 0.0 if the variable does not appear.
+    """
+    vars_row = constraint.vars.sel(row).values
+    coeffs_row = constraint.coeffs.sel(row).values
+    idx = np.where(vars_row == var_label)[0]
+    return float(coeffs_row[idx[0]]) if len(idx) else 0.0
+
+
+def _build(dt_hours: float = 2.0, cost_coeff: float = 30.0, co2_to_cost: float = 50.0) -> FlowSystem:
+    """Minimal 2-timestep system with a CO2 → cost cross-effect."""
+    timesteps = [datetime(2024, 1, 1, h * int(dt_hours)) for h in range(2)]
+    data = ModelData.build(
+        timesteps=timesteps,
+        carriers=[Carrier('Heat')],
+        effects=[
+            Effect('cost', contribution_from={'co2': co2_to_cost}),
+            Effect('co2'),
+        ],
+        ports=[
+            Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=[5, 5])]),
+            Port('Src', imports=[Flow('Heat', effects_per_flow_hour={'cost': cost_coeff, 'co2': 0.2})]),
+        ],
+    )
+    model = FlowSystem(data)
+    model._objective_effects = ['cost']
+    model.build()
+    return model
+
+
+class TestTemporalEquation:
+    """Verifies ``docs/math/effects.md`` -- Phi^temporal_{k,t} equation.
+
+    Phi^temporal_{k,t} = sum_f c_{f,k,t} * P_{f,t} * dt_t
+                       + sum_j alpha_{k,j,t} * Phi^temporal_{j,t}
+
+    linopy rearranges this to ``effect_temporal - (sum_f c*dt*P + sum_j alpha*Phi_j) = 0``,
+    so LHS coefficients are ``+1`` on Phi_k, ``-c*dt`` on flows, ``-alpha`` on
+    source-effect variables; RHS is 0.
+    """
+
+    def test_effect_temporal_equation(self) -> None:
+        dt = 2.0
+        cost_coeff = 30.0
+        alpha = 50.0
+        model = _build(dt_hours=dt, cost_coeff=cost_coeff, co2_to_cost=alpha)
+
+        constraint = model.m.constraints['effect_temporal_eq']
+        t0 = model.data.dims.time.values[0]
+        row = {'effect': 'cost', 'time': t0}
+
+        et_cost = int(model.effect_temporal.labels.sel(effect='cost', time=t0).item())
+        et_co2 = int(model.effect_temporal.labels.sel(effect='co2', time=t0).item())
+        src = int(model.flow_rate.labels.sel(flow='Src(Heat)', time=t0).item())
+        demand = int(model.flow_rate.labels.sel(flow='Demand(Heat)', time=t0).item())
+
+        # Phi^temporal_{cost, t0}: coefficient on itself is +1
+        assert _term_coeff(constraint, row, et_cost) == pytest.approx(1.0)
+
+        # Flow term: -c_{Src,cost} * dt
+        assert _term_coeff(constraint, row, src) == pytest.approx(-cost_coeff * dt)
+
+        # Cross-effect term: -alpha_{cost,co2}
+        assert _term_coeff(constraint, row, et_co2) == pytest.approx(-alpha)
+
+        # Demand flow has no cost coefficient -- should not contribute
+        assert _term_coeff(constraint, row, demand) == pytest.approx(0.0)
+
+        # Equality constraint with RHS = 0
+        assert constraint.sign.sel(row).item() == '='
+        assert float(constraint.rhs.sel(row)) == pytest.approx(0.0)

--- a/tests/test_doc_anchors.py
+++ b/tests/test_doc_anchors.py
@@ -1,0 +1,54 @@
+"""Enforce that every ``<!-- verified-by: ... -->`` anchor in docs/math resolves.
+
+Any LaTeX equation in ``docs/math/*.md`` that is backed by a structural test
+should sit next to an anchor of the form::
+
+    <!-- verified-by: tests/math/test_doc_formulas.py::<test_name_or_class::method> -->
+
+This test collects all such anchors and fails if the target file or test
+function is missing — so renaming a test without updating the doc pointer
+(or vice versa) fails CI loudly.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_MATH = REPO_ROOT / 'docs' / 'math'
+ANCHOR_RE = re.compile(r'<!--\s*verified-by:\s*(\S+?)::(\S+?)\s*-->')
+
+
+def _collect_anchors() -> list[tuple[str, str, str]]:
+    """Scan docs/math/*.md for `verified-by` anchors. Returns (md_file, target_path, nodeid)."""
+    anchors: list[tuple[str, str, str]] = []
+    for md in sorted(DOCS_MATH.rglob('*.md')):
+        anchors.extend(
+            (str(md.relative_to(REPO_ROOT)), m.group(1), m.group(2)) for m in ANCHOR_RE.finditer(md.read_text())
+        )
+    return anchors
+
+
+ANCHORS = _collect_anchors()
+
+
+def test_at_least_one_anchor_exists() -> None:
+    """Guardrail so an accidental regex change does not silently disable the check."""
+    assert ANCHORS, 'No verified-by anchors found in docs/math/ — did the regex break?'
+
+
+@pytest.mark.parametrize(('md_file', 'target_path', 'nodeid'), ANCHORS)
+def test_anchor_resolves(md_file: str, target_path: str, nodeid: str) -> None:
+    """Target file exists and defines the referenced test function."""
+    target = REPO_ROOT / target_path
+    assert target.exists(), f'{md_file}: anchor points to missing file {target_path!r}'
+
+    # nodeid may be "ClassName::method_name" or just "function_name"
+    leaf = nodeid.rsplit('::', 1)[-1]
+    content = target.read_text()
+    assert re.search(rf'\bdef {re.escape(leaf)}\s*\(', content), (
+        f'{md_file}: anchor {target_path}::{nodeid} — no def {leaf}(...) in target file'
+    )


### PR DESCRIPTION
## Summary

Prototype of a sustainable way to keep `docs/math/` formulas in sync with the actual linopy constraints — not by checking solved output values, but by **inspecting the constraint structure itself**.

Opens the design for feedback before rolling it out across the rest of the math docs.

## What's in the PR

### 1. Structural constraint inspection — `tests/math/test_doc_formulas.py`

Pins one equation (the temporal domain equation from `docs/math/effects.md`) term-by-term:

```python
# Flow term: -c_{Src,cost} * dt
assert _term_coeff(constraint, row, src) == pytest.approx(-cost_coeff * dt)

# Cross-effect term: -alpha_{cost,co2}
assert _term_coeff(constraint, row, et_co2) == pytest.approx(-alpha)
```

The helper `_term_coeff` looks up a variable label in `constraint.vars` / `constraint.coeffs`. If someone drops the `dt` factor, renames `effect_temporal_eq`, or forgets the cross-effect term, this test fails with the equation it verifies in the docstring.

Compare to the existing numeric tests (`test_math.py`): those verify `result.objective == 195`, which is a weaker claim — two wrong formulas can yield the same output on a small example.

### 2. Anchor convention — `docs/math/effects.md`

Each verified equation gets a sibling HTML comment:

```markdown
\[ \Phi_{k,t}^{\text{temporal}} = \sum_f c_{f,k,t} \cdot P_{f,t} \cdot \Delta t_t + \ldots \]

<!-- verified-by: tests/math/test_doc_formulas.py::TestTemporalEquation::test_effect_temporal_equation -->
```

### 3. CI guard — `tests/test_doc_anchors.py`

Parametrized pytest that collects every `verified-by` anchor and fails if the target file or `def <test_name>(` is missing. Prevents silent drift when a test is renamed or deleted.

## Tradeoffs to think through

- **Test writing cost.** Each equation needs ~20 lines. Total for fluxopt: ~10–15 tests. Manageable one-time cost.
- **Maintenance cost.** Refactors that change internal variable names or constraint structure require test updates — but that's exactly the drift we want to catch.
- **Coverage gap.** These tests verify the *structure* of built constraints, not that the derivation in prose is correct. Sensitivity tests in `test_math.py` complement this.
- **Readability.** The test docstring quotes the equation; the asserts mirror its terms. A reviewer can check "is this what the equation says?" without reading any model code.
- **Anchor placement.** Currently right below the `\[ \]` block. Could move into a footnote-like link if it feels noisy in rendered output.

## If accepted

Next steps would be to add tests for:
- `effect_lump_eq` (sizing cost sums, investment at-build, recurring)
- `effect_total_eq` (temporal sum + lump)
- `carrier_balance`
- Status-flow running-cost term on `effect_temporal_eq` (currently unverified)
- Storage level balance

Rolled out one equation at a time, not all at once.

## Test plan

- [x] New tests pass (`pytest tests/math/test_doc_formulas.py tests/test_doc_anchors.py`)
- [x] Full suite still green (385 passed)
- [x] Lint, format, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test suite to verify mathematical equations documented in the system are accurate.
  * Implemented automated validation to confirm documentation references properly link to test implementations.

* **Documentation**
  * Added verification anchors establishing traceability between documented mathematical equations and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->