### PR TITLE
fix: include Investment costs in compute_effect_contributions

### DIFF
--- a/src/fluxopt/contributions.py
+++ b/src/fluxopt/contributions.py
@@ -1,8 +1,8 @@
 """Per-contributor effect breakdown.
 
 Decomposes solver effect totals into per-contributor (flow/storage) parts,
-split into temporal (per-timestep) and periodic (sizing, fixed costs) domains — matching
-the model's own temporal/periodic structure.
+split into temporal (per-timestep) and lump (sizing + investment costs) domains —
+matching the model's own temporal/lump structure.
 
 Cross-effects use the Leontief inverse: total = (I - C)^-1 * direct,
 where C is the cross-effect coefficient matrix.
@@ -16,7 +16,7 @@ import numpy as np
 import xarray as xr
 
 if TYPE_CHECKING:
-    from fluxopt.model_data import ModelData
+    from fluxopt.model_data import FlowsData, ModelData
 
 
 def _leontief(cf: xr.DataArray) -> xr.DataArray:
@@ -51,7 +51,7 @@ def _apply_leontief(
     return result
 
 
-def _compute_periodic(
+def _compute_sizing_lump(
     effects_per_size: xr.DataArray | None,
     effects_fixed: xr.DataArray | None,
     mandatory: xr.DataArray | None,
@@ -63,7 +63,7 @@ def _compute_periodic(
     size_var: str,
     indicator_var: str,
 ) -> xr.DataArray:
-    """Compute periodic contributions for flows or storages.
+    """Compute Sizing lump contributions for flows or storages.
 
     Args:
         effects_per_size: Per-unit sizing costs ``(sizing_dim, effect)`` or None.
@@ -107,6 +107,40 @@ def _compute_periodic(
             term = ef_mand.reindex({entity_dim: contributor_ids}, fill_value=0.0)
             result = result + term.rename({entity_dim: 'contributor'})
 
+    return result
+
+
+def _compute_investment_lump(
+    fds: FlowsData,
+    solution: xr.Dataset,
+    flow_ids: list[str],
+    effect_ids: list[str],
+) -> xr.DataArray:
+    """Compute Investment lump contributions per (flow, effect).
+
+    Each of the 4 Investment cost parameters multiplies a different solver
+    variable, but all accumulate into the same lump bucket per flow.
+    """
+    result = xr.DataArray(
+        np.zeros((len(flow_ids), len(effect_ids))),
+        dims=['contributor', 'effect'],
+        coords={'contributor': flow_ids, 'effect': effect_ids},
+    )
+    pairs = [
+        (fds.invest_effects_per_size_at_build, 'invest--size_at_build'),
+        (fds.invest_effects_fixed_at_build, 'invest--build'),
+        (fds.invest_effects_per_size_recurring, 'flow--size'),  # selected to invest flows
+        (fds.invest_effects_fixed_recurring, 'invest--active'),
+    ]
+    for coeff, var_name in pairs:
+        if coeff is None:
+            continue
+        c = coeff.rename({'invest_flow': 'flow'})
+        var = solution[var_name]
+        if var_name == 'flow--size':
+            var = var.sel(flow=list(coeff.coords['invest_flow'].values))
+        term = (c * var).reindex(flow=flow_ids, fill_value=0.0)
+        result = result + term.rename({'flow': 'contributor'})
     return result
 
 
@@ -154,8 +188,8 @@ def compute_effect_contributions(solution: xr.Dataset, data: ModelData) -> xr.Da
     # Rename to contributor dim
     temporal = temporal_flow.rename({'flow': 'contributor'})
 
-    # --- Lump: flow costs ---
-    flow_lump = _compute_periodic(
+    # --- Lump: flow sizing costs ---
+    flow_lump = _compute_sizing_lump(
         data.flows.sizing_effects_per_size,
         data.flows.sizing_effects_fixed,
         data.flows.sizing_mandatory,
@@ -168,9 +202,12 @@ def compute_effect_contributions(solution: xr.Dataset, data: ModelData) -> xr.Da
         'flow--size_indicator',
     )
 
-    # --- Lump: storage costs ---
+    # --- Lump: flow investment costs (at_build + recurring) ---
+    flow_lump = flow_lump + _compute_investment_lump(data.flows, solution, flow_ids, effect_ids)
+
+    # --- Lump: storage sizing costs ---
     if stor_ids:
-        stor_lump = _compute_periodic(
+        stor_lump = _compute_sizing_lump(
             data.storages.sizing_effects_per_size,  # type: ignore[union-attr]
             data.storages.sizing_effects_fixed,  # type: ignore[union-attr]
             data.storages.sizing_mandatory,  # type: ignore[union-attr]

--- a/tests/math_port/test_multi_period.py
+++ b/tests/math_port/test_multi_period.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_allclose
 from fluxopt import Carrier, Effect, Flow, Investment, Port, Sizing, Status, Storage
 
 _VALIDATE = 'optimize->save->reload->validate'
-_XFAIL_REASON = 'effect_contributions does not yet support investment/period decomposition (#84)'
+_XFAIL_REASON = 'effect_contributions Leontief inverse fails for period-varying contribution_from (#134)'
 
 
 def _xfail_if_validate(optimize: object) -> None:
@@ -157,7 +157,6 @@ class TestInvestment:
         total[p=0]=130, total[p=1]=30, total[p=2]=30.
         Objective = 5*130 + 5*30 + 5*30 = 950.
         """
-        _xfail_if_validate(optimize)
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
@@ -316,7 +315,6 @@ class TestInvestment:
         Mandatory build → built in period 0. Lump = 100 in p=0, 0 in p=1.
         Objective = 5*100 + 5*0 = 500.
         """
-        _xfail_if_validate(optimize)
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
@@ -352,7 +350,6 @@ class TestInvestment:
         Recurring O&M = 2/MW/period, size=10 MW. 2 periods, weights=[5, 5].
         Periodic cost per period = 2*10 = 20. Weighted: 5*20 + 5*20 = 200.
         """
-        _xfail_if_validate(optimize)
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Heat')],
@@ -466,7 +463,6 @@ class TestPeriodVaryingEffects:
         Active in both periods. Periodic cost = O&M * size.
         2020: 1*10=10, 2025: 3*10=30. Weights=[1, 1]. Objective = 10 + 30 = 40.
         """
-        _xfail_if_validate(optimize)
         periods = [2020, 2025]
         om_by_period = xr.DataArray([1.0, 3.0], dims=['period'], coords={'period': periods})
         result = optimize(
@@ -502,7 +498,6 @@ class TestPeriodVaryingEffects:
         Investment(10, 10), fixed periodic cost varies: 5 in 2020, 15 in 2025.
         Active in both periods. Weights=[1, 1]. Objective = 5 + 15 = 20.
         """
-        _xfail_if_validate(optimize)
         periods = [2020, 2025]
         cost_by_period = xr.DataArray([5.0, 15.0], dims=['period'], coords={'period': periods})
         result = optimize(
@@ -539,7 +534,6 @@ class TestPeriodVaryingEffects:
         Mandatory build → builds in cheapest period (2020). Once cost = 10*10 = 100.
         Weights=[1, 1]. Objective = 100.
         """
-        _xfail_if_validate(optimize)
         periods = [2020, 2025]
         capex_by_period = xr.DataArray([10.0, 20.0], dims=['period'], coords={'period': periods})
         result = optimize(
@@ -576,7 +570,6 @@ class TestPeriodVaryingEffects:
         Mandatory build → builds in cheapest period (2020). Once cost = 50.
         Weights=[1, 1]. Objective = 50.
         """
-        _xfail_if_validate(optimize)
         periods = [2020, 2025]
         capex_by_period = xr.DataArray([50.0, 100.0], dims=['period'], coords={'period': periods})
         result = optimize(


### PR DESCRIPTION
## Summary

`compute_effect_contributions` previously only attributed Sizing costs to contributors; Investment costs were missing, causing the validation check to fail (`ValueError: Effect contributions do not sum to solver totals`) for any model using Investment.

This PR adds `_compute_investment_lump()` which attributes the four Investment cost types to the originating flow:
- `effects_per_size_at_build` × `invest--size_at_build` (CAPEX scaled by built capacity)
- `effects_fixed_at_build` × `invest--build` (CAPEX fixed when built)
- `effects_per_size_recurring` × `flow--size` (recurring O&M scaled by capacity)
- `effects_fixed_recurring` × `invest--active` (recurring fixed O&M)

Mirrors the model's own `lump_direct` accumulation in `_create_effects()`.

Closes #84.

## Test plan

- [x] 7 xfail markers removed from `test_multi_period.py` validate-pipeline tests that now pass
- [x] 1 xfail remains: period-varying `contribution_from` Leontief inverse — separate bug tracked in #134
- [x] Full suite: 389 passed, 1 xfailed (was 382 passed, 8 xfailed)
- [x] Validated `result.stats.effect_contributions['total'].sum('contributor') == result.effect_totals` for multi-period Investment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cost contribution calculations for investment and sizing components in multi-period analyses.

* **Tests**
  * Investment-related test cases for period-varying scenarios now pass correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->