### PR TITLE
feat: cache per-contributor effect contributions in Result

### DIFF
--- a/src/fluxopt/results.py
+++ b/src/fluxopt/results.py
@@ -41,11 +41,16 @@ class Result:
         solution: Solved variable values as xr.Dataset.
         data: ModelData used to build the optimization.
         duals: Dual values (shadow prices) from the solver.
+        contributions: Cached *direct* per-contributor effect breakdown (no
+            cross-effect propagation). Surfaced via
+            ``result.stats.effect_contributions_direct``;
+            ``result.stats.effect_contributions`` applies Leontief on top.
     """
 
     solution: xr.Dataset
     data: ModelData = field(repr=False)
     duals: xr.Dataset = field(default_factory=xr.Dataset, repr=False)
+    contributions: xr.Dataset | None = field(default=None, repr=False)
 
     @property
     def objective(self) -> float:
@@ -157,6 +162,8 @@ class Result:
         p = Path(path)
         self.solution.to_netcdf(p, mode='w', engine='netcdf4')
         self.data.to_netcdf(p)
+        if self.contributions is not None:
+            self.contributions.to_netcdf(p, mode='a', group='contributions', engine='netcdf4')
 
     @classmethod
     def from_netcdf(cls, path: str | Path) -> Result:
@@ -170,7 +177,23 @@ class Result:
         p = Path(path)
         solution = xr.load_dataset(p, engine='netcdf4')
         data = ModelData.from_netcdf(p)
-        return cls(solution=solution, data=data)
+
+        try:
+            contributions = xr.load_dataset(p, group='contributions', engine='netcdf4')
+        except OSError:
+            contributions = None
+            import warnings
+
+            warnings.warn(
+                f"NetCDF file {p} has no 'contributions' group; per-contributor effect "
+                'breakdown will be re-derived from solution + ModelData on first access. '
+                'Results may differ from the original solve if the contribution-decomposition '
+                'logic has changed since the file was written. Re-save the Result to refresh '
+                'the cached breakdown.',
+                stacklevel=2,
+            )
+
+        return cls(solution=solution, data=data, contributions=contributions)
 
     @cached_property
     def plot(self) -> PlotAccessor:
@@ -241,4 +264,25 @@ class Result:
 
         solution = xr.Dataset(sol_vars, attrs={'objective': obj_val})
         duals = model.m.dual
-        return cls(solution=solution, data=model.data, duals=duals)
+
+        from fluxopt.contributions import _with_cross_effects, compute_effect_contributions
+
+        try:
+            # Cache the direct (no cross-effect) view — it's the primitive both
+            # accessors build on. effect_contributions applies Leontief on top
+            # via _with_cross_effects, which is cheap relative to _compute_direct.
+            contributions = compute_effect_contributions(solution, model.data, cross_effects=False)
+            # Sanity-check at solve time: applying cross-effects must reproduce
+            # the solver's effect--total. Result discarded; caches stay direct.
+            _with_cross_effects(contributions, model.data, solution)
+        except Exception:
+            import warnings
+
+            warnings.warn(
+                'Failed to compute effect contributions during solve; '
+                'result.contributions will be None (re-derive via result.stats.effect_contributions)',
+                stacklevel=2,
+            )
+            contributions = None
+
+        return cls(solution=solution, data=model.data, duals=duals, contributions=contributions)

--- a/src/fluxopt/results.py
+++ b/src/fluxopt/results.py
@@ -275,11 +275,11 @@ class Result:
             # Sanity-check at solve time: applying cross-effects must reproduce
             # the solver's effect--total. Result discarded; caches stay direct.
             _with_cross_effects(contributions, model.data, solution)
-        except Exception:
+        except Exception as exc:
             import warnings
 
             warnings.warn(
-                'Failed to compute effect contributions during solve; '
+                f'Failed to compute effect contributions during solve ({exc!r}); '
                 'result.contributions will be None (re-derive via result.stats.effect_contributions)',
                 stacklevel=2,
             )

--- a/src/fluxopt/stats.py
+++ b/src/fluxopt/stats.py
@@ -63,6 +63,9 @@ class StatsAccessor:
         Returns:
             Dataset with ``temporal``, ``lump``, and ``total`` DataArrays.
         """
+        if self._result.contributions is not None:
+            return self._result.contributions
+
         from fluxopt.contributions import compute_effect_contributions
 
         return compute_effect_contributions(self._result.solution, self._result.data, cross_effects=False)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -246,8 +246,8 @@ class TestContributionsRoundtrip:
 
     def test_from_model_warns_and_falls_back_when_compute_fails(self, monkeypatch) -> None:
         """If compute_effect_contributions raises during solve, from_model emits a
-        warning and sets result.contributions to None — lazy re-derivation still
-        works via the stats accessor."""
+        warning (including the exception) and sets result.contributions to None —
+        lazy re-derivation via the stats accessor still produces the breakdown."""
         import fluxopt.contributions as contributions_mod
 
         def _raise(*args, **kwargs):
@@ -255,7 +255,15 @@ class TestContributionsRoundtrip:
 
         monkeypatch.setattr(contributions_mod, 'compute_effect_contributions', _raise)
 
-        with pytest.warns(UserWarning, match='Failed to compute effect contributions'):
+        with pytest.warns(UserWarning, match=r'synthetic failure for test'):
             result = _solve_simple([datetime(2024, 1, 1, h) for h in range(3)])
 
         assert result.contributions is None
+
+        # Restore the real function and exercise the lazy fallback path:
+        # result.stats.effect_contributions must still produce a valid breakdown
+        # by re-deriving from solution + ModelData.
+        monkeypatch.undo()
+        contrib = result.stats.effect_contributions
+        assert contrib is not None
+        assert set(contrib.data_vars) == {'temporal', 'lump', 'total'}

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -224,3 +224,38 @@ class TestContributionsRoundtrip:
             warnings.simplefilter('error', UserWarning)
             loaded = Result.from_netcdf(tmp_nc)
         assert loaded.contributions is not None
+
+    def test_netcdf_group_structure(self, tmp_nc: Path) -> None:
+        """The saved file has a 'contributions' NetCDF group with temporal/lump/total
+        variables on the (contributor, effect[, time]) dims — verified by opening
+        the group directly, independent of Result.from_netcdf."""
+        result = _solve_simple([datetime(2024, 1, 1, h) for h in range(3)])
+        assert result.contributions is not None
+        result.to_netcdf(tmp_nc)
+
+        # Main group (solution) loads without specifying group=
+        solution = xr.load_dataset(tmp_nc)
+        assert 'flow--rate' in solution
+
+        # The contributions group is its own NetCDF group on the same file.
+        contrib = xr.load_dataset(tmp_nc, group='contributions')
+        assert set(contrib.data_vars) == {'temporal', 'lump', 'total'}
+        assert set(contrib['temporal'].dims) == {'contributor', 'effect', 'time'}
+        assert set(contrib['lump'].dims) == {'contributor', 'effect'}
+        assert set(contrib['total'].dims) == {'contributor', 'effect'}
+
+    def test_from_model_warns_and_falls_back_when_compute_fails(self, monkeypatch) -> None:
+        """If compute_effect_contributions raises during solve, from_model emits a
+        warning and sets result.contributions to None — lazy re-derivation still
+        works via the stats accessor."""
+        import fluxopt.contributions as contributions_mod
+
+        def _raise(*args, **kwargs):
+            raise RuntimeError('synthetic failure for test')
+
+        monkeypatch.setattr(contributions_mod, 'compute_effect_contributions', _raise)
+
+        with pytest.warns(UserWarning, match='Failed to compute effect contributions'):
+            result = _solve_simple([datetime(2024, 1, 1, h) for h in range(3)])
+
+        assert result.contributions is None

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -183,3 +183,44 @@ class TestSolutionDataset:
         assert isinstance(ds, xr.Dataset)
         assert 'flow--rate' in ds
         assert ds.attrs['objective'] == pytest.approx(result.objective)
+
+
+class TestContributionsRoundtrip:
+    def test_contributions_serialized(self, tmp_nc: Path) -> None:
+        """Pre-computed contributions survive a NetCDF roundtrip."""
+        result = _solve_simple([datetime(2024, 1, 1, h) for h in range(3)])
+        assert result.contributions is not None
+
+        result.to_netcdf(tmp_nc)
+        loaded = Result.from_netcdf(tmp_nc)
+
+        assert loaded.contributions is not None
+        xr.testing.assert_allclose(loaded.contributions['temporal'], result.contributions['temporal'])
+        xr.testing.assert_allclose(loaded.contributions['lump'], result.contributions['lump'])
+        xr.testing.assert_allclose(loaded.contributions['total'], result.contributions['total'])
+
+    def test_old_file_without_contributions(self, tmp_nc: Path) -> None:
+        """Loading a file without contributions group falls back gracefully and warns."""
+        result = _solve_simple([datetime(2024, 1, 1, h) for h in range(3)])
+        # Write without contributions (simulate old format)
+        result.solution.to_netcdf(tmp_nc, mode='w', engine='netcdf4')
+        result.data.to_netcdf(tmp_nc)
+
+        with pytest.warns(UserWarning, match="no 'contributions' group"):
+            loaded = Result.from_netcdf(tmp_nc)
+        assert loaded.contributions is None
+        # Fallback re-derivation still works
+        contrib = loaded.stats.effect_contributions
+        assert 'temporal' in contrib
+
+    def test_roundtrip_does_not_warn(self, tmp_nc: Path) -> None:
+        """Loading a file with cached contributions does not emit the missing-group warning."""
+        import warnings
+
+        result = _solve_simple([datetime(2024, 1, 1, h) for h in range(3)])
+        result.to_netcdf(tmp_nc)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', UserWarning)
+            loaded = Result.from_netcdf(tmp_nc)
+        assert loaded.contributions is not None


### PR DESCRIPTION
## Summary

- Compute per-contributor effect contributions eagerly in `Result.from_model()` and store as a new `contributions` field on `Result`.
- Serialize/deserialize contributions via a `'contributions'` NetCDF group, with graceful fallback for files written before this change.
- `StatsAccessor.effect_contributions_direct` returns the cached dataset directly; `StatsAccessor.effect_contributions` builds on top via `_with_cross_effects`, so neither view re-runs the heavy `_compute_direct` work on reload.

Closes #136.

## Details

`compute_effect_contributions()` re-derives the same broadcasting logic the model uses for effect totals. Previously the `optimize→save→reload→validate` pipeline re-derived from scratch on every load.

This change calls `compute_effect_contributions(..., cross_effects=False)` once at solve time, caches the **direct** result on `Result`, and serializes it alongside the solution data. On reload, contributions are read directly from the NetCDF file. Old files without the group fall back to lazy re-derivation via `StatsAccessor`.

### Why cache the direct view?

After #161 introduced the direct vs with-cross distinction, the direct view is the natural cache target:

- It's the primitive — `effect_coeff × rate × dt` broadcasting + sizing/investment lump assembly, which dominates the cost.
- Both stats accessors benefit: `effect_contributions_direct` returns the cache as-is; `effect_contributions` applies the Leontief inverse on top, which is cheap.
- Caching with-cross would redundantly run `_compute_direct` again whenever a user accessed the direct view.

### Solve-time validation

The cache stores direct, but validation against solver `effect--total` still runs at solve time: we call `_with_cross_effects(direct, data, solution)` once and discard the result, so a buggy direct decomposition still fails loudly on solve. The `try/except` keeps the failure non-fatal for the cache (logs a warning, leaves `result.contributions = None`, lazy re-derivation still works).

## Test plan

- [x] `pytest tests/math/test_contributions.py` — 28 passing, including new direct-mode tests
- [x] `pytest tests/test_io.py` — roundtrip + backward-compat tests pass; cached contributions reload identically
- [x] `pytest tests/math_port/` — `optimize→save→reload→validate` pipelines pass for cross-effect tests (period-varying xfail dropped — fixed in #139)
- [x] `pytest -q` — 458 passed, 227 skipped
- [x] `mypy src/` — clean
- [x] `ruff check . && ruff format .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Result objects now cache contribution decomposition data for improved performance.
  * Contribution data is automatically persisted when saving to NetCDF files.

* **Improvements**
  * Enhanced backward compatibility: legacy files without contribution data load successfully with a helpful warning and can recompute contributions as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->