### PR TITLE
docs: expand area label taxonomy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,9 +75,17 @@ Optional scope: `feat(storage): add cyclic constraint`.
   `.github/workflows/label-from-title.yaml`. Only `feat`, `fix`, `docs`, `perf`
   get a label; other prefixes (`refac`, `test`, `ci`, `build`, `chore`) no-op.
 - **`area:*`** — subsystem. Applied manually during triage.
-  `area:api` (user-facing types, ergonomics), `area:model` (optimization math
-  and data model), `area:io` (serialization, loading, saving),
-  `area:viz` (plots, stats).
+  - `area:api` — cross-cutting naming, user-facing types, ergonomics
+  - `area:flow` — Flow, Port
+  - `area:converter` — Converter, part-load behavior
+  - `area:storage` — Storage elements
+  - `area:status` — on/off behavior, startup, min run time
+  - `area:sizing` — Sizing / Investment, capacity optimization
+  - `area:effects` — Effect system, objectives, contributions
+  - `area:multi-period` — Periods, rolling horizon, scenarios, TSA
+  - `area:io` — serialization, loading, saving
+  - `area:new` — novel concept not yet fitting an existing area (temporary
+    flag; recategorize when a new area emerges)
 - **Meta**: `good first issue`, `help wanted` (unprefixed — GitHub's
   contributors page recognizes these exact strings).
 


### PR DESCRIPTION
## Summary
- Split `area:model` into granular buckets: `area:flow`, `area:converter`, `area:storage`, `area:status`, `area:sizing`, `area:effects`, `area:multi-period`
- Drop `area:viz` — visualization lives in the `fluxopt-plot` companion package, not this repo
- Add `area:new` as a triage flag for novel concepts without a clear home (temporary; recategorize when a new area emerges)

All existing open issues and PRs have been backfilled with the new labels. Closed issues and recent merged PRs were also relabeled for navigation consistency.

## Test plan
- [x] Labels created/deleted on GitHub
- [x] All open issues labeled (type + area)
- [x] All open PRs labeled (type + area)
- [x] Closed issues and recent merged PRs backfilled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  - Updated internal development area labels and documentation structure to reflect a more granular categorization system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->