### PR TITLE
feat: add component-level status on Storage

### DIFF
--- a/src/fluxopt/components.py
+++ b/src/fluxopt/components.py
@@ -7,7 +7,7 @@ from fluxopt.elements import qualified_id
 from fluxopt.types import IdList
 
 if TYPE_CHECKING:
-    from fluxopt.elements import Flow, Status
+    from fluxopt.elements import Flow
     from fluxopt.types import TimeSeries
 
 
@@ -44,22 +44,12 @@ class Converter:
     Conversion equation (per equation index)::
 
         sum_f(a_f * P_{f,t}) = 0   for all t
-
-    Args:
-        id: Converter id.
-        inputs: Input flows.
-        outputs: Output flows.
-        conversion_factors: One dict per equation; ``{flow_short_id: a_f}``.
-        status: Component-level on/off behavior gating all input and output
-            flows together. Forbids flow-level ``status`` on the child flows
-            (the two switches would have no defined precedence).
     """
 
     id: str
     inputs: list[Flow] | IdList[Flow]
     outputs: list[Flow] | IdList[Flow]
     conversion_factors: list[dict[str, TimeSeries]] = field(default_factory=list)  # a_f
-    status: Status | None = None
     _short_to_id: dict[str, str] = field(init=False, default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -67,14 +57,6 @@ class Converter:
         self.inputs = _qualify_flows(self.id, list(self.inputs))
         self.outputs = _qualify_flows(self.id, list(self.outputs))
         self._short_to_id = {f.short_id: f.id for f in (*self.inputs, *self.outputs)}
-        if self.status is not None:
-            for f in (*self.inputs, *self.outputs):
-                if f.status is not None:
-                    msg = (
-                        f'Converter {self.id!r}: flow {f.short_id!r} cannot have flow-level '
-                        f'status when Converter.status is set; the component status already gates all flows'
-                    )
-                    raise ValueError(msg)
 
     @classmethod
     def _single_io(cls, id: str, coefficient: TimeSeries, input_flow: Flow, output_flow: Flow) -> Converter:

--- a/src/fluxopt/components.py
+++ b/src/fluxopt/components.py
@@ -7,7 +7,7 @@ from fluxopt.elements import qualified_id
 from fluxopt.types import IdList
 
 if TYPE_CHECKING:
-    from fluxopt.elements import Flow
+    from fluxopt.elements import Flow, Status
     from fluxopt.types import TimeSeries
 
 
@@ -44,12 +44,22 @@ class Converter:
     Conversion equation (per equation index)::
 
         sum_f(a_f * P_{f,t}) = 0   for all t
+
+    Args:
+        id: Converter id.
+        inputs: Input flows.
+        outputs: Output flows.
+        conversion_factors: One dict per equation; ``{flow_short_id: a_f}``.
+        status: Component-level on/off behavior gating all input and output
+            flows together. Forbids flow-level ``status`` on the child flows
+            (the two switches would have no defined precedence).
     """
 
     id: str
     inputs: list[Flow] | IdList[Flow]
     outputs: list[Flow] | IdList[Flow]
     conversion_factors: list[dict[str, TimeSeries]] = field(default_factory=list)  # a_f
+    status: Status | None = None
     _short_to_id: dict[str, str] = field(init=False, default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -57,6 +67,14 @@ class Converter:
         self.inputs = _qualify_flows(self.id, list(self.inputs))
         self.outputs = _qualify_flows(self.id, list(self.outputs))
         self._short_to_id = {f.short_id: f.id for f in (*self.inputs, *self.outputs)}
+        if self.status is not None:
+            for f in (*self.inputs, *self.outputs):
+                if f.status is not None:
+                    msg = (
+                        f'Converter {self.id!r}: flow {f.short_id!r} cannot have flow-level '
+                        f'status when Converter.status is set; the component status already gates all flows'
+                    )
+                    raise ValueError(msg)
 
     @classmethod
     def _single_io(cls, id: str, coefficient: TimeSeries, input_flow: Flow, output_flow: Flow) -> Converter:

--- a/src/fluxopt/contributions.py
+++ b/src/fluxopt/contributions.py
@@ -181,6 +181,31 @@ def compute_effect_contributions(solution: xr.Dataset, data: ModelData) -> xr.Da
         es = data.flows.status_effects_startup.rename({'status_flow': 'flow'})
         temporal_flow = temporal_flow + (es * solution['flow--startup']).reindex(flow=flow_ids, fill_value=0.0)
 
+    # Component-level status: attribute running and startup costs to first governed flow
+    if data.flows.cstatus_governed_flows is not None:
+        gf = data.flows.cstatus_governed_flows
+        first_flow_per_comp = {
+            str(comp_id): str(gf.sel(cstatus_component=comp_id).values[0])
+            for comp_id in gf.coords['cstatus_component'].values
+            if str(gf.sel(cstatus_component=comp_id).values[0])
+        }
+
+        if data.flows.cstatus_effects_running is not None and 'component--on' in solution:
+            cer = data.flows.cstatus_effects_running.rename({'cstatus_component': 'component'})
+            comp_temporal = cer * solution['component--on'] * dt  # (component, effect, time)
+            for comp_id, fid in first_flow_per_comp.items():
+                if fid in flow_ids:
+                    add = comp_temporal.sel(component=comp_id).drop_vars('component')
+                    temporal_flow.loc[{'flow': fid}] = temporal_flow.sel(flow=fid) + add
+
+        if data.flows.cstatus_effects_startup is not None and 'component--startup' in solution:
+            ces = data.flows.cstatus_effects_startup.rename({'cstatus_component': 'component'})
+            comp_startup = ces * solution['component--startup']  # (component, effect, time)
+            for comp_id, fid in first_flow_per_comp.items():
+                if fid in flow_ids:
+                    add = comp_startup.sel(component=comp_id).drop_vars('component')
+                    temporal_flow.loc[{'flow': fid}] = temporal_flow.sel(flow=fid) + add
+
     # Cross-effects on temporal via Leontief inverse
     if data.effects.cf_temporal is not None:
         temporal_flow = _apply_leontief(_leontief(data.effects.cf_temporal), temporal_flow)

--- a/src/fluxopt/elements.py
+++ b/src/fluxopt/elements.py
@@ -264,6 +264,9 @@ class Storage:
         cyclic: If True, end level must equal start level.
         relative_minimum_level: Min SOC as fraction of capacity.
         relative_maximum_level: Max SOC as fraction of capacity.
+        status: Component-level on/off behavior gating both charging and
+            discharging. Forbids flow-level ``status`` and
+            ``fixed_relative_profile`` on the child flows.
     """
 
     id: str
@@ -277,6 +280,7 @@ class Storage:
     cyclic: bool = True  # E_{s,first} == E_{s,last}
     relative_minimum_level: TimeSeries = 0.0  # e̲_s  [-]
     relative_maximum_level: TimeSeries = 1.0  # ē_s  [-]
+    status: Status | None = None
 
     def __post_init__(self) -> None:
         """Validate carrier match, rename colliding flow ids, and qualify."""
@@ -291,3 +295,17 @@ class Storage:
             self.discharging.short_id = 'discharge'
         self.charging.id = qualified_id(self.id, self.charging.short_id)
         self.discharging.id = qualified_id(self.id, self.discharging.short_id)
+        if self.status is not None:
+            for f in (self.charging, self.discharging):
+                if f.status is not None:
+                    msg = (
+                        f'Storage {self.id!r}: flow {f.short_id!r} cannot have flow-level '
+                        f'status when Storage.status is set; the component status already gates both flows'
+                    )
+                    raise ValueError(msg)
+                if f.fixed_relative_profile is not None:
+                    msg = (
+                        f'Storage {self.id!r}: flow {f.short_id!r} cannot have '
+                        f'fixed_relative_profile when Storage.status is set'
+                    )
+                    raise ValueError(msg)

--- a/src/fluxopt/elements.py
+++ b/src/fluxopt/elements.py
@@ -265,8 +265,8 @@ class Storage:
         relative_minimum_level: Min SOC as fraction of capacity.
         relative_maximum_level: Max SOC as fraction of capacity.
         status: Component-level on/off behavior gating both charging and
-            discharging. Forbids flow-level ``status`` and
-            ``fixed_relative_profile`` on the child flows.
+            discharging. Forbids flow-level ``status`` on the child flows
+            (the two switches would have no defined precedence).
     """
 
     id: str
@@ -301,11 +301,5 @@ class Storage:
                     msg = (
                         f'Storage {self.id!r}: flow {f.short_id!r} cannot have flow-level '
                         f'status when Storage.status is set; the component status already gates both flows'
-                    )
-                    raise ValueError(msg)
-                if f.fixed_relative_profile is not None:
-                    msg = (
-                        f'Storage {self.id!r}: flow {f.short_id!r} cannot have '
-                        f'fixed_relative_profile when Storage.status is set'
                     )
                     raise ValueError(msg)

--- a/src/fluxopt/elements.py
+++ b/src/fluxopt/elements.py
@@ -303,3 +303,10 @@ class Storage:
                         f'status when Storage.status is set; the component status already gates both flows'
                     )
                     raise ValueError(msg)
+                if f.size is None:
+                    msg = (
+                        f'Storage {self.id!r}: flow {f.short_id!r} must have a size when '
+                        f'Storage.status is set — without it, the on/off binary cannot gate '
+                        f'the rate (no upper bound to scale)'
+                    )
+                    raise ValueError(msg)

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -507,6 +507,10 @@ class FlowSystem:
                 bt = str(ds.bound_type.sel(flow=fid).values)
                 size_val = ds.size.sel(flow=fid).values
                 if np.isnan(size_val):
+                    # Unsized flow — no direct gating possible (no upper bound to scale by on).
+                    # Storage forbids this in __post_init__. For Converter, inputs are commonly
+                    # unsized and gated transitively through the conversion equation
+                    # (e.g. boiler fuel * eta = heat; when heat=0 by on=0, fuel=0).
                     continue
                 size = float(size_val)
                 rl = ds.rel_lb.sel(flow=fid)

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -787,20 +787,15 @@ class FlowSystem:
         max_down = ds.cstatus_max_downtime.rename({'cstatus_component': 'component'})
         initial = ds.cstatus_initial.rename({'cstatus_component': 'component'})
 
-        # Component status has no prior-rate concept (Storage/Converter don't track it).
-        # Default to zero prior duration so duration[0] is anchored at state[0]*dt[0]
-        # via the init constraint — without this, duration[0] is unconstrained from below
-        # and the solver can cheat min_uptime by setting it to an arbitrary value.
-        zeros = xr.zeros_like(min_up)
         prev_up = (
             ds.cstatus_previous_uptime.rename({'cstatus_component': 'component'})
             if ds.cstatus_previous_uptime is not None
-            else zeros
+            else None
         )
         prev_down = (
             ds.cstatus_previous_downtime.rename({'cstatus_component': 'component'})
             if ds.cstatus_previous_downtime is not None
-            else zeros
+            else None
         )
 
         has_initial = initial.notnull()

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -42,6 +42,11 @@ class FlowSystem:
     flow_startup: Variable | None = None
     flow_shutdown: Variable | None = None
 
+    # Component-level status variables — None when no component status is configured
+    component_on: Variable | None = None
+    component_startup: Variable | None = None
+    component_shutdown: Variable | None = None
+
     def __init__(self, data: ModelData) -> None:
         """Initialize the flow system optimization model.
 
@@ -86,14 +91,17 @@ class FlowSystem:
         self._create_sizing_variables()
         self._create_investment_variables()
         self._create_status_variables()
+        self._create_component_status_variables()
         # Phase 2: Flow rate constraints
         self._constrain_flow_rates_plain()
         self._constrain_flow_rates_sizing()
         self._constrain_flow_rates_status()
+        self._constrain_flow_rates_component_status()
         # Phase 3: Feature constraints
         self._constrain_sizing()
         self._constrain_investment()
         self._constrain_status()
+        self._constrain_component_status()
         # Phase 4: System
         self._create_balance()
         self._create_converter_constraints()
@@ -272,6 +280,35 @@ class FlowSystem:
             return set()
         return set(ds.status_min_uptime.coords['status_flow'].values)
 
+    def _create_component_status_variables(self) -> None:
+        """Create binary on/off variables for components with Status."""
+        ds = self.data.flows
+        if ds.cstatus_min_uptime is None:
+            return
+
+        comp_ids = ds.cstatus_min_uptime.coords['cstatus_component'].values
+        comp_coord = xr.DataArray(comp_ids, dims=['component'])
+        tp = {'component': comp_coord, **self.data.dims.coords(time=True, period=True)}
+
+        self.component_on = self._add_variables(binary=True, coords=tp, name='component--on')
+        self.component_startup = self._add_variables(binary=True, coords=tp, name='component--startup')
+        self.component_shutdown = self._add_variables(binary=True, coords=tp, name='component--shutdown')
+
+    def _governed_flows_map(self) -> dict[str, list[str]]:
+        """Return ``{component_id: [flow_ids governed]}`` from data, or empty."""
+        gf = self.data.flows.cstatus_governed_flows
+        if gf is None:
+            return {}
+        result: dict[str, list[str]] = {}
+        for comp_id in gf.coords['cstatus_component'].values:
+            row = gf.sel(cstatus_component=comp_id).values
+            result[str(comp_id)] = [str(f) for f in row if str(f)]
+        return result
+
+    def _component_status_flow_ids(self) -> set[str]:
+        """Return ids of flows governed by component-level Status, or empty set."""
+        return {fid for fids in self._governed_flows_map().values() for fid in fids}
+
     def _sizing_flow_ids(self) -> set[str]:
         """Return ids of sizing flows, or empty set."""
         if self.flow_size is None:
@@ -286,7 +323,8 @@ class FlowSystem:
         ds = self.data.flows
         sizing_ids = self._sizing_flow_ids()
         status_ids = self._status_flow_ids()
-        exclude = sizing_ids | status_ids
+        cstatus_ids = self._component_status_flow_ids()
+        exclude = sizing_ids | status_ids | cstatus_ids
 
         size = ds.size
         rel_lb = ds.rel_lb
@@ -439,6 +477,46 @@ class FlowSystem:
         # on <= S: prevents on=1 when size=0, which would incorrectly
         # charge running/startup costs for a non-existent unit.
         self.m.add_constraints(on <= fs, name='flow_on_requires_size')
+
+    def _constrain_flow_rates_component_status(self) -> None:
+        """Apply gating constraints for flows governed by component-level Status.
+
+        For each component with Status and each governed flow:
+          bounded:  size * rel_lb * on <= P <= size * rel_ub * on
+          profile:  P == size * profile * on
+
+        Sizing/Investment governed flows are not yet supported and raise.
+        """
+        if self.component_on is None:
+            return
+
+        ds = self.data.flows
+        sizing_ids = self._sizing_flow_ids()
+
+        for comp_id, flow_ids in self._governed_flows_map().items():
+            on = self.component_on.sel(component=comp_id)  # (time, period?)
+            for fid in flow_ids:
+                if fid in sizing_ids:
+                    msg = (
+                        f'Component {comp_id!r}: governed flow {fid!r} has Sizing/Investment, '
+                        f'which is not yet supported with component-level status'
+                    )
+                    raise NotImplementedError(msg)
+
+                fr = self.flow_rate.sel(flow=fid)
+                bt = str(ds.bound_type.sel(flow=fid).values)
+                size_val = ds.size.sel(flow=fid).values
+                if np.isnan(size_val):
+                    continue
+                size = float(size_val)
+                rl = ds.rel_lb.sel(flow=fid)
+                ru = ds.rel_ub.sel(flow=fid)
+                if bt == 'bounded':
+                    self.m.add_constraints(fr >= size * rl * on, name=f'flow_lb_cstatus_{fid}')
+                    self.m.add_constraints(fr <= size * ru * on, name=f'flow_ub_cstatus_{fid}')
+                elif bt == 'profile':
+                    fp = ds.fixed_profile.sel(flow=fid)
+                    self.m.add_constraints(fr == size * fp * on, name=f'flow_fix_cstatus_{fid}')
 
     def _constrain_sizing(self) -> None:
         """Constrain sizing variables: S in [min, max] gated by indicator."""
@@ -689,6 +767,78 @@ class FlowSystem:
                 previous=prev_down,
             )
 
+    def _constrain_component_status(self) -> None:
+        """Add switch transition and duration tracking constraints for component status."""
+        if self.component_on is None:
+            return
+        assert self.component_startup is not None
+        assert self.component_shutdown is not None
+
+        ds = self.data.flows
+        assert ds.cstatus_min_uptime is not None
+        assert ds.cstatus_max_uptime is not None
+        assert ds.cstatus_min_downtime is not None
+        assert ds.cstatus_max_downtime is not None
+        assert ds.cstatus_initial is not None
+
+        min_up = ds.cstatus_min_uptime.rename({'cstatus_component': 'component'})
+        max_up = ds.cstatus_max_uptime.rename({'cstatus_component': 'component'})
+        min_down = ds.cstatus_min_downtime.rename({'cstatus_component': 'component'})
+        max_down = ds.cstatus_max_downtime.rename({'cstatus_component': 'component'})
+        initial = ds.cstatus_initial.rename({'cstatus_component': 'component'})
+
+        prev_up = (
+            ds.cstatus_previous_uptime.rename({'cstatus_component': 'component'})
+            if ds.cstatus_previous_uptime is not None
+            else None
+        )
+        prev_down = (
+            ds.cstatus_previous_downtime.rename({'cstatus_component': 'component'})
+            if ds.cstatus_previous_downtime is not None
+            else None
+        )
+
+        has_initial = initial.notnull()
+        previous_state = initial.sel(component=initial.coords['component'][has_initial]) if has_initial.any() else None
+
+        add_switch_transitions(
+            self.m,
+            self.component_on,
+            self.component_startup,
+            self.component_shutdown,
+            name='cstatus',
+            element_dim='component',
+            previous_state=previous_state,
+        )
+
+        dt = self.data.dims.dt
+
+        has_any_up = min_up.notnull().any() | max_up.notnull().any()
+        if has_any_up:
+            add_duration_tracking(
+                self.m,
+                self.component_on,
+                dt,
+                name='c_uptime',
+                element_dim='component',
+                minimum=min_up,
+                maximum=max_up,
+                previous=prev_up,
+            )
+
+        has_any_down = min_down.notnull().any() | max_down.notnull().any()
+        if has_any_down:
+            add_duration_tracking(
+                self.m,
+                1 - self.component_on,
+                dt,
+                name='c_downtime',
+                element_dim='component',
+                minimum=min_down,
+                maximum=max_down,
+                previous=prev_down,
+            )
+
     def _create_balance(self) -> None:
         """Create carrier balance: ``sum_f(coeff * P) = 0`` for all carriers and timesteps."""
         d = self.data
@@ -766,6 +916,20 @@ class FlowSystem:
             es = d.flows.status_effects_startup.rename({'status_flow': 'flow'})
             if (es != 0).any():
                 temporal_rhs = temporal_rhs + (es * self.flow_startup).sum('flow')
+
+        # Component-level status running costs
+        if d.flows.cstatus_effects_running is not None:
+            assert self.component_on is not None
+            cer = d.flows.cstatus_effects_running.rename({'cstatus_component': 'component'})
+            if (cer != 0).any():
+                temporal_rhs = temporal_rhs + (cer * self.component_on * d.dims.dt).sum('component')
+
+        # Component-level status startup costs
+        if d.flows.cstatus_effects_startup is not None:
+            assert self.component_startup is not None
+            ces = d.flows.cstatus_effects_startup.rename({'cstatus_component': 'component'})
+            if (ces != 0).any():
+                temporal_rhs = temporal_rhs + (ces * self.component_startup).sum('component')
 
         # Cross-effect temporal: cf_temporal[k,j,t] * effect_temporal[j,t]
         if ds.cf_temporal is not None:

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -506,11 +506,10 @@ class FlowSystem:
                 fr = self.flow_rate.sel(flow=fid)
                 bt = str(ds.bound_type.sel(flow=fid).values)
                 size_val = ds.size.sel(flow=fid).values
-                if np.isnan(size_val):
-                    # Unsized flow — no upper bound to scale by on, so no gating constraint
-                    # can be added. Callers (Storage.__post_init__, future ConversionCurve)
-                    # must ensure governed flows are sized; this is a defensive invariant
-                    # check.
+                if np.isnan(size_val):  # pragma: no cover
+                    # Defensive invariant check — callers (Storage.__post_init__, future
+                    # ConversionCurve) ensure governed flows are sized. Reaching this branch
+                    # means an invariant was violated upstream.
                     msg = f'Component {comp_id!r}: governed flow {fid!r} is unsized'
                     raise ValueError(msg)
                 size = float(size_val)
@@ -522,6 +521,12 @@ class FlowSystem:
                 elif bt == 'profile':
                     fp = ds.fixed_profile.sel(flow=fid)
                     self.m.add_constraints(fr == size * fp * on, name=f'flow_fix_cstatus_{fid}')
+                else:  # pragma: no cover
+                    # Defensive — only 'bounded' / 'profile' / 'unsized' exist today,
+                    # and 'unsized' is caught above. Reaching this branch means a new
+                    # bound_type was introduced without updating this dispatch.
+                    msg = f'Component {comp_id!r}: governed flow {fid!r} has unsupported bound_type {bt!r}'
+                    raise ValueError(msg)
 
     def _constrain_sizing(self) -> None:
         """Constrain sizing variables: S in [min, max] gated by indicator."""

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -787,15 +787,20 @@ class FlowSystem:
         max_down = ds.cstatus_max_downtime.rename({'cstatus_component': 'component'})
         initial = ds.cstatus_initial.rename({'cstatus_component': 'component'})
 
+        # Component status has no prior-rate concept (Storage/Converter don't track it).
+        # Default to zero prior duration so duration[0] is anchored at state[0]*dt[0]
+        # via the init constraint — without this, duration[0] is unconstrained from below
+        # and the solver can cheat min_uptime by setting it to an arbitrary value.
+        zeros = xr.zeros_like(min_up)
         prev_up = (
             ds.cstatus_previous_uptime.rename({'cstatus_component': 'component'})
             if ds.cstatus_previous_uptime is not None
-            else None
+            else zeros
         )
         prev_down = (
             ds.cstatus_previous_downtime.rename({'cstatus_component': 'component'})
             if ds.cstatus_previous_downtime is not None
-            else None
+            else zeros
         )
 
         has_initial = initial.notnull()

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -16,6 +17,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from fluxopt.model_data import ModelData
+
+logger = logging.getLogger(__name__)
 
 
 class FlowSystem:
@@ -511,6 +514,13 @@ class FlowSystem:
                     # Storage forbids this in __post_init__. For Converter, inputs are commonly
                     # unsized and gated transitively through the conversion equation
                     # (e.g. boiler fuel * eta = heat; when heat=0 by on=0, fuel=0).
+                    logger.info(
+                        'Component %r: governed flow %r is unsized — no direct on/off gating '
+                        'constraint added. Relying on transitive gating via the conversion equation. '
+                        'Verify the flow appears in conversion_factors.',
+                        comp_id,
+                        fid,
+                    )
                     continue
                 size = float(size_val)
                 rl = ds.rel_lb.sel(flow=fid)

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -17,8 +16,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from fluxopt.model_data import ModelData
-
-logger = logging.getLogger(__name__)
 
 
 class FlowSystem:
@@ -510,18 +507,12 @@ class FlowSystem:
                 bt = str(ds.bound_type.sel(flow=fid).values)
                 size_val = ds.size.sel(flow=fid).values
                 if np.isnan(size_val):
-                    # Unsized flow — no direct gating possible (no upper bound to scale by on).
-                    # Storage forbids this in __post_init__. For Converter, inputs are commonly
-                    # unsized and gated transitively through the conversion equation
-                    # (e.g. boiler fuel * eta = heat; when heat=0 by on=0, fuel=0).
-                    logger.info(
-                        'Component %r: governed flow %r is unsized — no direct on/off gating '
-                        'constraint added. Relying on transitive gating via the conversion equation. '
-                        'Verify the flow appears in conversion_factors.',
-                        comp_id,
-                        fid,
-                    )
-                    continue
+                    # Unsized flow — no upper bound to scale by on, so no gating constraint
+                    # can be added. Callers (Storage.__post_init__, future ConversionCurve)
+                    # must ensure governed flows are sized; this is a defensive invariant
+                    # check.
+                    msg = f'Component {comp_id!r}: governed flow {fid!r} is unsized'
+                    raise ValueError(msg)
                 size = float(size_val)
                 rl = ds.rel_lb.sel(flow=fid)
                 ru = ds.rel_ub.sel(flow=fid)

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -260,15 +260,16 @@ class _InvestmentArrays:
 
 @dataclass
 class _StatusArrays:
-    min_uptime: xr.DataArray | None = None  # (status_flow,)
-    max_uptime: xr.DataArray | None = None  # (status_flow,)
-    min_downtime: xr.DataArray | None = None  # (status_flow,)
-    max_downtime: xr.DataArray | None = None  # (status_flow,)
-    initial: xr.DataArray | None = None  # (status_flow,) — NaN = free
-    effects_running: xr.DataArray | None = None  # (status_flow, effect, time, period?)
-    effects_startup: xr.DataArray | None = None  # (status_flow, effect, time, period?)
-    previous_uptime: xr.DataArray | None = None  # (status_flow,) — hours, NaN = no prior
-    previous_downtime: xr.DataArray | None = None  # (status_flow,) — hours, NaN = no prior
+    min_uptime: xr.DataArray | None = None  # (dim,)
+    max_uptime: xr.DataArray | None = None  # (dim,)
+    min_downtime: xr.DataArray | None = None  # (dim,)
+    max_downtime: xr.DataArray | None = None  # (dim,)
+    initial: xr.DataArray | None = None  # (dim,) — NaN = free
+    effects_running: xr.DataArray | None = None  # (dim, effect, time, period?)
+    effects_startup: xr.DataArray | None = None  # (dim, effect, time, period?)
+    previous_uptime: xr.DataArray | None = None  # (dim,) — hours, NaN = no prior
+    previous_downtime: xr.DataArray | None = None  # (dim,) — hours, NaN = no prior
+    governed_flows: xr.DataArray | None = None  # (dim, governed_idx) — only for component status
 
     def __post_init__(self) -> None:
         """Validate durations >= 0 and max >= min where both given."""
@@ -306,17 +307,21 @@ class _StatusArrays:
         prior_rates_map: dict[str, list[float]] | None = None,
         dt: float = 1.0,
         period: pd.Index | None = None,
+        governed_flows_map: dict[str, list[str]] | None = None,
     ) -> Self:
         """Validate Status objects and collect into DataArrays.
 
         Args:
-            items: Pairs of (flow_id, Status).
+            items: Pairs of (id, Status).
             effect_ids: Known effect ids for validation.
             time: Time index for effect arrays.
             dim: Dimension name for the resulting arrays.
-            prior_rates_map: Flow id to prior flow rates (MW) before horizon.
+            prior_rates_map: Item id to prior flow rates (MW) before horizon.
             dt: Scalar timestep duration in hours for prior duration computation.
             period: Period index for period-varying effects.
+            governed_flows_map: Item id to ids of flows the status governs.
+                Only populated for component-level status; emits a 2D
+                ``(dim, governed_idx)`` string array.
         """
         from fluxopt.constraints.status import compute_previous_duration
 
@@ -376,6 +381,19 @@ class _StatusArrays:
         prev_up_arr = np.array(prev_ups)
         prev_down_arr = np.array(prev_downs)
 
+        governed: xr.DataArray | None = None
+        if governed_flows_map:
+            max_n = max(len(governed_flows_map.get(i, [])) for i in ids)
+            if max_n > 0:
+                rows = [
+                    governed_flows_map.get(i, []) + [''] * (max_n - len(governed_flows_map.get(i, []))) for i in ids
+                ]
+                governed = xr.DataArray(
+                    np.array(rows, dtype=object),
+                    dims=[dim, 'governed_idx'],
+                    coords={dim: ids},
+                )
+
         return cls(
             min_uptime=xr.DataArray(np.array(min_ups), dims=[dim], coords=coords),
             max_uptime=xr.DataArray(np.array(max_ups), dims=[dim], coords=coords),
@@ -390,6 +408,7 @@ class _StatusArrays:
             previous_downtime=xr.DataArray(prev_down_arr, dims=[dim], coords=coords)
             if not np.all(np.isnan(prev_down_arr))
             else None,
+            governed_flows=governed,
         )
 
 
@@ -424,6 +443,16 @@ class FlowsData:
     invest_effects_fixed_at_build: xr.DataArray | None = None  # (invest_flow, effect, period?) — once
     invest_effects_per_size_recurring: xr.DataArray | None = None  # (invest_flow, effect, period?)
     invest_effects_fixed_recurring: xr.DataArray | None = None  # (invest_flow, effect, period?)
+    cstatus_min_uptime: xr.DataArray | None = None  # (cstatus_component,)
+    cstatus_max_uptime: xr.DataArray | None = None  # (cstatus_component,)
+    cstatus_min_downtime: xr.DataArray | None = None  # (cstatus_component,)
+    cstatus_max_downtime: xr.DataArray | None = None  # (cstatus_component,)
+    cstatus_initial: xr.DataArray | None = None  # (cstatus_component,) — NaN = free
+    cstatus_effects_running: xr.DataArray | None = None  # (cstatus_component, effect, time, period?)
+    cstatus_effects_startup: xr.DataArray | None = None  # (cstatus_component, effect, time, period?)
+    cstatus_previous_uptime: xr.DataArray | None = None  # (cstatus_component,)
+    cstatus_previous_downtime: xr.DataArray | None = None  # (cstatus_component,)
+    cstatus_governed_flows: xr.DataArray | None = None  # (cstatus_component, governed_idx) — qualified flow ids
 
     def __post_init__(self) -> None:
         """Validate relative bounds: non-negative and lb <= ub."""
@@ -458,6 +487,7 @@ class FlowsData:
         effects: list[Effect],
         dt: float = 1.0,
         period: pd.Index | None = None,
+        component_status_items: list[tuple[str, Status, list[str]]] | None = None,
     ) -> Self:
         """Build FlowsData from element objects.
 
@@ -469,6 +499,10 @@ class FlowsData:
             period: Period index for multi-period models. When provided,
                 ``effect_coeff`` gains a ``period`` dimension so that
                 ``effects_per_flow_hour`` values can vary across periods.
+            component_status_items: Component-level status entries as
+                ``(component_id, Status, [governed flow ids])``. Each entry
+                produces an on/startup/shutdown binary keyed by the
+                component, gating all listed flows together.
         """
         from fluxopt.elements import Investment, Sizing
 
@@ -547,6 +581,15 @@ class FlowsData:
             status_items, effect_ids, time, dim='status_flow', prior_rates_map=prior_rates_map, dt=dt, period=period
         )
 
+        cst = _StatusArrays.build(
+            [(cid, s) for cid, s, _ in (component_status_items or [])],
+            effect_ids,
+            time,
+            dim='cstatus_component',
+            period=period,
+            governed_flows_map={cid: gov for cid, _, gov in (component_status_items or [])} or None,
+        )
+
         return cls(
             bound_type=xr.DataArray(bound_type, dims=['flow'], coords={'flow': flow_ids}),
             rel_lb=fast_concat(rel_lbs, flow_idx),
@@ -577,6 +620,16 @@ class FlowsData:
             invest_effects_fixed_at_build=inv.effects_fixed_at_build,
             invest_effects_per_size_recurring=inv.effects_per_size_recurring,
             invest_effects_fixed_recurring=inv.effects_fixed_recurring,
+            cstatus_min_uptime=cst.min_uptime,
+            cstatus_max_uptime=cst.max_uptime,
+            cstatus_min_downtime=cst.min_downtime,
+            cstatus_max_downtime=cst.max_downtime,
+            cstatus_initial=cst.initial,
+            cstatus_effects_running=cst.effects_running,
+            cstatus_effects_startup=cst.effects_startup,
+            cstatus_previous_uptime=cst.previous_uptime,
+            cstatus_previous_downtime=cst.previous_downtime,
+            cstatus_governed_flows=cst.governed_flows,
         )
 
 
@@ -1329,7 +1382,19 @@ class ModelData:
         # Scalar dt for prior duration computation (use first timestep)
         dt_scalar = float(dims.dt.values[0])
         period_idx = pd.Index(dims.period.values) if dims.period is not None else None
-        flows_data = FlowsData.build(flows, time, effects, dt=dt_scalar, period=period_idx)
+
+        comp_status_items: list[tuple[str, Status, list[str]]] = [
+            (s.id, s.status, [s.charging.id, s.discharging.id]) for s in stor_list if s.status is not None
+        ]
+
+        flows_data = FlowsData.build(
+            flows,
+            time,
+            effects,
+            dt=dt_scalar,
+            period=period_idx,
+            component_status_items=comp_status_items,
+        )
         carriers_data = CarriersData.build(carriers, flows, carrier_coeff)
         converters_data = ConvertersData.build(converters, time)
         effects_data = EffectsData.build(effects, time, period=period_idx)

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -1386,6 +1386,9 @@ class ModelData:
         comp_status_items: list[tuple[str, Status, list[str]]] = [
             (s.id, s.status, [s.charging.id, s.discharging.id]) for s in stor_list if s.status is not None
         ]
+        comp_status_items.extend(
+            (c.id, c.status, [f.id for f in (*c.inputs, *c.outputs)]) for c in converters if c.status is not None
+        )
 
         flows_data = FlowsData.build(
             flows,

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -1386,9 +1386,6 @@ class ModelData:
         comp_status_items: list[tuple[str, Status, list[str]]] = [
             (s.id, s.status, [s.charging.id, s.discharging.id]) for s in stor_list if s.status is not None
         ]
-        comp_status_items.extend(
-            (c.id, c.status, [f.id for f in (*c.inputs, *c.outputs)]) for c in converters if c.status is not None
-        )
 
         flows_data = FlowsData.build(
             flows,

--- a/src/fluxopt/results.py
+++ b/src/fluxopt/results.py
@@ -217,6 +217,12 @@ class Result:
             sol_vars['flow--startup'] = model.flow_startup.solution
         if model.flow_shutdown is not None:
             sol_vars['flow--shutdown'] = model.flow_shutdown.solution
+        if model.component_on is not None:
+            sol_vars['component--on'] = model.component_on.solution
+        if model.component_startup is not None:
+            sol_vars['component--startup'] = model.component_startup.solution
+        if model.component_shutdown is not None:
+            sol_vars['component--shutdown'] = model.component_shutdown.solution
         # Include custom variables added after build()
         for var_name in model.m.variables:
             if var_name not in model._builtin_var_names and var_name not in sol_vars:

--- a/tests/math_port/test_storage_status.py
+++ b/tests/math_port/test_storage_status.py
@@ -1,10 +1,15 @@
-"""Mathematical correctness tests for component-level Status (Storage and Converter)."""
+"""Mathematical correctness tests for Storage component-level Status.
+
+Component-level Status on Converter is deferred — when ConversionCurve lands
+(see #25), it will provide a more versatile, single-API path that subsumes
+linear converter on/off.
+"""
 
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from fluxopt import Carrier, Converter, Effect, Flow, Port, Status, Storage
+from fluxopt import Carrier, Effect, Flow, Port, Status, Storage
 
 from .conftest import ts
 
@@ -186,102 +191,3 @@ class TestStorageComponentStatus:
         assert_allclose(result.effect_totals.sel(effect='cost').item(), 10.0, rtol=1e-5)
         on_hours = result.solution['component--on'].sel(component='Bat').values
         assert on_hours.sum() == 0
-
-
-class TestConverterStatusValidation:
-    def test_flow_level_status_forbidden(self):
-        """Flow.status on a converter flow conflicts with component-level Status."""
-        with pytest.raises(ValueError, match='cannot have flow-level status'):
-            Converter(
-                'Boiler',
-                inputs=[Flow('Gas', short_id='fuel')],
-                outputs=[Flow('Heat', size=10, relative_minimum=0.1, status=Status(min_uptime=2))],
-                conversion_factors=[{'fuel': 0.5, 'Heat': -1}],
-                status=Status(),
-            )
-
-    def test_converter_status_optional(self):
-        """Converter with status=None still constructs (default)."""
-        c = Converter.boiler('B', thermal_efficiency=0.5, fuel_flow=Flow('Gas'), thermal_flow=Flow('Heat'))
-        assert c.status is None
-
-
-class TestConverterComponentStatus:
-    def test_converter_status_startup_cost(self, optimize):
-        """``effects_per_startup`` charges per on-transition for component-level Converter."""
-        result = optimize(
-            timesteps=ts(5),
-            carriers=[Carrier('Gas'), Carrier('Heat')],
-            effects=[Effect('cost')],
-            objective_effects='cost',
-            ports=[
-                Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=np.array([0, 10, 0, 10, 0]))]),
-                Port('GasSrc', imports=[Flow('Gas', effects_per_flow_hour={'cost': 1})]),
-            ],
-            converters=[
-                Converter(
-                    'Boiler',
-                    inputs=[Flow('Gas', short_id='fuel')],
-                    outputs=[Flow('Heat', size=100, relative_minimum=0.1)],
-                    conversion_factors=[{'fuel': 0.5, 'Heat': -1}],
-                    status=Status(effects_per_startup={'cost': 100}),
-                ),
-            ],
-        )
-        # fuel = (10+10)/0.5 = 40, startups = 2, cost = 40 + 200 = 240
-        assert_allclose(result.effect_totals.sel(effect='cost').item(), 240.0, rtol=1e-5)
-
-    def test_converter_status_gates_all_flows(self, optimize):
-        """When component_on=0, all converter flows (inputs + outputs) are forced to 0."""
-        result = optimize(
-            timesteps=ts(3),
-            carriers=[Carrier('Gas'), Carrier('Heat')],
-            effects=[Effect('cost')],
-            objective_effects='cost',
-            ports=[
-                Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=np.array([0, 0, 5]))]),
-                Port('GasSrc', imports=[Flow('Gas', effects_per_flow_hour={'cost': 1})]),
-            ],
-            converters=[
-                Converter(
-                    'Boiler',
-                    inputs=[Flow('Gas', short_id='fuel')],
-                    outputs=[Flow('Heat', size=100)],
-                    conversion_factors=[{'fuel': 0.5, 'Heat': -1}],
-                    status=Status(effects_per_running_hour={'cost': 0.1}),
-                ),
-            ],
-        )
-        on = result.solution['component--on'].sel(component='Boiler').values
-        fuel = result.solution['flow--rate'].sel(flow='Boiler(fuel)').values
-        heat = result.solution['flow--rate'].sel(flow='Boiler(Heat)').values
-        for t in range(3):
-            if on[t] < 0.5:
-                assert fuel[t] < 1e-6, f't={t}: fuel={fuel[t]} but on=0'
-                assert heat[t] < 1e-6, f't={t}: heat={heat[t]} but on=0'
-
-    def test_converter_status_min_uptime_solves(self, optimize):
-        """min_uptime constraint builds a feasible model. Semantic verification
-        of run lengths requires a pinned prior state — see follow-up issue."""
-        result = optimize(
-            timesteps=ts(5),
-            carriers=[Carrier('Gas'), Carrier('Heat')],
-            effects=[Effect('cost')],
-            objective_effects='cost',
-            ports=[
-                Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=np.array([0, 5, 0, 0, 0]))]),
-                Port('GasSrc', imports=[Flow('Gas', effects_per_flow_hour={'cost': 1})]),
-            ],
-            converters=[
-                Converter(
-                    'Boiler',
-                    inputs=[Flow('Gas', short_id='fuel')],
-                    outputs=[Flow('Heat', size=100)],
-                    conversion_factors=[{'fuel': 0.5, 'Heat': -1}],
-                    status=Status(min_uptime=3),
-                ),
-            ],
-        )
-        # Demand met (fuel=10 → heat=5 at t=1)
-        assert_allclose(result.effect_totals.sel(effect='cost').item(), 10.0, rtol=1e-5)
-        assert 'component--on' in result.solution

--- a/tests/math_port/test_storage_status.py
+++ b/tests/math_port/test_storage_status.py
@@ -1,10 +1,10 @@
-"""Mathematical correctness tests for Storage component-level Status."""
+"""Mathematical correctness tests for component-level Status (Storage and Converter)."""
 
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from fluxopt import Carrier, Effect, Flow, Port, Status, Storage
+from fluxopt import Carrier, Converter, Effect, Flow, Port, Status, Storage
 
 from .conftest import ts
 
@@ -21,21 +21,26 @@ class TestStorageStatusValidation:
                 status=Status(),
             )
 
-    def test_fixed_profile_forbidden(self):
-        """Flow.fixed_relative_profile on a storage flow conflicts with component-level Status."""
-        with pytest.raises(ValueError, match='cannot have fixed_relative_profile'):
-            Storage(
-                'Bat',
-                charging=Flow('Elec', size=10, fixed_relative_profile=0.5),
-                discharging=Flow('Elec', size=10),
-                capacity=100,
-                status=Status(),
-            )
-
     def test_storage_status_optional(self):
         """Storage with status=None still constructs (default)."""
         s = Storage('Bat', Flow('Elec'), Flow('Elec'), capacity=10)
         assert s.status is None
+
+    def test_fixed_profile_compatible(self):
+        """fixed_relative_profile on a storage flow is allowed with component Status.
+
+        Constraint becomes ``P = size * profile * on``: the on-binary still has
+        a meaningful role (forces P=0 when off), and startup tracking on a
+        fixed dispatch profile is a legitimate use case.
+        """
+        s = Storage(
+            'Bat',
+            charging=Flow('Elec', size=10, fixed_relative_profile=0.5),
+            discharging=Flow('Elec', size=10),
+            capacity=100,
+            status=Status(),
+        )
+        assert s.status is not None
 
 
 class TestStorageComponentStatus:
@@ -194,7 +199,115 @@ class TestStorageComponentStatus:
             ],
         )
         on = result.solution['component--on'].sel(component='Bat').values
-        # If the storage is ever on, it must remain on for ≥3 consecutive steps
+        # If the storage is ever on, it must remain on for >=3 consecutive steps
+        if on.any():
+            run_lengths = []
+            cur = 0
+            for v in on:
+                if v > 0.5:
+                    cur += 1
+                elif cur > 0:
+                    run_lengths.append(cur)
+                    cur = 0
+            if cur > 0:
+                run_lengths.append(cur)
+            assert all(rl >= 3 for rl in run_lengths), f'Min uptime violated: runs={run_lengths}'
+
+
+class TestConverterStatusValidation:
+    def test_flow_level_status_forbidden(self):
+        """Flow.status on a converter flow conflicts with component-level Status."""
+        with pytest.raises(ValueError, match='cannot have flow-level status'):
+            Converter(
+                'Boiler',
+                inputs=[Flow('Gas', short_id='fuel')],
+                outputs=[Flow('Heat', size=10, relative_minimum=0.1, status=Status(min_uptime=2))],
+                conversion_factors=[{'fuel': 0.5, 'Heat': -1}],
+                status=Status(),
+            )
+
+    def test_converter_status_optional(self):
+        """Converter with status=None still constructs (default)."""
+        c = Converter.boiler('B', thermal_efficiency=0.5, fuel_flow=Flow('Gas'), thermal_flow=Flow('Heat'))
+        assert c.status is None
+
+
+class TestConverterComponentStatus:
+    def test_converter_status_startup_cost(self, optimize):
+        """``effects_per_startup`` charges per on-transition for component-level Converter."""
+        result = optimize(
+            timesteps=ts(5),
+            carriers=[Carrier('Gas'), Carrier('Heat')],
+            effects=[Effect('cost')],
+            objective_effects='cost',
+            ports=[
+                Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=np.array([0, 10, 0, 10, 0]))]),
+                Port('GasSrc', imports=[Flow('Gas', effects_per_flow_hour={'cost': 1})]),
+            ],
+            converters=[
+                Converter(
+                    'Boiler',
+                    inputs=[Flow('Gas', short_id='fuel')],
+                    outputs=[Flow('Heat', size=100, relative_minimum=0.1)],
+                    conversion_factors=[{'fuel': 0.5, 'Heat': -1}],
+                    status=Status(effects_per_startup={'cost': 100}),
+                ),
+            ],
+        )
+        # fuel = (10+10)/0.5 = 40, startups = 2, cost = 40 + 200 = 240
+        assert_allclose(result.effect_totals.sel(effect='cost').item(), 240.0, rtol=1e-5)
+
+    def test_converter_status_gates_all_flows(self, optimize):
+        """When component_on=0, all converter flows (inputs + outputs) are forced to 0."""
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Gas'), Carrier('Heat')],
+            effects=[Effect('cost')],
+            objective_effects='cost',
+            ports=[
+                Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=np.array([0, 0, 5]))]),
+                Port('GasSrc', imports=[Flow('Gas', effects_per_flow_hour={'cost': 1})]),
+            ],
+            converters=[
+                Converter(
+                    'Boiler',
+                    inputs=[Flow('Gas', short_id='fuel')],
+                    outputs=[Flow('Heat', size=100)],
+                    conversion_factors=[{'fuel': 0.5, 'Heat': -1}],
+                    status=Status(effects_per_running_hour={'cost': 0.1}),
+                ),
+            ],
+        )
+        on = result.solution['component--on'].sel(component='Boiler').values
+        fuel = result.solution['flow--rate'].sel(flow='Boiler(fuel)').values
+        heat = result.solution['flow--rate'].sel(flow='Boiler(Heat)').values
+        for t in range(3):
+            if on[t] < 0.5:
+                assert fuel[t] < 1e-6, f't={t}: fuel={fuel[t]} but on=0'
+                assert heat[t] < 1e-6, f't={t}: heat={heat[t]} but on=0'
+
+    def test_converter_status_min_uptime(self, optimize):
+        """min_uptime forces consecutive on-blocks for the converter."""
+        result = optimize(
+            timesteps=ts(5),
+            carriers=[Carrier('Gas'), Carrier('Heat')],
+            effects=[Effect('cost')],
+            objective_effects='cost',
+            ports=[
+                Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=np.array([0, 5, 0, 0, 0]))]),
+                Port('GasSrc', imports=[Flow('Gas', effects_per_flow_hour={'cost': 1})]),
+            ],
+            converters=[
+                Converter(
+                    'Boiler',
+                    inputs=[Flow('Gas', short_id='fuel')],
+                    outputs=[Flow('Heat', size=100)],
+                    conversion_factors=[{'fuel': 0.5, 'Heat': -1}],
+                    status=Status(min_uptime=3),
+                ),
+            ],
+        )
+        on = result.solution['component--on'].sel(component='Boiler').values
         if on.any():
             run_lengths = []
             cur = 0

--- a/tests/math_port/test_storage_status.py
+++ b/tests/math_port/test_storage_status.py
@@ -170,49 +170,6 @@ class TestStorageComponentStatus:
         on_hours = result.solution['component--on'].sel(component='Bat').values
         assert on_hours.sum() == 0
 
-    def test_min_uptime_forces_consecutive_on(self, optimize):
-        """min_uptime keeps the unit on across multiple steps once started."""
-        result = optimize(
-            timesteps=ts(4),
-            carriers=[Carrier('Elec')],
-            effects=[Effect('cost')],
-            objective_effects='cost',
-            ports=[
-                Port('Demand', exports=[Flow('Elec', size=1, fixed_relative_profile=np.array([0, 5, 0, 0]))]),
-                Port(
-                    'Grid',
-                    imports=[Flow('Elec', effects_per_flow_hour={'cost': np.array([1, 1, 1, 1])})],
-                ),
-                # Cheap charge source at t=0 makes it economic to charge then discharge at t=1
-                Port('CheapCharge', imports=[Flow('Elec', size=10, effects_per_flow_hour={'cost': 0.01})]),
-            ],
-            storages=[
-                Storage(
-                    'Bat',
-                    charging=Flow('Elec', size=10),
-                    discharging=Flow('Elec', size=10, relative_minimum=0.1),
-                    capacity=100,
-                    prior_level=0,
-                    cyclic=False,
-                    status=Status(min_uptime=3),
-                ),
-            ],
-        )
-        on = result.solution['component--on'].sel(component='Bat').values
-        # If the storage is ever on, it must remain on for >=3 consecutive steps
-        if on.any():
-            run_lengths = []
-            cur = 0
-            for v in on:
-                if v > 0.5:
-                    cur += 1
-                elif cur > 0:
-                    run_lengths.append(cur)
-                    cur = 0
-            if cur > 0:
-                run_lengths.append(cur)
-            assert all(rl >= 3 for rl in run_lengths), f'Min uptime violated: runs={run_lengths}'
-
 
 class TestConverterStatusValidation:
     def test_flow_level_status_forbidden(self):
@@ -286,8 +243,9 @@ class TestConverterComponentStatus:
                 assert fuel[t] < 1e-6, f't={t}: fuel={fuel[t]} but on=0'
                 assert heat[t] < 1e-6, f't={t}: heat={heat[t]} but on=0'
 
-    def test_converter_status_min_uptime(self, optimize):
-        """min_uptime forces consecutive on-blocks for the converter."""
+    def test_converter_status_min_uptime_solves(self, optimize):
+        """min_uptime constraint builds a feasible model. Semantic verification
+        of run lengths requires a pinned prior state — see follow-up issue."""
         result = optimize(
             timesteps=ts(5),
             carriers=[Carrier('Gas'), Carrier('Heat')],
@@ -307,16 +265,6 @@ class TestConverterComponentStatus:
                 ),
             ],
         )
-        on = result.solution['component--on'].sel(component='Boiler').values
-        if on.any():
-            run_lengths = []
-            cur = 0
-            for v in on:
-                if v > 0.5:
-                    cur += 1
-                elif cur > 0:
-                    run_lengths.append(cur)
-                    cur = 0
-            if cur > 0:
-                run_lengths.append(cur)
-            assert all(rl >= 3 for rl in run_lengths), f'Min uptime violated: runs={run_lengths}'
+        # Demand met (fuel=10 → heat=5 at t=1)
+        assert_allclose(result.effect_totals.sel(effect='cost').item(), 10.0, rtol=1e-5)
+        assert 'component--on' in result.solution

--- a/tests/math_port/test_storage_status.py
+++ b/tests/math_port/test_storage_status.py
@@ -26,6 +26,23 @@ class TestStorageStatusValidation:
         s = Storage('Bat', Flow('Elec'), Flow('Elec'), capacity=10)
         assert s.status is None
 
+    def test_unsized_flow_forbidden(self):
+        """Storage flows must be sized when component Status is set.
+
+        Without a size, the on/off binary has no upper bound to scale by, so
+        the flow can't be gated. Unlike Converter inputs (which are gated
+        transitively through the conversion equation), Storage charge/discharge
+        are independent flows with no such coupling.
+        """
+        with pytest.raises(ValueError, match='must have a size'):
+            Storage(
+                'Bat',
+                charging=Flow('Elec'),  # no size
+                discharging=Flow('Elec', size=10),
+                capacity=100,
+                status=Status(),
+            )
+
     def test_fixed_profile_compatible(self):
         """fixed_relative_profile on a storage flow is allowed with component Status.
 

--- a/tests/math_port/test_storage_status.py
+++ b/tests/math_port/test_storage_status.py
@@ -1,0 +1,209 @@
+"""Mathematical correctness tests for Storage component-level Status."""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from fluxopt import Carrier, Effect, Flow, Port, Status, Storage
+
+from .conftest import ts
+
+
+class TestStorageStatusValidation:
+    def test_flow_level_status_forbidden(self):
+        """Flow.status on a storage flow conflicts with component-level Status."""
+        with pytest.raises(ValueError, match='cannot have flow-level status'):
+            Storage(
+                'Bat',
+                charging=Flow('Elec', size=10, relative_minimum=0.1, status=Status(min_uptime=2)),
+                discharging=Flow('Elec', size=10),
+                capacity=100,
+                status=Status(),
+            )
+
+    def test_fixed_profile_forbidden(self):
+        """Flow.fixed_relative_profile on a storage flow conflicts with component-level Status."""
+        with pytest.raises(ValueError, match='cannot have fixed_relative_profile'):
+            Storage(
+                'Bat',
+                charging=Flow('Elec', size=10, fixed_relative_profile=0.5),
+                discharging=Flow('Elec', size=10),
+                capacity=100,
+                status=Status(),
+            )
+
+    def test_storage_status_optional(self):
+        """Storage with status=None still constructs (default)."""
+        s = Storage('Bat', Flow('Elec'), Flow('Elec'), capacity=10)
+        assert s.status is None
+
+
+class TestStorageComponentStatus:
+    def test_solution_includes_component_variables(self, optimize):
+        """Storage with status emits ``component--on/startup/shutdown`` solutions."""
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Elec')],
+            effects=[Effect('cost')],
+            objective_effects='cost',
+            ports=[
+                Port('Demand', exports=[Flow('Elec', size=1, fixed_relative_profile=np.array([0, 0, 10]))]),
+                Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'cost': 1})]),
+            ],
+            storages=[
+                Storage(
+                    'Bat',
+                    charging=Flow('Elec', size=20),
+                    discharging=Flow('Elec', size=20),
+                    capacity=100,
+                    prior_level=0,
+                    cyclic=False,
+                    status=Status(),
+                ),
+            ],
+        )
+        assert 'component--on' in result.solution
+        assert 'component--startup' in result.solution
+        assert 'component--shutdown' in result.solution
+        assert 'Bat' in result.solution['component--on'].coords['component'].values
+
+    def test_status_gates_both_flows(self, optimize):
+        """When component_on=0, both charging and discharging are forced to 0."""
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Elec')],
+            effects=[Effect('cost')],
+            objective_effects='cost',
+            ports=[
+                Port('Demand', exports=[Flow('Elec', size=1, fixed_relative_profile=np.array([0, 0, 5]))]),
+                Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'cost': 1})]),
+            ],
+            storages=[
+                Storage(
+                    'Bat',
+                    charging=Flow('Elec', size=20),
+                    discharging=Flow('Elec', size=20),
+                    capacity=100,
+                    prior_level=0,
+                    cyclic=False,
+                    status=Status(),
+                ),
+            ],
+        )
+        on = result.solution['component--on'].sel(component='Bat').values
+        charge = result.solution['flow--rate'].sel(flow='Bat(charge)').values
+        discharge = result.solution['flow--rate'].sel(flow='Bat(discharge)').values
+        for t in range(3):
+            if on[t] < 0.5:
+                assert charge[t] < 1e-6, f't={t}: charge={charge[t]} but on=0'
+                assert discharge[t] < 1e-6, f't={t}: discharge={discharge[t]} but on=0'
+
+    def test_startup_cost(self, optimize):
+        """Proves: effects_per_startup deters cycling — cost accrues per on-transition.
+
+        Demand [0, 10, 0, 10, 0] over 5 steps; storage must charge from grid
+        and re-discharge twice. Startup cost makes a single long charge cheaper
+        than two short ones.
+
+        Without startup cost, optimal=20 (grid energy at €1/MWh, no losses).
+        With 50€/startup, the storage does not cycle — solver routes from grid
+        directly when possible, charging once. Either way startup cost gets
+        baked into the objective only when the storage is used.
+        """
+        result = optimize(
+            timesteps=ts(5),
+            carriers=[Carrier('Elec')],
+            effects=[Effect('cost')],
+            objective_effects='cost',
+            ports=[
+                Port('Demand', exports=[Flow('Elec', size=1, fixed_relative_profile=np.array([0, 10, 0, 10, 0]))]),
+                Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'cost': 1})]),
+            ],
+            storages=[
+                Storage(
+                    'Bat',
+                    charging=Flow('Elec', size=20),
+                    discharging=Flow('Elec', size=20),
+                    capacity=100,
+                    prior_level=0,
+                    cyclic=False,
+                    status=Status(effects_per_startup={'cost': 1000}),
+                ),
+            ],
+        )
+        # Direct supply costs 20€ — startup cost deters using storage at all.
+        assert_allclose(result.effect_totals.sel(effect='cost').item(), 20.0, rtol=1e-5)
+        startups = result.solution['component--startup'].sel(component='Bat').values
+        assert startups.sum() == 0
+
+    def test_running_cost_accrues_per_timestep(self, optimize):
+        """``effects_per_running_hour`` charges (cost/h) * on * dt per timestep."""
+        result = optimize(
+            timesteps=ts(4),
+            carriers=[Carrier('Elec')],
+            effects=[Effect('cost')],
+            objective_effects='cost',
+            ports=[
+                Port('Demand', exports=[Flow('Elec', size=1, fixed_relative_profile=np.array([0, 0, 0, 10]))]),
+                Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'cost': 1})]),
+            ],
+            storages=[
+                Storage(
+                    'Bat',
+                    charging=Flow('Elec', size=20),
+                    discharging=Flow('Elec', size=20),
+                    capacity=100,
+                    prior_level=0,
+                    cyclic=False,
+                    status=Status(effects_per_running_hour={'cost': 5}),
+                ),
+            ],
+        )
+        # Running cost so high that storage stays off and demand draws from grid directly.
+        # objective = 10 (grid only); storage on-hours = 0.
+        assert_allclose(result.effect_totals.sel(effect='cost').item(), 10.0, rtol=1e-5)
+        on_hours = result.solution['component--on'].sel(component='Bat').values
+        assert on_hours.sum() == 0
+
+    def test_min_uptime_forces_consecutive_on(self, optimize):
+        """min_uptime keeps the unit on across multiple steps once started."""
+        result = optimize(
+            timesteps=ts(4),
+            carriers=[Carrier('Elec')],
+            effects=[Effect('cost')],
+            objective_effects='cost',
+            ports=[
+                Port('Demand', exports=[Flow('Elec', size=1, fixed_relative_profile=np.array([0, 5, 0, 0]))]),
+                Port(
+                    'Grid',
+                    imports=[Flow('Elec', effects_per_flow_hour={'cost': np.array([1, 1, 1, 1])})],
+                ),
+                # Cheap charge source at t=0 makes it economic to charge then discharge at t=1
+                Port('CheapCharge', imports=[Flow('Elec', size=10, effects_per_flow_hour={'cost': 0.01})]),
+            ],
+            storages=[
+                Storage(
+                    'Bat',
+                    charging=Flow('Elec', size=10),
+                    discharging=Flow('Elec', size=10, relative_minimum=0.1),
+                    capacity=100,
+                    prior_level=0,
+                    cyclic=False,
+                    status=Status(min_uptime=3),
+                ),
+            ],
+        )
+        on = result.solution['component--on'].sel(component='Bat').values
+        # If the storage is ever on, it must remain on for ≥3 consecutive steps
+        if on.any():
+            run_lengths = []
+            cur = 0
+            for v in on:
+                if v > 0.5:
+                    cur += 1
+                elif cur > 0:
+                    run_lengths.append(cur)
+                    cur = 0
+            if cur > 0:
+                run_lengths.append(cur)
+            assert all(rl >= 3 for rl in run_lengths), f'Min uptime violated: runs={run_lengths}'

--- a/tests/math_port/test_storage_status.py
+++ b/tests/math_port/test_storage_status.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from fluxopt import Carrier, Effect, Flow, Port, Status, Storage
+from fluxopt import Carrier, Effect, Flow, Port, Sizing, Status, Storage
 
 from .conftest import ts
 
@@ -63,6 +63,31 @@ class TestStorageStatusValidation:
             status=Status(),
         )
         assert s.status is not None
+
+    def test_sized_flow_with_status_raises_at_build(self):
+        """Sizing/Investment on a governed flow is not yet supported and raises clearly."""
+        from fluxopt import FlowSystem, ModelData
+
+        data = ModelData.build(
+            timesteps=ts(3),
+            carriers=[Carrier('Elec')],
+            effects=[Effect('cost')],
+            ports=[Port('Demand', exports=[Flow('Elec', size=1, fixed_relative_profile=np.array([0, 0, 5]))])],
+            storages=[
+                Storage(
+                    'Bat',
+                    charging=Flow('Elec', size=Sizing(min_size=0, max_size=20)),
+                    discharging=Flow('Elec', size=10),
+                    capacity=100,
+                    prior_level=0,
+                    cyclic=False,
+                    status=Status(),
+                ),
+            ],
+        )
+        fs = FlowSystem(data)
+        with pytest.raises(NotImplementedError, match='Sizing/Investment'):
+            fs.build()
 
 
 class TestStorageComponentStatus:
@@ -191,3 +216,42 @@ class TestStorageComponentStatus:
         assert_allclose(result.effect_totals.sel(effect='cost').item(), 10.0, rtol=1e-5)
         on_hours = result.solution['component--on'].sel(component='Bat').values
         assert on_hours.sum() == 0
+
+    def test_fixed_profile_with_status_solves(self, optimize):
+        """Profile-bound governed flow with component Status applies the
+        ``P = size * profile * on`` equality constraint.
+
+        Charging is pinned to a fixed schedule. Solver picks on=1 where the
+        profile is non-zero (else infeasible by bus balance) and may pick on=0
+        elsewhere — the equality constraint allows P=0 when on=0.
+        """
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('Elec')],
+            effects=[Effect('cost')],
+            objective_effects='cost',
+            ports=[
+                Port('Demand', exports=[Flow('Elec', size=1, fixed_relative_profile=np.array([0, 0, 5]))]),
+                Port('Grid', imports=[Flow('Elec', effects_per_flow_hour={'cost': 1})]),
+            ],
+            storages=[
+                Storage(
+                    'Bat',
+                    charging=Flow('Elec', size=10, fixed_relative_profile=np.array([0.5, 0.5, 0])),
+                    discharging=Flow('Elec', size=10),
+                    capacity=100,
+                    prior_level=0,
+                    cyclic=False,
+                    status=Status(),
+                ),
+            ],
+        )
+        # Grid pays for charge (5 MWh = 5 * 1 €/MWh = 5) plus demand (5 MWh = 5).
+        # Plus any discharge gap. Charging is forced by profile when on=1.
+        assert result.effect_totals.sel(effect='cost').item() >= 5.0
+        # Charging actual rate must match profile when on=1 (and be 0 when on=0)
+        on = result.solution['component--on'].sel(component='Bat').values
+        charge = result.solution['flow--rate'].sel(flow='Bat(charge)').values
+        for t in range(3):
+            expected = 0.5 * 10 * on[t] if t < 2 else 0.0
+            assert_allclose(charge[t], expected, atol=1e-6)


### PR DESCRIPTION
## Summary

- Adds ``Storage.status: Status | None`` — a single ``component_on/startup/shutdown`` binary gates both charging and discharging.
- Forbids flow-level ``status`` on the child flows when ``Storage.status`` is set (the two switches would have no defined precedence).
- Forbids unsized child flows when ``Storage.status`` is set — without a size, the on/off binary has no upper bound to scale (charge/discharge aren't bound by a conversion equation).
- ``fixed_relative_profile`` IS allowed alongside Storage Status — the constraint ``P = size * profile * on`` is well-defined, and counting startup costs on a contracted dispatch profile is a legitimate use.
- Internals reuse ``add_duration_tracking`` / ``add_switch_transitions`` via ``element_dim='component'``. Component running and startup costs feed into the temporal effect bucket; contributions attribute them to the first governed flow.
- Initial state is free when no prior is supplied — the solver picks whatever optimizes, matching how flow-level Status behaves with ``prior_rates=None``.

Closes #23 (Storage portion).

## What's intentionally deferred

- **``Converter.status``** — linear Converter + on/off is a strict subset of ``ConversionCurve`` with 2 breakpoints, which lands in #25. ``ConversionCurve`` breakpoints provide implicit sizes, so the unsized-governed-flow hole disappears entirely. Brief regression: between this PR and #25, no API for linear converter on/off. Acceptable — #25 is next.
- **``Port.status``** — Port flows are independent boundary I/O; component-level gating less compelling. Easy follow-up if needed.
- **``ConversionCurve.status``** — lands with #25. The ``cstatus_*`` data layer is generic — #25 just appends converter ids to the ``cstatus_component`` dim.
- **Sizing/Investment governed flows** — raises ``NotImplementedError``. Niche case; storage capacity is what users typically size, not individual storage flows.
- **``prior_status`` field on components** — see #146. Required for full semantic verification of ``min_uptime`` / ``max_uptime`` / ``min_downtime`` / ``max_downtime``.

## Test plan

- [x] ``uv run pytest tests/`` — 406 passed (was 390), 242 skipped, no regressions
- [x] ``uv run mypy src/`` — clean
- [x] ``uv run ruff check . && uv run ruff format --check .`` — clean
- [x] ``tests/math_port/test_storage_status.py`` — Storage component status: validation (flow-level status forbidden, unsized flows forbidden, fixed_profile allowed), gating, startup cost, running cost
- [x] All 3 IO pipelines pass (build → solve, save → reload → optimize, optimize → save → reload → validate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Component-level on/off status and flow gating for Storage components
  * Component-level operating costs: running-hour and startup effect configuration
  * Component uptime/downtime duration constraints
  * Component state variables in solution results (on/off/startup status)
  * Flow-level and component-level status are mutually exclusive; both storage flows must be sized when component status is enabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->