### PR TITLE
docs: theme mkdocs site (landing, palette, layout, mkdocstrings)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,69 @@
+---
+hide:
+  - navigation
+  - toc
+---
+
+<div class="hero" markdown>
+
 # fluxopt
 
-Energy system optimization with [linopy](https://github.com/PyPSA/linopy) — progressive modeling, from simple to complex.
+Energy system optimization with [linopy](https://github.com/PyPSA/linopy) — detailed dispatch, scaled to multi-period planning.
 
-## Installation
+[![PyPI](https://img.shields.io/pypi/v/fluxopt)](https://pypi.org/project/fluxopt/)
+[![Downloads](https://img.shields.io/pypi/dm/fluxopt)](https://pypi.org/project/fluxopt/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
-```bash
-pip install fluxopt
-```
+[Get Started](notebooks/01-quickstart.ipynb){ .md-button .md-button--primary }
+[GitHub](https://github.com/FBumann/fluxopt){ .md-button }
+
+</div>
+
+---
+
+<div class="landing" markdown>
+
+<div class="grid cards" markdown>
+
+-   :material-cube-outline: __Composable elements__
+
+    ---
+
+    Build models from `Flow`, `Bus`, `Converter`, `Storage`, and `Effect` — clear separation of physics, costs, and topology.
+
+-   :material-chart-line: __xarray-native__
+
+    ---
+
+    Time series, parameters, and results as `xr.Dataset` — vectorized constraints via [linopy](https://github.com/PyPSA/linopy).
+
+-   :material-tune: __Sizing & status__
+
+    ---
+
+    Capacity optimization and on/off behavior as first-class concerns, not bolt-ons.
+
+-   :material-rocket-launch: __HiGHS out of the box__
+
+    ---
+
+    Open-source MIP solver bundled. Swap in Gurobi, CPLEX, or any linopy-supported backend.
+
+-   :material-book-open-page-variant: __Math, documented__
+
+    ---
+
+    Every constraint has a formulation page with notation, derivation, and the line of code that emits it.
+
+-   :material-puzzle: __Companion ecosystem__
+
+    ---
+
+    Lean core, optional companions for [plotting](https://fbumann.github.io/fluxopt-plot/latest/) and [YAML loading](https://fbumann.github.io/fluxopt-yaml/latest/).
+
+</div>
 
 ## Quick Example
 
@@ -21,7 +78,6 @@ timesteps = [datetime(2024, 1, 1, h) for h in range(4)]
 gas = Carrier('gas')
 heat = Carrier('heat')
 
-# Flows
 gas_source = Flow('gas', size=500, effects_per_flow_hour={'cost': 0.04})
 fuel = Flow('gas', size=300)
 heat_out = Flow('heat', size=200)
@@ -40,13 +96,34 @@ print(f"Total cost: {result.objective:.2f}")
 print(result.flow_rates)
 ```
 
-## Companion Packages
+## Where to next
 
-- **[fluxopt-plot](https://fbumann.github.io/fluxopt-plot/latest/)** — interactive plotly visualization for optimization results
-- **[fluxopt-yaml](https://fbumann.github.io/fluxopt-yaml/latest/)** — declarative model definition via YAML + CSV
+<div class="grid cards" markdown>
 
-## Next Steps
+-   :material-school: __Learn by example__
 
-- **[Quickstart](notebooks/01-quickstart.ipynb)** — build your first model in five minutes
-- **[Notebooks](notebooks/02-heat-system.ipynb)** — worked examples from heat systems to investment optimization
-- **[Math](math/notation.md)** — formulation reference with notation, constraints, and examples
+    ---
+
+    Seven executable notebooks from quickstart through investment and piecewise conversion.
+
+    [:octicons-arrow-right-24: Notebooks](notebooks/01-quickstart.ipynb)
+
+-   :material-function-variant: __Math reference__
+
+    ---
+
+    Notation, objective, and per-element formulations.
+
+    [:octicons-arrow-right-24: Math](math/notation.md)
+
+-   :material-api: __API reference__
+
+    ---
+
+    Auto-generated from source — every public class, every parameter.
+
+    [:octicons-arrow-right-24: API](api/fluxopt/)
+
+</div>
+
+</div>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,3 +1,142 @@
+/* --- Custom palette: soft dark slate primary + sky accent --- */
+
+:root,
+[data-md-color-primary="custom"] {
+  --md-primary-fg-color: #334155;          /* slate-700 — soft dark header */
+  --md-primary-fg-color--light: #475569;   /* slate-600 */
+  --md-primary-fg-color--dark: #1e293b;    /* slate-800 — hover/active */
+  --md-primary-bg-color: #ffffff;
+  --md-primary-bg-color--light: #ffffffb3;
+}
+
+/* Light-mode accent: deeper sky for contrast on white */
+[data-md-color-accent="custom"] {
+  --md-accent-fg-color: #0284c7;           /* sky-600 */
+  --md-accent-fg-color--transparent: rgba(2, 132, 199, 0.1);
+  --md-accent-bg-color: #ffffff;
+  --md-accent-bg-color--light: #ffffffb3;
+}
+
+/* Dark-mode accent: brighter sky for contrast on slate background */
+[data-md-color-scheme="slate"][data-md-color-accent="custom"] {
+  --md-accent-fg-color: #38bdf8;           /* sky-400 — brighter for dark bg */
+  --md-accent-fg-color--transparent: rgba(56, 189, 248, 0.15);
+}
+
+/* Light-mode resting link: brighter than the accent for prominence.
+   Hover keeps the accent (sky-600) for darken-on-hover affordance. */
+.md-typeset a {
+  color: #0284c7;                          /* sky-600 */
+}
+
+.md-typeset a:hover {
+  color: #0ea5e9;                          /* sky-500 — brighten on hover */
+}
+
+[data-md-color-scheme="slate"] .md-typeset a {
+  color: #38bdf8;                          /* sky-400 */
+}
+
+[data-md-color-scheme="slate"] .md-typeset a:hover {
+  color: #7dd3fc;                          /* sky-300 */
+}
+
+/* --- Layout: wider content, denser sidebars --- */
+
+:root {
+  --md-grid-max-width: 80rem;  /* default 61rem — let content breathe */
+}
+
+.md-grid {
+  max-width: var(--md-grid-max-width);
+}
+
+/* Narrower sidebars — defaults are 12.1rem each.
+   Both kept visible (no toc.integrate) so the per-page TOC stays on the right. */
+.md-sidebar--primary {
+  width: 11rem;
+}
+
+.md-sidebar--secondary {
+  width: 10rem;
+}
+
+/* Tighter heading spacing in long-form content */
+.md-typeset h1 {
+  margin: 0 0 1rem;
+  font-weight: 600;
+}
+
+.md-typeset h2 {
+  margin: 1.6em 0 0.6em;
+}
+
+.md-typeset h3 {
+  margin: 1.2em 0 0.4em;
+}
+
+/* Slightly denser code blocks */
+.md-typeset pre > code {
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+/* --- Landing page --- */
+
+/* Centered hero: tagline, badges, CTA buttons */
+.md-typeset .hero {
+  max-width: 42rem;
+  margin: 2rem auto 1rem;
+  text-align: center;
+}
+
+.md-typeset .hero h1 {
+  margin-bottom: 0.6rem;
+  font-size: 2.6rem;
+  font-weight: 700;
+}
+
+.md-typeset .hero p {
+  font-size: 1.1rem;
+  color: var(--md-default-fg-color--light);
+}
+
+/* Badge row: tight, centered, no paragraph spacing */
+.md-typeset .hero p:has(img) {
+  margin: 0.6rem 0 1.4rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  justify-content: center;
+}
+
+.md-typeset .hero img {
+  margin: 0;
+}
+
+/* Landing-page content (cards, code, etc.) — narrower than full grid */
+.md-typeset .landing {
+  max-width: 64rem;
+  margin: 0 auto;
+}
+
+/* Button row spacing */
+.md-typeset .md-button + .md-button {
+  margin-left: 0.5rem;
+}
+
+/* Grid card hover lift — small polish */
+.md-typeset .grid.cards > ul > li,
+.md-typeset .grid > .card {
+  transition: border-color 125ms, box-shadow 125ms;
+}
+
+.md-typeset .grid.cards > ul > li:hover,
+.md-typeset .grid > .card:hover {
+  border-color: var(--md-accent-fg-color);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
 /* --- Notebook styling (inspired by nbsphinx / PyData theme) --- */
 
 /* Hide prompts — code vs output distinguished by background.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -120,8 +120,8 @@
   margin: 0 auto;
 }
 
-/* Button row spacing */
-.md-typeset .md-button + .md-button {
+/* Button row spacing — scoped to the landing hero where button rows actually appear */
+.md-typeset .hero .md-button + .md-button {
   margin-left: 0.5rem;
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: fluxopt
 site_description: Energy system optimization with linopy
 repo_url: https://github.com/FBumann/fluxopt
 repo_name: FBumann/fluxopt
+edit_uri: edit/main/docs/
 
 nav:
   - Home: index.md
@@ -30,6 +31,9 @@ theme:
   name: material
   language: en
 
+  # logo: assets/logo.svg       # placeholder — text-only header for now
+  # favicon: assets/favicon.png
+
   palette:
     - media: "(prefers-color-scheme)"
       toggle:
@@ -37,15 +41,15 @@ theme:
         name: Switch to light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: teal
-      accent: cyan
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: teal
-      accent: cyan
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-4
         name: Switch to system preference
@@ -58,22 +62,30 @@ theme:
     repo: fontawesome/brands/github
 
   features:
+    - header.autohide
     - navigation.instant
+    - navigation.instant.progress
     - navigation.tracking
     - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.prune
+    - navigation.indexes
     - navigation.top
     - navigation.footer
     - toc.follow
     - search.suggest
     - search.highlight
+    - search.share
     - content.code.copy
     - content.code.select
+    - content.tabs.link
 
 markdown_extensions:
   - admonition
   - attr_list
   - def_list
   - footnotes
+  - md_in_html
   - tables
   - toc:
       permalink: true
@@ -87,6 +99,9 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.tabbed:
       alternate_style: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 plugins:
   - search
@@ -110,6 +125,12 @@ plugins:
       handlers:
         python:
           paths: [src]
+          inventories:
+            - https://docs.python.org/3/objects.inv
+            - https://numpy.org/doc/stable/objects.inv
+            - https://docs.xarray.dev/en/stable/objects.inv
+            - https://pandas.pydata.org/docs/objects.inv
+            - https://linopy.readthedocs.io/en/latest/objects.inv
           options:
             docstring_style: google
             docstring_section_style: table
@@ -119,10 +140,16 @@ plugins:
             show_root_heading: true
             show_signature: true
             show_signature_annotations: true
+            signature_crossrefs: true
             separate_signature: true
             line_length: 80
             modernize_annotations: true
             merge_init_into_class: true
+            summary: true
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            show_source: true
+            parameter_headings: true
 
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
## Summary

Restyle the existing mkdocs Material docs — no framework switch. Closes the visual gap to PyData/Sphinx-themed sites (linopy, NPAP, PyPSA) by improving the landing page, palette, content density, and API rendering.

- **Landing page** (`docs/index.md`): hero + CTAs + badge row + feature card grid; nav and per-page TOC hidden so it reads as a real homepage.
- **Custom palette**: slate-700 primary (`#334155`), sky-600 accent on light / sky-400 on dark, brighten-on-hover. WCAG AA contrast on white.
- **Layout density** (`extra.css`): 80rem content max-width (was 61rem), narrower sidebars (11/10rem), tighter heading & code spacing, `header.autohide`.
- **mkdocstrings**: `summary: true`, symbol type badges, `signature_crossrefs`, `parameter_headings`, `inventories:` block (xarray/linopy/numpy/pandas — intersphinx-equivalent type cross-links), `edit_uri` for "Edit on GitHub" links.
- **Material features**: `navigation.tabs.sticky`, `navigation.prune`, `navigation.indexes`, `navigation.instant.progress`, `search.share`, `pymdownx.emoji` + `md_in_html` (for grid cards / Material icons).

Out of scope (deferred): `Port` docstring (lacks `Args:`), API curation/denylist of internal modules, `gh-pages`/`mike` cleanup, `GUIDE_MIGRATION_PLAN.md` execution.

## Test plan

- [ ] `uv run mkdocs build --strict` passes
- [ ] `uv run mkdocs serve` — open http://127.0.0.1:8000
- [ ] Landing page renders with hero, badges, CTA buttons, and feature card grids
- [ ] Header auto-hides on scroll-down, reappears on scroll-up
- [ ] Palette toggle (auto/light/dark) cycles correctly; links readable in both modes (sky-600 on white, sky-400 on slate)
- [ ] API pages (e.g. `api/fluxopt/elements/`) show summary tables, symbol type badges, and "Edit on GitHub" pencil
- [ ] Type names in API signatures (`xr.Dataset`, `linopy.Variable`, `pd.Series`) resolve to external docs (intersphinx via inventories)
- [ ] Notebooks render with executed plotly outputs
- [ ] Math pages render with MathJax intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Documentation**
* Redesigned landing page with hero layout and feature cards showcasing key capabilities
* Enhanced visual styling with custom color palette for light and dark modes and improved content hierarchy
* Expanded documentation navigation features and refined site configuration for better user experience
* Added prominent call-to-action buttons for streamlined access to getting started resources and GitHub repository
* Improved cross-reference linking and symbol navigation throughout documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->