### PR TITLE
docs: regroup nav into Home / User Guide / API / Contributing

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,3 @@
+{%
+   include-markdown "../.github/CONTRIBUTING.md"
+%}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,25 +6,27 @@ edit_uri: edit/main/docs/
 
 nav:
   - Home: index.md
-  - Notebooks:
-    - Quickstart: notebooks/01-quickstart.ipynb
-    - Heat System: notebooks/02-heat-system.ipynb
-    - Multi-Node Heat: notebooks/03-multi-node-heat.ipynb
-    - Multi-Period: notebooks/04-multi-period.ipynb
-    - Investment: notebooks/05-investment.ipynb
-    - Status: notebooks/06-status.ipynb
-    - Piecewise: notebooks/07-piecewise.ipynb
-  - Math:
-    - Notation: math/notation.md
-    - Objective: math/objective.md
-    - Carrier Balance: math/carrier-balance.md
-    - Flows: math/flows.md
-    - Converters: math/converters.md
-    - Storage: math/storage.md
-    - Effects: math/effects.md
-    - Sizing: math/sizing.md
-    - Status: math/status.md
+  - User Guide:
+    - Tutorials:
+      - Quickstart: notebooks/01-quickstart.ipynb
+      - Heat System: notebooks/02-heat-system.ipynb
+      - Multi-Node Heat: notebooks/03-multi-node-heat.ipynb
+      - Multi-Period: notebooks/04-multi-period.ipynb
+      - Investment: notebooks/05-investment.ipynb
+      - Status: notebooks/06-status.ipynb
+      - Piecewise: notebooks/07-piecewise.ipynb
+    - Math:
+      - Notation: math/notation.md
+      - Objective: math/objective.md
+      - Carrier Balance: math/carrier-balance.md
+      - Flows: math/flows.md
+      - Converters: math/converters.md
+      - Storage: math/storage.md
+      - Effects: math/effects.md
+      - Sizing: math/sizing.md
+      - Status: math/status.md
   - API Reference: api/
+  - Contributing: contributing.md
   - Changelog: changelog.md
 
 theme:


### PR DESCRIPTION
## Summary

Restructure the docs nav around what users come for, not what file-type they're in.

**Before**
\`\`\`
Home · Notebooks · Math · API Reference · Changelog
\`\`\`

**After**
\`\`\`
Home · User Guide (Tutorials, Math) · API Reference · Contributing · Changelog
\`\`\`

- Notebooks → \`User Guide / Tutorials/\` (they're how you learn the library — calling them "Tutorials" beats calling them "Notebooks")
- Math pages → \`User Guide / Math/\` (formulation reference — same place, just nested under User Guide so the top-level isn't crowded)
- New top-level **Contributing** entry: \`docs/contributing.md\` includes \`../.github/CONTRIBUTING.md\` via \`mkdocs-include-markdown\` (already in docs deps). Single source of truth — GitHub keeps showing it natively.

**Stacked on #148** — base is \`docs/material-theming\`. Auto-retargets to \`main\` when #148 merges.

## Test plan

- [x] \`uv run mkdocs build --strict\` passes (4.85s, no warnings)
- [x] Contributing page renders included content (Setup / Workflow / Code Quality / Testing headings present)
- [ ] \`uv run mkdocs serve\` — verify nav shows User Guide expandable with Tutorials + Math sub-sections
- [ ] All 7 notebooks reachable via User Guide → Tutorials
- [ ] All 9 math pages reachable via User Guide → Math
- [ ] Contributing tab loads and shows the same content as \`.github/CONTRIBUTING.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)