### PR TITLE
docs: notebook polish (linopy aesthetic, prompts, accent stripes)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -65,30 +65,33 @@ Energy system optimization with [linopy](https://github.com/PyPSA/linopy) — de
 
 </div>
 
-## Quick Example
 
-A gas boiler covers a heat demand, minimizing fuel cost:
 
 ```python
+# A gas boiler covers a heat demand, minimizing fuel cost
 from datetime import datetime
 from fluxopt import Carrier, Converter, Effect, Flow, Port, optimize
 
-timesteps = [datetime(2024, 1, 1, h) for h in range(4)]
-
-gas = Carrier('gas')
-heat = Carrier('heat')
-
-gas_source = Flow('gas', size=500, effects_per_flow_hour={'cost': 0.04})
-fuel = Flow('gas', size=300)
-heat_out = Flow('heat', size=200)
-demand = Flow('heat', size=100, fixed_relative_profile=[0.4, 0.7, 0.5, 0.6])
-
 result = optimize(
-    timesteps=timesteps,
-    carriers=[gas, heat],
+    timesteps=[datetime(2024, 1, 1, h) for h in range(4)],
+    carriers=[Carrier('gas'), Carrier('heat')],
     effects=[Effect('cost')],
-    ports=[Port('grid', imports=[gas_source]), Port('demand', exports=[demand])],
-    converters=[Converter.boiler('boiler', thermal_efficiency=0.9, fuel_flow=fuel, thermal_flow=heat_out)],
+    ports=[
+        Port('grid', imports=[
+            Flow('gas', size=500, effects_per_flow_hour={'cost': 0.04})
+        ]),
+        Port('demand', exports=[
+            Flow('heat', size=100, fixed_relative_profile=[0.4, 0.7, 0.5, 0.6])
+        ])
+    ],
+    converters=[
+        Converter.boiler(
+            'boiler',
+            thermal_efficiency=0.9,
+            fuel_flow=Flow('gas', size=300),
+            thermal_flow=Flow('heat', size=200)
+        )
+    ],
     objective_effects='cost',
 )
 

--- a/docs/javascripts/notebook-prompts.js
+++ b/docs/javascripts/notebook-prompts.js
@@ -16,13 +16,19 @@ function stripPromptPrefixes() {
 }
 
 function attachClickToCopy() {
-  document.querySelectorAll('.jp-CodeCell .highlight-ipynb').forEach((block) => {
+  // Notebook code cells AND markdown code fences (skip inline `code` and
+  // mkdocstrings .doc-signature — neither is meant for copy-the-block UX)
+  const blocks = document.querySelectorAll(
+    '.jp-CodeCell .highlight-ipynb, .md-typeset .highlight'
+  );
+  blocks.forEach((block) => {
     if (block.dataset.copyAttached) return;
+    if (block.closest('.doc-signature')) return;
     block.dataset.copyAttached = '1';
     block.addEventListener('click', (event) => {
       // Don't fire if the user is selecting text (or just clicked a link inside)
       if (window.getSelection().toString().length > 0) return;
-      if (event.target.closest('a')) return;
+      if (event.target.closest('a, button')) return;
 
       const codeEl = block.querySelector('pre');
       if (!codeEl) return;
@@ -30,7 +36,7 @@ function attachClickToCopy() {
 
       navigator.clipboard.writeText(text).then(() => {
         block.classList.add('copied');
-        setTimeout(() => block.classList.remove('copied'), 600);
+        setTimeout(() => block.classList.remove('copied'), 700);
       }).catch(() => {});
     });
   });

--- a/docs/javascripts/notebook-prompts.js
+++ b/docs/javascripts/notebook-prompts.js
@@ -1,0 +1,20 @@
+// Strip "In " / "Out" prefixes from notebook prompts, keep only [N]:
+// Subscribes to Material's instant-nav lifecycle when available so it
+// re-runs on every page transition, not just initial load.
+
+function stripPromptPrefixes() {
+  document.querySelectorAll('.jp-InputPrompt, .jp-OutputPrompt').forEach((el) => {
+    if (el.dataset.fixed) return;
+    const m = el.textContent.match(/^\s*(?:In|Out)\s*(\[\s*\d*\s*\]:?)\s*$/);
+    if (m) {
+      el.textContent = m[1];
+      el.dataset.fixed = '1';
+    }
+  });
+}
+
+if (typeof document$ !== 'undefined') {
+  document$.subscribe(stripPromptPrefixes);
+} else {
+  document.addEventListener('DOMContentLoaded', stripPromptPrefixes);
+}

--- a/docs/javascripts/notebook-prompts.js
+++ b/docs/javascripts/notebook-prompts.js
@@ -1,6 +1,8 @@
-// Strip "In " / "Out" prefixes from notebook prompts, keep only [N]:
-// Subscribes to Material's instant-nav lifecycle when available so it
-// re-runs on every page transition, not just initial load.
+// Strip "In " / "Out" prefixes from notebook prompts (keep only [N]:),
+// and make the whole input code block clickable to copy.
+//
+// Subscribes to Material's `document$` instant-nav lifecycle when available
+// so both behaviours re-attach on every page transition.
 
 function stripPromptPrefixes() {
   document.querySelectorAll('.jp-InputPrompt, .jp-OutputPrompt').forEach((el) => {
@@ -13,8 +15,34 @@ function stripPromptPrefixes() {
   });
 }
 
+function attachClickToCopy() {
+  document.querySelectorAll('.jp-CodeCell .highlight-ipynb').forEach((block) => {
+    if (block.dataset.copyAttached) return;
+    block.dataset.copyAttached = '1';
+    block.addEventListener('click', (event) => {
+      // Don't fire if the user is selecting text (or just clicked a link inside)
+      if (window.getSelection().toString().length > 0) return;
+      if (event.target.closest('a')) return;
+
+      const codeEl = block.querySelector('pre');
+      if (!codeEl) return;
+      const text = codeEl.innerText;
+
+      navigator.clipboard.writeText(text).then(() => {
+        block.classList.add('copied');
+        setTimeout(() => block.classList.remove('copied'), 600);
+      }).catch(() => {});
+    });
+  });
+}
+
+function init() {
+  stripPromptPrefixes();
+  attachClickToCopy();
+}
+
 if (typeof document$ !== 'undefined') {
-  document$.subscribe(stripPromptPrefixes);
+  document$.subscribe(init);
 } else {
-  document.addEventListener('DOMContentLoaded', stripPromptPrefixes);
+  document.addEventListener('DOMContentLoaded', init);
 }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -33,7 +33,9 @@
 
 [data-md-color-scheme="slate"] {
   --md-code-fg-color: #f8f8f2;
-  --md-code-bg-color: #272822;
+  /* Derived from slate body bg hsla(var(--md-hue), 15%, 14%, 1):
+     same hue, less saturated (6%), brighter (18%). Subtle slate hint, mostly gray. */
+  --md-code-bg-color: hsla(var(--md-hue), 6%, 18%, 1);
 
   /* Material code blocks — classic Monokai */
   --md-code-hl-keyword-color:     #f92672;   /* hot pink */
@@ -130,10 +132,10 @@ body[data-md-color-scheme="slate"] .jupyter-wrapper {
   color: #7dd3fc;                          /* sky-300 */
 }
 
-/* TOC active item: Material binds .md-nav__link--active to --md-typeset-a-color,
-   which defaults to --md-primary-fg-color (slate-700 in our palette). That makes
-   the selected header invisible (slate-on-white in light, slate-on-dark in dark).
-   Re-bind to our sky link colors and add a left rule + tint for visual punch. */
+/* TOC + nav active item: Material binds .md-nav__link--active to
+   --md-typeset-a-color, which defaults to --md-primary-fg-color (slate-700).
+   That makes the selected item near-invisible (slate-on-white in light,
+   slate-on-dark in dark). Re-bind to our sky link colors. */
 :root,
 [data-md-color-scheme="default"] {
   --md-typeset-a-color: #0284c7;           /* sky-600 — matches link color */
@@ -143,15 +145,40 @@ body[data-md-color-scheme="slate"] .jupyter-wrapper {
   --md-typeset-a-color: #38bdf8;           /* sky-400 — matches link color */
 }
 
+/* macOS-style nav items (left sidebar + right TOC): rounded pill on hover and
+   active, no harsh borders. Inspired by PyData Sphinx / Furo nav treatments. */
+.md-nav__link {
+  border-radius: 4px;
+  padding: 0.2rem 0.5rem;
+  margin: 0.05rem -0.5rem;
+  transition: background 100ms, color 100ms;
+}
+
+.md-nav__link:hover {
+  background: rgba(2, 132, 199, 0.07);     /* sky-600 tint */
+  color: var(--md-typeset-a-color);
+}
+
+[data-md-color-scheme="slate"] .md-nav__link:hover {
+  background: rgba(56, 189, 248, 0.10);    /* sky-400 tint */
+}
+
 .md-nav__link--active {
-  font-weight: 600;
-  border-left: 2px solid #0284c7;
-  padding-left: 0.4rem;
-  margin-left: -0.4rem;
+  background: rgba(2, 132, 199, 0.10);
+  font-weight: 500;
 }
 
 [data-md-color-scheme="slate"] .md-nav__link--active {
-  border-left-color: #38bdf8;
+  background: rgba(56, 189, 248, 0.14);
+}
+
+/* Material fades .md-nav__link--passed (already-scrolled-past TOC items + the
+   previous nav page) to --md-default-fg-color--light, which in slate is 56%
+   opacity → unreadable. Keep some fade but make it legible. */
+.md-nav__link--passed,
+.md-nav__link--passed code {
+  color: var(--md-default-fg-color);
+  opacity: 0.85;
 }
 
 /* --- Layout: wider content, denser sidebars --- */
@@ -219,19 +246,21 @@ body[data-md-color-scheme="slate"] .jupyter-wrapper {
 }
 
 .md-typeset .highlight.copied::after {
-  content: 'Copied!';
+  content: '✓ Copied!';
   position: absolute;
   top: 50%;
   left: 50%;
-  padding: 0.5em 1.4em;
-  background: rgba(0, 0, 0, 0.7);
+  padding: 0.65em 1.6em;
+  background: #0284c7;                     /* sky-600 — brand color, vivid */
   color: #ffffff;
   font-family: 'JetBrains Mono', monospace;
-  font-size: 1.1em;
-  font-weight: 600;
-  border-radius: 4px;
+  font-size: 1.35em;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  border-radius: 6px;
+  box-shadow: 0 4px 18px rgba(2, 132, 199, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.15) inset;
   pointer-events: none;
-  animation: copied-fade 700ms ease-out forwards;
+  animation: copied-fade 900ms ease-out forwards;
 }
 
 [data-md-color-scheme="slate"] .md-typeset .highlight {
@@ -284,6 +313,114 @@ body[data-md-color-scheme="slate"] .jupyter-wrapper {
 .md-typeset .landing {
   max-width: 64rem;
   margin: 0 auto;
+}
+
+/* Landing-page section headings: centered, with breathing room */
+.md-typeset .landing h2 {
+  text-align: center;
+  margin: 2.4rem 0 1rem;
+}
+
+/* Landing-page code blocks: macOS-window treatment with traffic-light dots.
+   Title-bar space is created by padding-top on .highlight; the dots are drawn
+   in a single ::before via box-shadow (red dot + 2 shadow-offset dots).
+   Always-dark: locally redefine the Monokai dark palette so the showcase reads
+   like a terminal screenshot, regardless of the site's color scheme. */
+.md-typeset .landing > .highlight {
+  position: relative;
+  max-width: 40rem;                        /* match regular code-block width */
+  margin: 0 auto 1.5rem;
+  padding-top: 1.9rem;
+  border-left: none;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 8px;
+  /* Linear gradient: top 1.9rem = title bar (uses --md-primary-fg-color so it
+     always matches the "Get Started" / .md-button--primary background, whether
+     the user is on auto/indigo or our custom slate palette). Below = code area
+     (derived from site bg, brighter + less saturated). Confines the title-bar
+     color to the top only — no "footer" bleed at the bottom. */
+  background: linear-gradient(
+    to bottom,
+    var(--md-primary-fg-color) 0,
+    var(--md-primary-fg-color) 1.9rem,
+    hsla(var(--md-hue), 6%, 18%, 1) 1.9rem,
+    hsla(var(--md-hue), 6%, 18%, 1) 100%
+  );
+  box-shadow:
+    0 0 24px rgba(2, 132, 199, 0.18),      /* sky glow */
+    0 8px 28px rgba(0, 0, 0, 0.18);        /* drop shadow */
+  overflow: hidden;
+
+  /* Force Monokai dark, locally — overrides whatever scheme is active. */
+  --md-code-fg-color: #f8f8f2;
+  --md-code-bg-color: hsla(var(--md-hue), 6%, 18%, 1);    /* matches global dark code bg */
+  --md-code-hl-keyword-color:     #f92672;
+  --md-code-hl-string-color:      #e6db74;
+  --md-code-hl-number-color:      #ae81ff;
+  --md-code-hl-function-color:    #a6e22e;
+  --md-code-hl-comment-color:     #75715e;
+  --md-code-hl-name-color:        #f8f8f2;
+  --md-code-hl-operator-color:    #f92672;
+  --md-code-hl-punctuation-color: #f8f8f2;
+  --md-code-hl-constant-color:    #ae81ff;
+  --md-code-hl-special-color:     #a6e22e;
+  --md-code-hl-variable-color:    #fd971f;
+  --md-code-hl-generic-color:     #f8f8f2;
+}
+
+.md-typeset .landing > .highlight::before {
+  content: '';
+  position: absolute;
+  top: 0.65rem;
+  left: 0.85rem;
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  background: #ff5f57;                     /* close — red */
+  box-shadow:
+    1.05rem 0 0 #febc2e,                   /* minimize — yellow */
+    2.10rem 0 0 #28c840;                   /* zoom — green */
+}
+
+/* Title-bar label centered in the title strip. :not(.copied) so the
+   "Copied!" badge can take over the ::after slot during click feedback. */
+.md-typeset .landing > .highlight:not(.copied)::after {
+  content: '✨ Quick Start';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1.9rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.75);
+  font-family: var(--md-text-font);
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  pointer-events: none;
+}
+
+.md-typeset .landing > .highlight:hover {
+  border-color: rgba(2, 132, 199, 0.4);
+  box-shadow:
+    0 0 36px rgba(2, 132, 199, 0.32),
+    0 10px 32px rgba(0, 0, 0, 0.22);
+}
+
+[data-md-color-scheme="slate"] .md-typeset .landing > .highlight {
+  border-color: rgba(255, 255, 255, 0.10);
+  box-shadow:
+    0 0 28px rgba(56, 189, 248, 0.18),     /* sky-400 glow on dark */
+    0 8px 28px rgba(0, 0, 0, 0.45);
+}
+
+[data-md-color-scheme="slate"] .md-typeset .landing > .highlight:hover {
+  border-color: rgba(56, 189, 248, 0.4);
+  box-shadow:
+    0 0 40px rgba(56, 189, 248, 0.32),
+    0 10px 32px rgba(0, 0, 0, 0.5);
 }
 
 /* Button row spacing — scoped to the landing hero where button rows actually appear */
@@ -404,19 +541,21 @@ body[data-md-color-scheme="slate"] .jupyter-wrapper {
 }
 
 .jupyter-wrapper .jp-CodeCell .highlight-ipynb.copied::after {
-  content: 'Copied!';
+  content: '✓ Copied!';
   position: absolute;
   top: 50%;
   left: 50%;
-  padding: 0.5em 1.4em;
-  background: rgba(0, 0, 0, 0.7);
+  padding: 0.65em 1.6em;
+  background: #0284c7;                     /* sky-600 — brand color, vivid */
   color: #ffffff;
   font-family: 'JetBrains Mono', monospace;
-  font-size: 1.1em;
-  font-weight: 600;
-  border-radius: 4px;
+  font-size: 1.35em;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  border-radius: 6px;
+  box-shadow: 0 4px 18px rgba(2, 132, 199, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.15) inset;
   pointer-events: none;
-  animation: copied-fade 700ms ease-out forwards;
+  animation: copied-fade 900ms ease-out forwards;
 }
 
 @keyframes copied-fade {
@@ -512,8 +651,9 @@ body[data-md-color-scheme="slate"] .jupyter-wrapper {
 }
 
 [data-md-color-scheme="slate"] .jupyter-wrapper .jp-CodeCell .highlight-ipynb.copied::after {
-  background: rgba(255, 255, 255, 0.2);
-  color: #ffffff;
+  background: #38bdf8;                     /* sky-400 — brighter for dark bg */
+  color: #0c1620;                          /* dark text on bright sky bg for max contrast */
+  box-shadow: 0 4px 22px rgba(56, 189, 248, 0.6), 0 0 0 1px rgba(255, 255, 255, 0.2) inset;
 }
 
 [data-md-color-scheme="slate"] .jupyter-wrapper .jp-InputPrompt {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,3 +1,92 @@
+/* --- Syntax highlighting: Monokai Light + Monokai Dark ---
+ *
+ * TWO sets of variables to override:
+ *   --md-code-hl-*-color     → Material's markdown code blocks (.highlight)
+ *   --jp-mirror-editor-*-color → notebook code blocks (.highlight-ipynb)
+ *
+ * Notebook code uses JupyterLab's CSS variables, NOT Material's. Both must
+ * be overridden together to keep colors consistent across the whole site.
+ *
+ * Light = darkened-Monokai variant (dark hues on light bg for readability);
+ * Dark = classic Monokai.
+ */
+
+:root,
+[data-md-color-scheme="default"] {
+  --md-code-fg-color: #272822;
+  --md-code-bg-color: #fafafa;
+
+  /* Material code blocks — Monokai (darkened for light bg) */
+  --md-code-hl-keyword-color:     #d11f72;   /* darkened pink */
+  --md-code-hl-string-color:      #998800;   /* mustard yellow */
+  --md-code-hl-number-color:      #6f42c1;   /* purple */
+  --md-code-hl-function-color:    #4d8d04;   /* green */
+  --md-code-hl-comment-color:     #75715e;   /* olive-gray */
+  --md-code-hl-name-color:        #272822;   /* default text */
+  --md-code-hl-operator-color:    #d11f72;   /* pink */
+  --md-code-hl-punctuation-color: #272822;
+  --md-code-hl-constant-color:    #6f42c1;   /* purple — None, True, False */
+  --md-code-hl-special-color:     #4d8d04;   /* green — decorators */
+  --md-code-hl-variable-color:    #d35400;   /* burnt orange */
+  --md-code-hl-generic-color:     #272822;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-code-fg-color: #f8f8f2;
+  --md-code-bg-color: #272822;
+
+  /* Material code blocks — classic Monokai */
+  --md-code-hl-keyword-color:     #f92672;   /* hot pink */
+  --md-code-hl-string-color:      #e6db74;   /* yellow */
+  --md-code-hl-number-color:      #ae81ff;   /* purple */
+  --md-code-hl-function-color:    #a6e22e;   /* green */
+  --md-code-hl-comment-color:     #75715e;   /* olive-gray */
+  --md-code-hl-name-color:        #f8f8f2;   /* default text */
+  --md-code-hl-operator-color:    #f92672;   /* pink */
+  --md-code-hl-punctuation-color: #f8f8f2;
+  --md-code-hl-constant-color:    #ae81ff;   /* purple — None, True, False */
+  --md-code-hl-special-color:     #a6e22e;   /* green — decorators */
+  --md-code-hl-variable-color:    #fd971f;   /* orange */
+  --md-code-hl-generic-color:     #f8f8f2;
+}
+
+/* JupyterLab vars: must be set ON .jupyter-wrapper because that element
+   re-defines them locally (e.g. --jp-mirror-editor-keyword-color: #008000).
+   Prefix with `body` (where Material puts the scheme attribute) to outrank
+   mkdocs-jupyter's inline `[data-md-color-scheme=slate] .jupyter-wrapper`,
+   which otherwise wins on cascade order. */
+body[data-md-color-scheme="default"] .jupyter-wrapper {
+  --jp-mirror-editor-keyword-color:     #d11f72;
+  --jp-mirror-editor-string-color:      #998800;
+  --jp-mirror-editor-number-color:      #6f42c1;
+  --jp-mirror-editor-builtin-color:     #4d8d04;
+  --jp-mirror-editor-comment-color:     #75715e;
+  --jp-mirror-editor-operator-color:    #d11f72;
+  --jp-mirror-editor-punctuation-color: #272822;
+  --jp-mirror-editor-variable-color:    #d35400;
+  --jp-mirror-editor-meta-color:        #4d8d04;
+  --jp-mirror-editor-bracket-color:     #272822;
+  --jp-mirror-editor-property-color:    #272822;
+  --jp-mirror-editor-attribute-color:   #d11f72;
+  --jp-mirror-editor-tag-color:         #d11f72;
+}
+
+body[data-md-color-scheme="slate"] .jupyter-wrapper {
+  --jp-mirror-editor-keyword-color:     #f92672;
+  --jp-mirror-editor-string-color:      #e6db74;
+  --jp-mirror-editor-number-color:      #ae81ff;
+  --jp-mirror-editor-builtin-color:     #a6e22e;
+  --jp-mirror-editor-comment-color:     #75715e;
+  --jp-mirror-editor-operator-color:    #f92672;
+  --jp-mirror-editor-punctuation-color: #f8f8f2;
+  --jp-mirror-editor-variable-color:    #fd971f;
+  --jp-mirror-editor-meta-color:        #a6e22e;
+  --jp-mirror-editor-bracket-color:     #f8f8f2;
+  --jp-mirror-editor-property-color:    #f8f8f2;
+  --jp-mirror-editor-attribute-color:   #f92672;
+  --jp-mirror-editor-tag-color:         #f92672;
+}
+
 /* --- Custom palette: soft dark slate primary + sky accent --- */
 
 :root,
@@ -269,7 +358,7 @@
 }
 
 .jupyter-wrapper .jp-CodeCell .highlight-ipynb {
-  background: #f5f5f5;
+  background: var(--md-code-bg-color);   /* matches Material's other code blocks */
   border: none;
   border-left: 2px solid #0284c7;        /* sky-600 accent stripe */
   border-radius: 0 2px 2px 0;
@@ -386,7 +475,6 @@
 
 /* Dark mode tone-down */
 [data-md-color-scheme="slate"] .jupyter-wrapper .jp-CodeCell .highlight-ipynb {
-  background: #2a2a2a;
   border-left-color: #38bdf8;            /* sky-400 — brighter accent for dark bg */
 }
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -130,6 +130,30 @@ body[data-md-color-scheme="slate"] .jupyter-wrapper {
   color: #7dd3fc;                          /* sky-300 */
 }
 
+/* TOC active item: Material binds .md-nav__link--active to --md-typeset-a-color,
+   which defaults to --md-primary-fg-color (slate-700 in our palette). That makes
+   the selected header invisible (slate-on-white in light, slate-on-dark in dark).
+   Re-bind to our sky link colors and add a left rule + tint for visual punch. */
+:root,
+[data-md-color-scheme="default"] {
+  --md-typeset-a-color: #0284c7;           /* sky-600 — matches link color */
+}
+
+[data-md-color-scheme="slate"] {
+  --md-typeset-a-color: #38bdf8;           /* sky-400 — matches link color */
+}
+
+.md-nav__link--active {
+  font-weight: 600;
+  border-left: 2px solid #0284c7;
+  padding-left: 0.4rem;
+  margin-left: -0.4rem;
+}
+
+[data-md-color-scheme="slate"] .md-nav__link--active {
+  border-left-color: #38bdf8;
+}
+
 /* --- Layout: wider content, denser sidebars --- */
 
 :root {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -200,7 +200,7 @@
 }
 
 .jupyter-wrapper .jp-OutputPrompt {
-  color: #d62728 !important;       /* classic Jupyter red */
+  color: #cbd5e1 !important;       /* slate-300 — muted, secondary to input */
 }
 
 /* Input area: subtle bg, no border, tight padding */
@@ -252,6 +252,8 @@
   min-width: 0;
   background: none;
   margin: 0;
+  border-left: 2px solid #cbd5e1;       /* muted stripe pairs visually with input */
+  padding-left: 0.6em;
 }
 
 .jupyter-wrapper .jp-RenderedText pre {
@@ -263,16 +265,23 @@
   line-height: 1.4;
 }
 
-/* Markdown cells: aggressive heading spacing — let cells breathe via prompt gutter */
-.jupyter-wrapper .jp-MarkdownCell .md-typeset h2 {
+/* Markdown cells: aggressive heading spacing.
+   `.md-typeset` is on <article> (ancestor of the notebook) — putting it
+   inside the chain after .jp-MarkdownCell never matches. Drop it and rely
+   on .jupyter-wrapper for specificity over Material's `.md-typeset h2`. */
+.jupyter-wrapper .jp-MarkdownCell h2 {
   margin: 0.3em 0 0.15em;
 }
 
-.jupyter-wrapper .jp-MarkdownCell .md-typeset h3 {
+.jupyter-wrapper .jp-MarkdownCell h3 {
   margin: 0.25em 0 0.1em;
 }
 
-.jupyter-wrapper .jp-MarkdownCell .md-typeset p {
+.jupyter-wrapper .jp-MarkdownCell h1 {
+  margin: 0.4em 0 0.2em;
+}
+
+.jupyter-wrapper .jp-MarkdownCell p {
   margin: 0.3em 0;
 }
 
@@ -297,5 +306,9 @@
 }
 
 [data-md-color-scheme="slate"] .jupyter-wrapper .jp-OutputPrompt {
-  color: #ff6b6b !important;       /* salmon for dark bg */
+  color: #64748b !important;       /* slate-500 — readable muted on dark bg */
+}
+
+[data-md-color-scheme="slate"] .jupyter-wrapper .jp-OutputArea-output {
+  border-left-color: #475569;       /* slate-600 — subtle on dark bg */
 }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -479,7 +479,8 @@ body[data-md-color-scheme="slate"] .jupyter-wrapper {
   display: block;
 }
 
-/* Numbered prompts: monospace gutter — input blue, output red (Jupyter convention).
+/* Numbered prompts: monospace gutter — input sky (#0284c7), output muted
+   slate (#cbd5e1) to keep the output secondary.
    The "In " / "Out" prefixes are stripped by javascripts/notebook-prompts.js;
    only the bracketed number remains.
    !important needed because JupyterLab's `:not(.jp-mod-active)` rule has

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -488,8 +488,11 @@ body[data-md-color-scheme="slate"] .jupyter-wrapper {
 .jupyter-wrapper .jp-InputPrompt,
 .jupyter-wrapper .jp-OutputPrompt {
   display: block !important;
-  flex: 0 0 2.5em !important;
-  min-width: 0 !important;
+  /* ch-based gutter sized for post-JS "[NN]:" / "[NNN]:" — the JS strips the
+     "In " / "Out" prefixes within milliseconds, so we optimise for the
+     steady-state look. Pre-JS may briefly overflow leftward into the margin. */
+  flex: 0 0 5ch !important;
+  min-width: 5ch !important;
   padding: 0.4em 0.5em 0 0 !important;
   font-family: 'Fira Code', monospace;
   font-size: 0.78em;

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -222,6 +222,42 @@
   border-radius: 0 2px 2px 0;
   margin: 0;
   width: 100%;
+  cursor: pointer;                       /* signals click-to-copy */
+  position: relative;                    /* anchor for the .copied ::after badge */
+  transition: border-left-color 150ms, box-shadow 150ms, background 200ms;
+}
+
+.jupyter-wrapper .jp-CodeCell .highlight-ipynb:hover {
+  border-left-color: #0ea5e9;            /* sky-500 — brighten on hover */
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+/* Copy confirmation: subtle gray-tinted background flash + "Copied!" badge */
+.jupyter-wrapper .jp-CodeCell .highlight-ipynb.copied {
+  background: rgba(0, 0, 0, 0.04);       /* barely-there gray overlay */
+}
+
+.jupyter-wrapper .jp-CodeCell .highlight-ipynb.copied::after {
+  content: 'Copied!';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  padding: 0.5em 1.4em;
+  background: rgba(0, 0, 0, 0.7);
+  color: #ffffff;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 1.1em;
+  font-weight: 600;
+  border-radius: 4px;
+  pointer-events: none;
+  animation: copied-fade 700ms ease-out forwards;
+}
+
+@keyframes copied-fade {
+  0%   { opacity: 0; transform: translate(-50%, -50%) scale(0.92); }
+  20%  { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+  80%  { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+  100% { opacity: 0; transform: translate(-50%, -50%) scale(1); }
 }
 
 .jupyter-wrapper .jp-CodeCell .highlight-ipynb pre {
@@ -299,6 +335,20 @@
 [data-md-color-scheme="slate"] .jupyter-wrapper .jp-CodeCell .highlight-ipynb {
   background: #2a2a2a;
   border-left-color: #38bdf8;            /* sky-400 — brighter accent for dark bg */
+}
+
+[data-md-color-scheme="slate"] .jupyter-wrapper .jp-CodeCell .highlight-ipynb:hover {
+  border-left-color: #7dd3fc;            /* sky-300 — brighter still on hover */
+  box-shadow: 0 1px 4px rgba(255, 255, 255, 0.06);
+}
+
+[data-md-color-scheme="slate"] .jupyter-wrapper .jp-CodeCell .highlight-ipynb.copied {
+  background: rgba(255, 255, 255, 0.05); /* subtle light overlay on dark */
+}
+
+[data-md-color-scheme="slate"] .jupyter-wrapper .jp-CodeCell .highlight-ipynb.copied::after {
+  background: rgba(255, 255, 255, 0.2);
+  color: #ffffff;
 }
 
 [data-md-color-scheme="slate"] .jupyter-wrapper .jp-InputPrompt {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -144,9 +144,9 @@
  * on specificity against the inlined Jupyter Lab stylesheet.
  */
 
-/* Cell rhythm: tight, minimal */
+/* Cell rhythm: as tight as possible without cramping */
 .jupyter-wrapper .jp-Cell {
-  margin: 0 0 0.35em 0;
+  margin: 0;
   padding: 0;
 }
 
@@ -218,13 +218,14 @@
 .jupyter-wrapper .jp-CodeCell .highlight-ipynb {
   background: #f5f5f5;
   border: none;
-  border-radius: 2px;
+  border-left: 2px solid #0284c7;        /* sky-600 accent stripe */
+  border-radius: 0 2px 2px 0;
   margin: 0;
   width: 100%;
 }
 
 .jupyter-wrapper .jp-CodeCell .highlight-ipynb pre {
-  padding: 0.4em 0.75em;
+  padding: 0.3em 0.6em;
   margin: 0;
   line-height: 1.45;
   background: transparent;
@@ -262,17 +263,17 @@
   line-height: 1.4;
 }
 
-/* Markdown cells: tight heading spacing */
+/* Markdown cells: aggressive heading spacing — let cells breathe via prompt gutter */
 .jupyter-wrapper .jp-MarkdownCell .md-typeset h2 {
-  margin: 1em 0 0.35em;
+  margin: 0.3em 0 0.15em;
 }
 
 .jupyter-wrapper .jp-MarkdownCell .md-typeset h3 {
-  margin: 0.7em 0 0.25em;
+  margin: 0.25em 0 0.1em;
 }
 
 .jupyter-wrapper .jp-MarkdownCell .md-typeset p {
-  margin: 0.4em 0;
+  margin: 0.3em 0;
 }
 
 /* Hide non-functional UI elements */
@@ -288,6 +289,7 @@
 /* Dark mode tone-down */
 [data-md-color-scheme="slate"] .jupyter-wrapper .jp-CodeCell .highlight-ipynb {
   background: #2a2a2a;
+  border-left-color: #38bdf8;            /* sky-400 — brighter accent for dark bg */
 }
 
 [data-md-color-scheme="slate"] .jupyter-wrapper .jp-InputPrompt {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -137,72 +137,163 @@
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 }
 
-/* --- Notebook styling (inspired by nbsphinx / PyData theme) --- */
+/* --- Notebook styling — nbsphinx / linopy aesthetic ---
+ *
+ * mkdocs-jupyter's CSS uses `.jupyter-wrapper .jp-*` selectors;
+ * the `.jupyter-wrapper` prefix is required for our overrides to win
+ * on specificity against the inlined Jupyter Lab stylesheet.
+ */
 
-/* Hide prompts — code vs output distinguished by background.
-   !important needed to override mkdocs-jupyter's inline high-specificity rule. */
-.jp-InputPrompt,
-.jp-OutputPrompt {
-  display: none !important;
+/* Cell rhythm: tight, minimal */
+.jupyter-wrapper .jp-Cell {
+  margin: 0 0 0.35em 0;
+  padding: 0;
 }
 
-/* Code input area: light gray background */
-.jp-Cell-inputWrapper {
+/* Code cells: prompt + content side-by-side, indented as one unit.
+   Markdown cells share the wrapper structure but have an empty prompt;
+   below we strip both so markdown flows full-width at the left edge. */
+.jupyter-wrapper .jp-CodeCell .jp-Cell-inputWrapper,
+.jupyter-wrapper .jp-Cell-outputWrapper {
   display: flex;
-}
-
-.jp-InputArea {
-  display: flex;
-  width: 100%;
-}
-
-.jp-InputArea-editor {
-  flex: 1;
-  min-width: 0;
-}
-
-.jp-CodeCell .highlight-ipynb {
-  background: #f7f7f7;
-  border: 1px solid #e0e0e0;
-  border-radius: 3px;
+  align-items: flex-start;
+  gap: 0.25em;
   margin: 0;
+  padding: 0;
 }
 
-/* Output area: no background */
-.jp-Cell-outputWrapper {
-  display: flex;
-}
-
-.jp-OutputArea {
-  flex: 1;
-  min-width: 0;
-}
-
-/* Text output */
-.jp-RenderedText pre {
-  background: none;
-  border: none;
-  padding: 0.4em 0.75em;
+/* Markdown cells: full width, no prompt gutter, no left indent */
+.jupyter-wrapper .jp-MarkdownCell .jp-Cell-inputWrapper {
   margin: 0;
+  padding: 0;
 }
 
-/* Hide collapsers — not functional in static docs */
-.jp-Collapser {
+.jupyter-wrapper .jp-MarkdownCell .jp-InputPrompt {
   display: none;
 }
 
-/* Cell spacing */
-.jp-Cell {
-  margin-bottom: 1em;
+.jupyter-wrapper .jp-MarkdownCell .jp-InputArea {
+  display: block;
 }
 
-/* Compact plotly chart spacing */
-.jp-OutputArea .js-plotly-plot {
-  margin: 0.25em 0 !important;
+/* Numbered prompts: monospace gutter — input blue, output red (Jupyter convention).
+   The "In " / "Out" prefixes are stripped by javascripts/notebook-prompts.js;
+   only the bracketed number remains.
+   !important needed because JupyterLab's `:not(.jp-mod-active)` rule has
+   higher specificity and forces a gray color + reduced opacity. */
+.jupyter-wrapper .jp-InputPrompt,
+.jupyter-wrapper .jp-OutputPrompt {
+  display: block !important;
+  flex: 0 0 2.5em !important;
+  min-width: 0 !important;
+  padding: 0.4em 0.5em 0 0 !important;
+  font-family: 'Fira Code', monospace;
+  font-size: 0.78em;
+  text-align: right;
+  background: none;
+  border: none;
+  opacity: 1 !important;
 }
 
-/* Dark mode overrides */
-[data-md-color-scheme="slate"] .jp-CodeCell .highlight-ipynb {
-  background: #2b2b2b;
-  border-color: #404040;
+.jupyter-wrapper .jp-InputPrompt {
+  color: #0284c7 !important;       /* sky-600 — matches our link color */
+}
+
+.jupyter-wrapper .jp-OutputPrompt {
+  color: #d62728 !important;       /* classic Jupyter red */
+}
+
+/* Input area: subtle bg, no border, tight padding */
+.jupyter-wrapper .jp-InputArea {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+}
+
+.jupyter-wrapper .jp-InputArea-editor {
+  flex: 1;
+  min-width: 0;
+}
+
+.jupyter-wrapper .jp-CodeCell .highlight-ipynb {
+  background: #f5f5f5;
+  border: none;
+  border-radius: 2px;
+  margin: 0;
+  width: 100%;
+}
+
+.jupyter-wrapper .jp-CodeCell .highlight-ipynb pre {
+  padding: 0.4em 0.75em;
+  margin: 0;
+  line-height: 1.45;
+  background: transparent;
+  border: none;
+}
+
+/* Output area: prompt + content laid out via .jp-OutputArea-child
+   (mkdocs-jupyter wraps each output in a child div — that's the flex row,
+   not the outer .jp-Cell-outputWrapper) */
+.jupyter-wrapper .jp-OutputArea {
+  flex: 1;
+  min-width: 0;
+}
+
+.jupyter-wrapper .jp-OutputArea-child {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.25em;
+  margin: 0;
+}
+
+.jupyter-wrapper .jp-OutputArea-output {
+  flex: 1;
+  min-width: 0;
+  background: none;
+  margin: 0;
+}
+
+.jupyter-wrapper .jp-RenderedText pre {
+  background: transparent;
+  border: none;
+  padding: 0.3em 0.75em;
+  margin: 0;
+  font-size: 0.85em;
+  line-height: 1.4;
+}
+
+/* Markdown cells: tight heading spacing */
+.jupyter-wrapper .jp-MarkdownCell .md-typeset h2 {
+  margin: 1em 0 0.35em;
+}
+
+.jupyter-wrapper .jp-MarkdownCell .md-typeset h3 {
+  margin: 0.7em 0 0.25em;
+}
+
+.jupyter-wrapper .jp-MarkdownCell .md-typeset p {
+  margin: 0.4em 0;
+}
+
+/* Hide non-functional UI elements */
+.jupyter-wrapper .jp-Collapser {
+  display: none;
+}
+
+/* Plotly compactness */
+.jupyter-wrapper .jp-OutputArea .js-plotly-plot {
+  margin: 0.25em 0;
+}
+
+/* Dark mode tone-down */
+[data-md-color-scheme="slate"] .jupyter-wrapper .jp-CodeCell .highlight-ipynb {
+  background: #2a2a2a;
+}
+
+[data-md-color-scheme="slate"] .jupyter-wrapper .jp-InputPrompt {
+  color: #38bdf8 !important;       /* sky-400 — brighter for dark bg */
+}
+
+[data-md-color-scheme="slate"] .jupyter-wrapper .jp-OutputPrompt {
+  color: #ff6b6b !important;       /* salmon for dark bg */
 }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -61,24 +61,77 @@
   width: 10rem;
 }
 
-/* Tighter heading spacing in long-form content */
+/* Tighter heading spacing site-wide (matches notebook aesthetic) */
 .md-typeset h1 {
-  margin: 0 0 1rem;
+  margin: 0 0 0.5em;
   font-weight: 600;
 }
 
 .md-typeset h2 {
-  margin: 1.6em 0 0.6em;
+  margin: 0.8em 0 0.3em;
 }
 
 .md-typeset h3 {
-  margin: 1.2em 0 0.4em;
+  margin: 0.6em 0 0.2em;
+}
+
+.md-typeset h4 {
+  margin: 0.5em 0 0.15em;
 }
 
 /* Slightly denser code blocks */
 .md-typeset pre > code {
   font-size: 0.78rem;
   line-height: 1.5;
+}
+
+/* Markdown code fences — same treatment as notebook code cells:
+   sky-600 left stripe, hover brightens, click-to-copy via JS, "Copied!" badge.
+   Excludes inline `code` and mkdocstrings .doc-signature blocks. */
+.md-typeset .highlight {
+  border-left: 2px solid #0284c7;
+  border-radius: 0 2px 2px 0;
+  cursor: pointer;
+  position: relative;
+  transition: border-left-color 150ms, box-shadow 150ms, background 200ms;
+}
+
+.md-typeset .highlight:hover {
+  border-left-color: #0ea5e9;            /* sky-500 */
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+.md-typeset .highlight.copied {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.md-typeset .highlight.copied::after {
+  content: 'Copied!';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  padding: 0.5em 1.4em;
+  background: rgba(0, 0, 0, 0.7);
+  color: #ffffff;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 1.1em;
+  font-weight: 600;
+  border-radius: 4px;
+  pointer-events: none;
+  animation: copied-fade 700ms ease-out forwards;
+}
+
+[data-md-color-scheme="slate"] .md-typeset .highlight {
+  border-left-color: #38bdf8;            /* sky-400 — brighter for dark bg */
+}
+
+[data-md-color-scheme="slate"] .md-typeset .highlight:hover {
+  border-left-color: #7dd3fc;            /* sky-300 */
+  box-shadow: 0 1px 4px rgba(255, 255, 255, 0.06);
+}
+
+[data-md-color-scheme="slate"] .md-typeset .highlight.copied {
+  background: rgba(255, 255, 255, 0.05);
 }
 
 /* --- Landing page --- */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -158,6 +158,7 @@ extra_css:
 
 extra_javascript:
   - javascripts/mathjax.js
+  - javascripts/notebook-prompts.js
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 
 watch:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,9 +94,6 @@ markdown_extensions:
   - pymdownx.highlight:
       anchor_linenums: true
       use_pygments: true
-      pygments_style: nord
-      line_spans: __span
-      pygments_lang_class: true
   - pymdownx.inlinehilite
   - pymdownx.arithmatex:
       generic: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,7 +58,7 @@ theme:
 
   font:
     text: Roboto
-    code: Fira Code
+    code: JetBrains Mono
 
   icon:
     repo: fontawesome/brands/github
@@ -94,6 +94,9 @@ markdown_extensions:
   - pymdownx.highlight:
       anchor_linenums: true
       use_pygments: true
+      pygments_style: nord
+      line_spans: __span
+      pygments_lang_class: true
   - pymdownx.inlinehilite
   - pymdownx.arithmatex:
       generic: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,24 +37,21 @@ theme:
   # favicon: assets/favicon.png
 
   palette:
-    - media: "(prefers-color-scheme)"
+    # Dark first = default for new visitors (no auto/system-pref entry).
+    # Icon represents the CURRENT scheme — moon when active is dark,
+    # sun when active is light. The `name` describes the toggle action.
+    - scheme: slate
+      primary: custom
+      accent: custom
       toggle:
-        icon: material/brightness-auto
+        icon: material/brightness-4
         name: Switch to light mode
-    - media: "(prefers-color-scheme: light)"
-      scheme: default
+    - scheme: default
       primary: custom
       accent: custom
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
-      primary: custom
-      accent: custom
-      toggle:
-        icon: material/brightness-4
-        name: Switch to system preference
 
   font:
     text: Roboto


### PR DESCRIPTION
## Summary

Restyle notebook rendering in the docs from "boxy mkdocs-jupyter default" to a denser, linopy/nbsphinx-inspired look. Pure CSS + a small JS snippet — no notebook content changes.

**Visible changes** (compare any page in \`docs/notebooks/\` before/after):
- **Numbered prompts on the left** (\`[1]:\` / \`[1]:\`) — input prompt sky-600 / output prompt slate-300. The "In " / "Out" prefixes are stripped at runtime by \`docs/javascripts/notebook-prompts.js\` (subscribed to Material's \`document\$\` so it re-runs on instant-nav transitions).
- **Left accent stripe** on code blocks (sky-600, 2px) and outputs (slate-300, 2px) — visually pairs an input with its output without using heavy backgrounds.
- **Markdown cells flush at column 0**, code/output cells indented via the prompt gutter — clear hierarchy between prose and code.
- **Tight rhythm**: \`.jp-Cell\` margin → 0; h2 top margin → 0.3em (was Material's 1.6em default); code padding 0.3em / 0.6em.
- **Output background removed** — cleaner, the stripe carries the visual weight.

**Specificity / cascade fixes** (the messy part):
- All \`.jp-*\` selectors prefixed with \`.jupyter-wrapper\` — JupyterLab's CSS uses that prefix and beat ours otherwise.
- \`!important\` on prompt color/opacity/flex — JupyterLab's \`.jp-Cell:not(.jp-mod-active) .jp-InputPrompt\` rule (4 classes deep) forces gray + 0.5 opacity otherwise.
- Heading margin overrides dropped \`.md-typeset\` from the chain — that class is on \`<article>\` (ancestor of the notebook), not a descendant. The original selectors silently never matched.
- \`.jp-OutputArea-child\` made \`display: flex\` — the prompt + output content live there, not in \`.jp-Cell-outputWrapper\`.

## Test plan

- [x] \`uv run mkdocs build --strict\` passes
- [ ] \`uv run mkdocs serve\` — open \`/notebooks/01-quickstart/\` and verify:
  - Prompts show as \`[1]:\` (no In/Out prefix), input blue, output slate
  - Code blocks have left sky stripe; outputs have left slate stripe
  - Markdown headings tight against preceding code
  - Dark mode (palette toggle): stripes & prompts still readable
- [ ] All 7 notebooks render without missing plots or layout breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewritten quick example to inline model components for a more compact code sample.
  * Updated docs content and layout to match new styling and examples.

* **New Features**
  * Notebook prompts now display as numbered gutters and present cleaner labels.
  * Click-to-copy added for code blocks with a brief “Copied” feedback badge.

* **Style**
  * Overhauled code block and notebook styling, improved dark mode palette, typography tweaks, and macOS-style code headers; nav links restyled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->