### PR TITLE
refac: rename ConversionCurve → PiecewiseConversion

### DIFF
--- a/docs/math/converters.md
+++ b/docs/math/converters.md
@@ -134,12 +134,12 @@ Converter.heat_pump("hp", cop=cop_profile, electrical_flow=el, source_flow=src, 
 # Piecewise Conversion
 
 For non-linear efficiency curves, varying COP, part-load behaviour, or
-combined-heat-and-power with non-constant ratios, set `conversion=ConversionCurve(...)`
+combined-heat-and-power with non-constant ratios, set `conversion=PiecewiseConversion(...)`
 on the `Converter` instead of `conversion_factors`.
 
 ## Formulation
 
-A `ConversionCurve` defines breakpoints \(b_{f,k}\) for each flow \(f\) at \(K\)
+A `PiecewiseConversion` defines breakpoints \(b_{f,k}\) for each flow \(f\) at \(K\)
 piece-vertices \(k = 0, \dots, K-1\). At every timestep, a vector of
 non-negative interpolation weights \(\lambda_{k,t}\) selects the operating
 point on the curve:
@@ -176,7 +176,7 @@ Override with `method="sos2"` / `"incremental"` / `"lp"` if needed.
 
 ## Status gating
 
-When `ConversionCurve.status` is set, the curve is gated by a binary
+When `PiecewiseConversion.status` is set, the curve is gated by a binary
 \(\delta_{c,t}\) (see [Status](status.md)) passed as `active=` to the linopy
 formulation:
 
@@ -201,11 +201,11 @@ where \(f^{\star}\) is the first flow in the curve.
 
 | Symbol | Description | Reference |
 |---|---|---|
-| \(b_{f,k}\) | Breakpoint values per flow | `ConversionCurve.points` |
+| \(b_{f,k}\) | Breakpoint values per flow | `PiecewiseConversion.points` |
 | \(\lambda_{k,t}\) | Interpolation weights | linopy auxiliaries |
 | \(\diamond_f\) | Curve relation | tuple bound `'=='` / `'<='` / `'>='` |
-| \(\delta_{c,t}\) | On/off binary | `ConversionCurve.status` |
-| \(\alpha_t\) | Availability scaling | `ConversionCurve.availability` |
+| \(\delta_{c,t}\) | On/off binary | `PiecewiseConversion.status` |
+| \(\alpha_t\) | Availability scaling | `PiecewiseConversion.availability` |
 
 ## Examples
 
@@ -219,7 +219,7 @@ Converter(
     'Boiler',
     inputs=[Flow('Gas', short_id='fuel')],
     outputs=[Flow('Heat', size=100)],
-    conversion=ConversionCurve({
+    conversion=PiecewiseConversion({
         'fuel': [0, 50, 100],
         'Heat': [0, 45, 70],
     }),
@@ -236,7 +236,7 @@ Converter(
     'CHP',
     inputs=[Flow('Gas', short_id='fuel')],
     outputs=[Flow('Power', size=100), Flow('Heat', size=100)],
-    conversion=ConversionCurve({
+    conversion=PiecewiseConversion({
         'fuel':  [0, 30, 60, 100],
         'Power': [0, 10, 22,  40],
         'Heat':  [0, 15, 30,  45],
@@ -255,7 +255,7 @@ Converter(
     'Boiler',
     inputs=[Flow('Gas', short_id='fuel')],
     outputs=[Flow('Heat', size=100)],
-    conversion=ConversionCurve(
+    conversion=PiecewiseConversion(
         [
             ('Heat', [0, 30, 60, 100]),
             ('fuel', [0, 36, 84, 170], '>='),
@@ -272,7 +272,7 @@ Converter(
     'Boiler',
     inputs=[Flow('Gas', short_id='fuel')],
     outputs=[Flow('Heat', size=100)],
-    conversion=ConversionCurve(
+    conversion=PiecewiseConversion(
         {'fuel': [0, 50, 100], 'Heat': [0, 45, 70]},
         status=Status(min_uptime=3, effects_per_startup={'cost': 50}),
     ),

--- a/src/fluxopt/__init__.py
+++ b/src/fluxopt/__init__.py
@@ -5,10 +5,10 @@ from fluxopt.components import Converter, Port
 from fluxopt.elements import (
     PENALTY_EFFECT_ID,
     Carrier,
-    ConversionCurve,
     Effect,
     Flow,
     Investment,
+    PiecewiseConversion,
     Sizing,
     Status,
     Storage,
@@ -76,7 +76,6 @@ def optimize(
 __all__ = [
     'PENALTY_EFFECT_ID',
     'Carrier',
-    'ConversionCurve',
     'Converter',
     'Dims',
     'Effect',
@@ -85,6 +84,7 @@ __all__ = [
     'IdList',
     'Investment',
     'ModelData',
+    'PiecewiseConversion',
     'Port',
     'Result',
     'Sizing',

--- a/src/fluxopt/components.py
+++ b/src/fluxopt/components.py
@@ -7,7 +7,7 @@ from fluxopt.elements import qualified_id
 from fluxopt.types import IdList
 
 if TYPE_CHECKING:
-    from fluxopt.elements import ConversionCurve, Flow
+    from fluxopt.elements import Flow, PiecewiseConversion
     from fluxopt.types import TimeSeries
 
 
@@ -45,9 +45,9 @@ class Converter:
 
     - **Linear** — ``conversion_factors=[{flow_short_id: a_f}, ...]``,
       one dict per equation; constraint ``sum_f(a_f * P_{f,t}) = 0``.
-    - **Piecewise** — ``conversion=ConversionCurve(...)``; the solver
+    - **Piecewise** — ``conversion=PiecewiseConversion(...)``; the solver
       interpolates between breakpoints, optionally with on/off via
-      ``ConversionCurve.status``.
+      ``PiecewiseConversion.status``.
 
     Args:
         id: Converter id.
@@ -62,7 +62,7 @@ class Converter:
     inputs: list[Flow] | IdList[Flow]
     outputs: list[Flow] | IdList[Flow]
     conversion_factors: list[dict[str, TimeSeries]] = field(default_factory=list)  # a_f
-    conversion: ConversionCurve | None = None
+    conversion: PiecewiseConversion | None = None
     _short_to_id: dict[str, str] = field(init=False, default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -82,7 +82,7 @@ class Converter:
             unknown = curve_flows - set(self._short_to_id)
             if unknown:
                 msg = (
-                    f'Converter {self.id!r}: ConversionCurve references unknown flow short_ids '
+                    f'Converter {self.id!r}: PiecewiseConversion references unknown flow short_ids '
                     f'{sorted(unknown)}; known: {sorted(self._short_to_id)}'
                 )
                 raise ValueError(msg)
@@ -91,7 +91,7 @@ class Converter:
                     if f.status is not None:
                         msg = (
                             f'Converter {self.id!r}: flow {f.short_id!r} cannot have flow-level '
-                            f'status when ConversionCurve.status is set'
+                            f'status when PiecewiseConversion.status is set'
                         )
                         raise ValueError(msg)
 

--- a/src/fluxopt/elements.py
+++ b/src/fluxopt/elements.py
@@ -316,7 +316,7 @@ _CurveTuple = tuple[str, 'list[TimeSeries]'] | tuple[str, 'list[TimeSeries]', Li
 
 
 @dataclass
-class ConversionCurve:
+class PiecewiseConversion:
     """Piecewise-linear conversion linking N flows.
 
     Wraps :func:`linopy.piecewise.add_piecewise_formulation`. All flows
@@ -327,11 +327,11 @@ class ConversionCurve:
 
     - **Dict** — equality-only, terse for the common case::
 
-          ConversionCurve({'fuel': [0, 50, 100], 'Heat': [0, 45, 70]})
+          PiecewiseConversion({'fuel': [0, 50, 100], 'Heat': [0, 45, 70]})
 
     - **List of tuples** — supports per-flow inequality bounds::
 
-          ConversionCurve(
+          PiecewiseConversion(
               [
                   ('fuel', [0, 50, 100]),
                   ('Heat', [0, 45, 70], '>='),
@@ -363,28 +363,28 @@ class ConversionCurve:
         flows_pts_bounds = list(self._iter_normalized())
 
         if len(flows_pts_bounds) < 2:
-            msg = f'ConversionCurve needs >=2 flows, got {len(flows_pts_bounds)}'
+            msg = f'PiecewiseConversion needs >=2 flows, got {len(flows_pts_bounds)}'
             raise ValueError(msg)
 
         n = len(flows_pts_bounds[0][1])
         if n < 2:
-            msg = f'ConversionCurve needs >=2 breakpoints per flow, got {n}'
+            msg = f'PiecewiseConversion needs >=2 breakpoints per flow, got {n}'
             raise ValueError(msg)
 
         if any(len(pts) != n for _, pts, _ in flows_pts_bounds):
             lengths = {flow: len(pts) for flow, pts, _ in flows_pts_bounds}
-            msg = f'ConversionCurve breakpoint lists must all have the same length, got {lengths}'
+            msg = f'PiecewiseConversion breakpoint lists must all have the same length, got {lengths}'
             raise ValueError(msg)
 
         flows = [flow for flow, _, _ in flows_pts_bounds]
         if len(set(flows)) != len(flows):
             dupes = [f for f in flows if flows.count(f) > 1]
-            msg = f'ConversionCurve has duplicate flow ids: {sorted(set(dupes))}'
+            msg = f'PiecewiseConversion has duplicate flow ids: {sorted(set(dupes))}'
             raise ValueError(msg)
 
         nonequal = [b for _, _, b in flows_pts_bounds if b != '==']
         if len(nonequal) > 1:
-            msg = f'At most one bounded flow per ConversionCurve, got {len(nonequal)}'
+            msg = f'At most one bounded flow per PiecewiseConversion, got {len(nonequal)}'
             raise ValueError(msg)
         if nonequal and len(flows_pts_bounds) > 2:
             msg = f'Inequality bounds require exactly 2 flows, got {len(flows_pts_bounds)}'
@@ -405,10 +405,10 @@ class ConversionCurve:
                 result.append((t[0], list(t[1]), '=='))
             elif len(t) == 3:
                 if t[2] not in ('==', '<=', '>='):
-                    msg = f'ConversionCurve tuple {i} has invalid bound {t[2]!r}; expected one of (==, <=, >=)'
+                    msg = f'PiecewiseConversion tuple {i} has invalid bound {t[2]!r}; expected one of (==, <=, >=)'
                     raise ValueError(msg)
                 result.append((t[0], list(t[1]), t[2]))
             else:
-                msg = f'ConversionCurve tuple {i} has length {len(t)}; expected 2 or 3'
+                msg = f'PiecewiseConversion tuple {i} has length {len(t)}; expected 2 or 3'
                 raise ValueError(msg)
         return result

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -517,7 +517,7 @@ class FlowSystem:
                 size_val = ds.size.sel(flow=fid).values
                 if np.isnan(size_val):  # pragma: no cover
                     # Defensive invariant check — callers (Storage.__post_init__, future
-                    # ConversionCurve) ensure governed flows are sized. Reaching this branch
+                    # PiecewiseConversion) ensure governed flows are sized. Reaching this branch
                     # means an invariant was violated upstream.
                     msg = f'Component {comp_id!r}: governed flow {fid!r} is unsized'
                     raise ValueError(msg)
@@ -900,9 +900,9 @@ class FlowSystem:
     def _create_piecewise_constraints(self) -> None:
         """Create piecewise-linear conversion constraints via linopy's piecewise API.
 
-        For each converter with ``ConversionCurve``: builds one
+        For each converter with ``PiecewiseConversion``: builds one
         ``add_piecewise_formulation`` call linking all curve flows through
-        shared interpolation weights. The optional ``ConversionCurve.status``
+        shared interpolation weights. The optional ``PiecewiseConversion.status``
         wires in the existing ``component_on`` binary as the ``active`` gate.
         Per-converter availability is enforced separately as
         ``flow_rate <= avail * max_bp * active``.

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Self
@@ -909,7 +910,7 @@ class PiecewiseData:
         conv_idx = pd.Index(conv_ids, name='pw_converter')
         availability = fast_concat(avail_slices, conv_idx)
 
-        return cls(
+        data = cls(
             breakpoints=breakpoints_da,
             pair_converter=xr.DataArray(pair_conv_ids, dims=['pw_pair']),
             pair_flow=xr.DataArray(pair_flow_ids, dims=['pw_pair']),
@@ -918,6 +919,37 @@ class PiecewiseData:
             availability=availability,
             has_status=xr.DataArray(has_statuses, dims=['pw_converter'], coords={'pw_converter': conv_ids}),
         )
+        data._warn_redundant_status()
+        return data
+
+    def _warn_redundant_status(self) -> None:
+        """Warn for converters where Status is set but the curve includes a
+        (0, ..., 0) breakpoint at any (breakpoint, timestep) position.
+
+        Wherever an all-flows-zero breakpoint exists, the optimizer can sit
+        at zero with ``active=1`` already — the binary tracks startup events
+        for cost accounting at that timestep, but doesn't gate the operating
+        range.
+        """
+        atol = 1e-9
+        is_zero = abs(self.breakpoints) <= atol  # (pw_pair, breakpoint, time)
+        for conv_id in self.converter_ids():
+            if not bool(self.has_status.sel(pw_converter=conv_id).item()):
+                continue
+            mask = self.pair_converter.values == conv_id
+            all_flows_zero = is_zero.isel(pw_pair=mask).all('pw_pair')  # (breakpoint, time)
+            if bool(all_flows_zero.any().item()):
+                warnings.warn(
+                    f'ConversionCurve on converter {str(conv_id)!r} has Status, '
+                    'but the curve includes a (0, ..., 0) breakpoint. Status '
+                    'will track startup events for cost accounting, but the '
+                    'binary does not gate the operating range — the optimizer '
+                    'can already produce zero by sitting at that breakpoint. '
+                    'Drop the zero breakpoint if you want Status to express '
+                    'off-vs-on.',
+                    UserWarning,
+                    stacklevel=4,
+                )
 
 
 def _detect_contribution_cycle(adjacency: dict[str, list[str]]) -> list[str] | None:

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -823,7 +823,7 @@ class ConvertersData:
 
 @dataclass
 class PiecewiseData:
-    """Piecewise-linear conversion data for converters with ``ConversionCurve``.
+    """Piecewise-linear conversion data for converters with ``PiecewiseConversion``.
 
     Stored sparsely as one row per (converter, flow) pair; the ``method``
     and ``availability`` arrays index by ``pw_converter``.
@@ -864,7 +864,7 @@ class PiecewiseData:
 
     @classmethod
     def build(cls, converters: list[Converter], time: TimeIndex) -> Self | None:
-        """Build PiecewiseData from converters with ``ConversionCurve``.
+        """Build PiecewiseData from converters with ``PiecewiseConversion``.
 
         Args:
             converters: Converter definitions; only those with

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -926,10 +926,10 @@ class PiecewiseData:
         """Warn for converters where Status is set but the curve includes a
         (0, ..., 0) breakpoint at any (breakpoint, timestep) position.
 
-        Wherever an all-flows-zero breakpoint exists, the optimizer can sit
-        at zero with ``active=1`` already — the binary tracks startup events
-        for cost accounting at that timestep, but doesn't gate the operating
-        range.
+        When that's the case, the optimizer can sit at zero with ``active=1``,
+        so the on/off binary is decoupled from the actual operating state.
+        Startup tracking, ``min_uptime``, and ``effects_per_running_hour``
+        will not behave as expected.
         """
         atol = 1e-9
         is_zero = abs(self.breakpoints) <= atol  # (pw_pair, breakpoint, time)
@@ -941,12 +941,13 @@ class PiecewiseData:
             if bool(all_flows_zero.any().item()):
                 warnings.warn(
                     f'ConversionCurve on converter {str(conv_id)!r} has Status, '
-                    'but the curve includes a (0, ..., 0) breakpoint. Status '
-                    'will track startup events for cost accounting, but the '
-                    'binary does not gate the operating range — the optimizer '
-                    'can already produce zero by sitting at that breakpoint. '
-                    'Drop the zero breakpoint if you want Status to express '
-                    'off-vs-on.',
+                    'but the curve includes a (0, ..., 0) breakpoint. The '
+                    'optimizer can sit at zero with status=on, decoupling the '
+                    'binary from the actual operating state — so startup '
+                    'tracking, min_uptime, and effects_per_running_hour will '
+                    'not behave as expected. If you want Status to work as '
+                    'expected, drop the zero breakpoint so the only way to '
+                    'produce zero is status=off.',
                     UserWarning,
                     stacklevel=4,
                 )

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -927,9 +927,8 @@ class PiecewiseData:
         (0, ..., 0) breakpoint at any (breakpoint, timestep) position.
 
         When that's the case, the optimizer can sit at zero with ``active=1``,
-        so the on/off binary is decoupled from the actual operating state.
-        Startup tracking, ``min_uptime``, and ``effects_per_running_hour``
-        will not behave as expected.
+        so the on/off binary is decoupled from the actual operating state and
+        Status features will not behave as expected.
         """
         atol = 1e-9
         is_zero = abs(self.breakpoints) <= atol  # (pw_pair, breakpoint, time)
@@ -943,10 +942,9 @@ class PiecewiseData:
                     f'ConversionCurve on converter {str(conv_id)!r} has Status, '
                     'but the curve includes a (0, ..., 0) breakpoint. The '
                     'optimizer can sit at zero with status=on, decoupling the '
-                    'binary from the actual operating state — so startup '
-                    'tracking, min_uptime, and effects_per_running_hour will '
-                    'not behave as expected. If you want Status to work as '
-                    'expected, drop the zero breakpoint so the only way to '
+                    'binary from the actual operating state — Status features '
+                    'will not behave as expected. If you want Status to work '
+                    'as expected, drop the zero breakpoint so the only way to '
                     'produce zero is status=off.',
                     UserWarning,
                     stacklevel=4,

--- a/tests/math_port/test_piecewise.py
+++ b/tests/math_port/test_piecewise.py
@@ -5,6 +5,8 @@ auto-selects between LP (convex/concave 2-flow inequality), incremental
 (monotonic), and SOS2 formulations.
 """
 
+import warnings
+
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
@@ -292,3 +294,76 @@ class TestPiecewiseStatus:
         assert_allclose(on, [0, 1, 0], atol=1e-5)
         expected_cost = 5.0 / 0.9 + 100.0
         assert_allclose(result.effect_totals.sel(effect='cost').item(), expected_cost, rtol=1e-5)
+
+
+class TestRedundantStatusWarning:
+    """Warn when PiecewiseConversion has Status alongside an all-flows-zero breakpoint."""
+
+    def _build_with_curve(self, curve: PiecewiseConversion):
+        """Build ModelData with a single piecewise converter using `curve`."""
+        from fluxopt.model_data import ModelData
+
+        return ModelData.build(
+            timesteps=ts(3),
+            carriers=[Carrier('Gas'), Carrier('Heat')],
+            effects=[Effect('cost')],
+            ports=[
+                Port('Demand', exports=[Flow('Heat', size=1, fixed_relative_profile=np.array([0, 5, 0]))]),
+                Port('GasSrc', imports=[Flow('Gas', effects_per_flow_hour={'cost': 1})]),
+            ],
+            converters=[
+                Converter(
+                    'Boiler',
+                    inputs=[Flow('Gas', short_id='fuel')],
+                    outputs=[Flow('Heat', size=100)],
+                    conversion=curve,
+                )
+            ],
+        )
+
+    def test_warns_when_zero_breakpoint_with_status(self):
+        """Curve with (0, 0) first breakpoint AND Status -> warn."""
+        curve = PiecewiseConversion(
+            {'fuel': [0, 50, 100], 'Heat': [0, 45, 70]},
+            status=Status(effects_per_startup={'cost': 1}),
+        )
+        with pytest.warns(UserWarning, match=r'Boiler.*\(0, \.\.\., 0\) breakpoint'):
+            self._build_with_curve(curve)
+
+    def test_warns_when_zero_breakpoint_not_first(self):
+        """All-zero point anywhere in the curve (not just first) -> warn (SOS2 allows non-monotonic)."""
+        curve = PiecewiseConversion(
+            {'fuel': [50, 0, 100], 'Heat': [45, 0, 70]},
+            method='sos2',
+            status=Status(effects_per_startup={'cost': 1}),
+        )
+        with pytest.warns(UserWarning, match=r'Boiler.*\(0, \.\.\., 0\) breakpoint'):
+            self._build_with_curve(curve)
+
+    def test_no_warn_when_curve_avoids_zero(self):
+        """Curve that never hits all-flows-zero -> no warning, even with Status."""
+        curve = PiecewiseConversion(
+            {'fuel': [30, 70, 100], 'Heat': [22.5, 58.5, 78.5]},
+            status=Status(effects_per_startup={'cost': 1}),
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', UserWarning)
+            self._build_with_curve(curve)
+
+    def test_no_warn_without_status(self):
+        """No Status -> no warning, even when curve includes (0, 0)."""
+        curve = PiecewiseConversion({'fuel': [0, 50, 100], 'Heat': [0, 45, 70]})
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', UserWarning)
+            self._build_with_curve(curve)
+
+    def test_no_warn_when_only_one_flow_zero(self):
+        """Only one flow is zero at a breakpoint (not all) -> no warning."""
+        # heat=0 at first bp but fuel=10 -> the curve doesn't include the origin.
+        curve = PiecewiseConversion(
+            {'fuel': [10, 50, 100], 'Heat': [0, 45, 70]},
+            status=Status(effects_per_startup={'cost': 1}),
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', UserWarning)
+            self._build_with_curve(curve)

--- a/tests/math_port/test_piecewise.py
+++ b/tests/math_port/test_piecewise.py
@@ -9,54 +9,54 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from fluxopt import Carrier, ConversionCurve, Converter, Effect, Flow, Port, Status
+from fluxopt import Carrier, Converter, Effect, Flow, PiecewiseConversion, Port, Status
 
 from .conftest import ts
 
 
-class TestConversionCurveValidation:
+class TestPiecewiseConversionValidation:
     def test_dict_form(self):
-        c = ConversionCurve({'fuel': [0, 50, 100], 'Heat': [0, 45, 70]})
+        c = PiecewiseConversion({'fuel': [0, 50, 100], 'Heat': [0, 45, 70]})
         normalized = c._iter_normalized()
         assert [t[0] for t in normalized] == ['fuel', 'Heat']
         assert all(t[2] == '==' for t in normalized)
 
     def test_tuple_form_with_bound(self):
-        c = ConversionCurve([('fuel', [0, 50, 100]), ('Heat', [0, 45, 70], '>=')])
+        c = PiecewiseConversion([('fuel', [0, 50, 100]), ('Heat', [0, 45, 70], '>=')])
         normalized = c._iter_normalized()
         assert normalized[1][2] == '>='
 
     def test_needs_two_flows(self):
         with pytest.raises(ValueError, match='>=2 flows'):
-            ConversionCurve({'fuel': [0, 1, 2]})
+            PiecewiseConversion({'fuel': [0, 1, 2]})
 
     def test_equal_lengths(self):
         with pytest.raises(ValueError, match='same length'):
-            ConversionCurve({'A': [0, 1, 2], 'B': [0, 1]})
+            PiecewiseConversion({'A': [0, 1, 2], 'B': [0, 1]})
 
     def test_needs_two_breakpoints(self):
         with pytest.raises(ValueError, match='>=2 breakpoints'):
-            ConversionCurve({'A': [0], 'B': [0]})
+            PiecewiseConversion({'A': [0], 'B': [0]})
 
     def test_at_most_one_bound(self):
         with pytest.raises(ValueError, match='At most one bounded flow'):
-            ConversionCurve(
+            PiecewiseConversion(
                 [('A', [0, 1], '<='), ('B', [0, 1], '>=')],
             )
 
     def test_inequality_requires_two_flows(self):
         with pytest.raises(ValueError, match='Inequality bounds require exactly 2 flows'):
-            ConversionCurve(
+            PiecewiseConversion(
                 [('A', [0, 1], '>='), ('B', [0, 1]), ('C', [0, 1])],
             )
 
     def test_lp_requires_bound(self):
         with pytest.raises(ValueError, match="method='lp' requires"):
-            ConversionCurve({'A': [0, 1], 'B': [0, 1]}, method='lp')
+            PiecewiseConversion({'A': [0, 1], 'B': [0, 1]}, method='lp')
 
     def test_no_duplicate_flows(self):
         with pytest.raises(ValueError, match='duplicate flow'):
-            ConversionCurve([('A', [0, 1]), ('A', [0, 2])])
+            PiecewiseConversion([('A', [0, 1]), ('A', [0, 2])])
 
 
 class TestConverterPiecewiseValidation:
@@ -67,7 +67,7 @@ class TestConverterPiecewiseValidation:
                 inputs=[Flow('A', short_id='a')],
                 outputs=[Flow('B')],
                 conversion_factors=[{'a': 1, 'B': -1}],
-                conversion=ConversionCurve({'a': [0, 1], 'B': [0, 1]}),
+                conversion=PiecewiseConversion({'a': [0, 1], 'B': [0, 1]}),
             )
 
     def test_unknown_flow_in_curve(self):
@@ -76,7 +76,7 @@ class TestConverterPiecewiseValidation:
                 'X',
                 inputs=[Flow('A', short_id='a')],
                 outputs=[Flow('B')],
-                conversion=ConversionCurve({'a': [0, 1], 'C': [0, 1]}),
+                conversion=PiecewiseConversion({'a': [0, 1], 'C': [0, 1]}),
             )
 
     def test_flow_status_forbidden_with_curve_status(self):
@@ -85,13 +85,13 @@ class TestConverterPiecewiseValidation:
                 'X',
                 inputs=[Flow('A', short_id='a')],
                 outputs=[Flow('B', size=10, relative_minimum=0.1, status=Status())],
-                conversion=ConversionCurve({'a': [0, 1], 'B': [0, 1]}, status=Status()),
+                conversion=PiecewiseConversion({'a': [0, 1], 'B': [0, 1]}, status=Status()),
             )
 
 
 class TestPiecewise:
     def test_two_flow_interpolation(self, optimize):
-        """A 2-flow ConversionCurve interpolates the output linearly between breakpoints.
+        """A 2-flow PiecewiseConversion interpolates the output linearly between breakpoints.
 
         Boiler has efficiency 90% in [0,50] (slope 0.9) and 50% in [50,100]
         (slope 0.5). Demand=5 hits the cheap segment: fuel = 5 / 0.9.
@@ -110,7 +110,7 @@ class TestPiecewise:
                     'Boiler',
                     inputs=[Flow('Gas', short_id='fuel')],
                     outputs=[Flow('Heat', size=100)],
-                    conversion=ConversionCurve({'fuel': [0, 50, 100], 'Heat': [0, 45, 70]}),
+                    conversion=PiecewiseConversion({'fuel': [0, 50, 100], 'Heat': [0, 45, 70]}),
                 ),
             ],
         )
@@ -144,7 +144,7 @@ class TestPiecewise:
                         'Boiler',
                         inputs=[Flow('Gas', short_id='fuel')],
                         outputs=[Flow('Heat', size=100)],
-                        conversion=ConversionCurve({'fuel': [0, 30, 100], 'Heat': [0, 30, 70]}),
+                        conversion=PiecewiseConversion({'fuel': [0, 30, 100], 'Heat': [0, 30, 70]}),
                     ),
                 ],
             )
@@ -176,7 +176,7 @@ class TestPiecewise:
                     'CHP',
                     inputs=[Flow('Gas', short_id='fuel')],
                     outputs=[Flow('Power', size=100), Flow('Heat', size=100)],
-                    conversion=ConversionCurve(
+                    conversion=PiecewiseConversion(
                         {
                             'fuel': [0, 30, 60, 100],
                             'Power': [0, 10, 22, 40],
@@ -211,7 +211,7 @@ class TestPiecewise:
                     'Boiler',
                     inputs=[Flow('Gas', short_id='fuel')],
                     outputs=[Flow('Heat', size=100)],
-                    conversion=ConversionCurve(
+                    conversion=PiecewiseConversion(
                         {
                             'fuel': [np.array([0.0, 0.0]), bp_max_fuel],
                             'Heat': [np.array([0.0, 0.0]), bp_max_heat],
@@ -227,7 +227,7 @@ class TestPiecewise:
 
 class TestPiecewiseStatus:
     def test_status_gates_curve(self, optimize):
-        """ConversionCurve.status forces all curve flows to 0 when on=0."""
+        """PiecewiseConversion.status forces all curve flows to 0 when on=0."""
         result = optimize(
             timesteps=ts(3),
             carriers=[Carrier('Gas'), Carrier('Heat')],
@@ -242,7 +242,7 @@ class TestPiecewiseStatus:
                     'Boiler',
                     inputs=[Flow('Gas', short_id='fuel')],
                     outputs=[Flow('Heat', size=100)],
-                    conversion=ConversionCurve(
+                    conversion=PiecewiseConversion(
                         {'fuel': [0, 50, 100], 'Heat': [0, 45, 70]},
                         status=Status(effects_per_startup={'cost': 1000}),
                     ),
@@ -279,7 +279,7 @@ class TestPiecewiseStatus:
                     'Boiler',
                     inputs=[Flow('Gas', short_id='fuel')],
                     outputs=[Flow('Heat', size=100)],
-                    conversion=ConversionCurve(
+                    conversion=PiecewiseConversion(
                         {'fuel': [0, 50, 100], 'Heat': [0, 45, 70]},
                         status=Status(effects_per_running_hour={'cost': 100}),
                     ),

--- a/tests/math_port/test_storage_status.py
+++ b/tests/math_port/test_storage_status.py
@@ -1,6 +1,6 @@
 """Mathematical correctness tests for Storage component-level Status.
 
-Component-level Status on Converter is deferred — when ConversionCurve lands
+Component-level Status on Converter is deferred — when PiecewiseConversion lands
 (see #25), it will provide a more versatile, single-API path that subsumes
 linear converter on/off.
 """


### PR DESCRIPTION
## Summary
- **Rename** the public dataclass `ConversionCurve` → `PiecewiseConversion`. Pure rename, no behavior change.
- **New warning**: when `PiecewiseConversion(..., status=Status(...))` is constructed with a `(0, ..., 0)` breakpoint reachable, the optimizer can sit at zero with `status=on`, decoupling the binary from the actual operating state. Status features (`effects_per_startup`, `min_uptime`, `effects_per_running_hour`, …) silently misbehave. The warning fires from `PiecewiseData.build` (data layer) where breakpoints are already xr.DataArrays — vectorized check across `(pw_pair, breakpoint, time)`.
- 5 tests cover the warning (`TestRedundantStatusWarning`): zero at first / non-first breakpoint, curves that avoid zero, no Status, single-flow-zero (which should NOT warn).

## Why rename
- Matches the codebase's own vocabulary (`linopy.add_piecewise_formulation`, the feature commit `bf25e39`).
- Makes the linear/piecewise opposition visible at the import site: `Converter`'s linear option is `conversion_factors=[{...}]`; its non-linear option is `conversion=PiecewiseConversion(...)`.
- "Curve" was misleading for the N≥3 flow case (CHP); the geometry is a piecewise-linear path through N-space.

## Test plan
- [x] `uv run pytest tests/` — 445 passed (was 440 + 5 new), 227 skipped.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)