### PR TITLE
docs: bump code block font size for readability

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -701,9 +701,11 @@ body[data-md-color-scheme="slate"] .jupyter-wrapper {
   font-size: 0.92em;
 }
 
-/* Notebook code cells (mkdocs-jupyter uses JupyterLab CSS variables). */
+/* Notebook code cells (mkdocs-jupyter uses JupyterLab CSS variables).
+   The plugin inlines its own .jupyter-wrapper rule later in the cascade,
+   so we need !important to win the override. */
 .jupyter-wrapper {
-  --jp-code-font-size: 14.5px;
+  --jp-code-font-size: 14.5px !important;
 }
 
 /* --- Download notebook button --- */

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -692,6 +692,20 @@ body[data-md-color-scheme="slate"] .jupyter-wrapper {
   border-left-color: #475569;       /* slate-600 — subtle on dark bg */
 }
 
+/* --- Code block font size ---
+   Material defaults to 0.85em on code blocks, which is hard to scan in
+   tutorials. Bump to 0.92em on blocks; leave inline `code` at default so
+   it still stands out mid-sentence. */
+.md-typeset pre > code,
+.md-typeset .highlight pre {
+  font-size: 0.92em;
+}
+
+/* Notebook code cells (mkdocs-jupyter uses JupyterLab CSS variables). */
+.jupyter-wrapper {
+  --jp-code-font-size: 14.5px;
+}
+
 /* --- Download notebook button --- */
 
 /* Injected by notebook-download.js as the first child of .jupyter-wrapper.


### PR DESCRIPTION
## Summary
- Markdown code blocks: `0.85em` → `0.92em` (Material defaults are tuned for reference docs, but our tutorial readers parse syntax line by line).
- mkdocs-jupyter notebook cells: set `--jp-code-font-size` to `14.5px` so notebook code matches.
- Inline `` `code` `` stays at the default so it keeps visually contrasting against prose.

## Test plan
- [ ] Build docs locally (`mkdocs serve`) and eyeball a tutorial with both Markdown code (e.g. tutorial intros) and notebook cells side by side.
- [ ] Spot-check on a narrow viewport — bigger code shouldn't push the download button into trouble (it's already a flex/static fallback under 640px).

🤖 Generated with [Claude Code](https://claude.com/claude-code)