### PR TITLE
docs: footer social icons (GitHub + PyPI)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -158,6 +158,15 @@ plugins:
 extra_css:
   - stylesheets/extra.css
 
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/FBumann/fluxopt
+      name: fluxopt on GitHub
+    - icon: simple/pypi
+      link: https://pypi.org/project/fluxopt/
+      name: fluxopt on PyPI
+
 extra_javascript:
   - javascripts/mathjax.js
   - javascripts/notebook-prompts.js


### PR DESCRIPTION
## Summary
- Adds Material's footer social bar with GitHub and PyPI links via `extra.social`. Both icons are bundled (FontAwesome / Simple Icons) — no external SVGs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)