### PR TITLE
docs: math pages — strip code, fix notation, link API, polish anchors

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -125,7 +125,7 @@ print(result.flow_rates)
 
     Auto-generated from source — every public class, every parameter.
 
-    [:octicons-arrow-right-24: API](api/fluxopt/)
+    [:octicons-arrow-right-24: API](api/fluxopt/index.md)
 
 </div>
 

--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -11,15 +11,11 @@ window.MathJax = {
   },
 };
 
-// On every instant-nav page swap, re-typeset math — but only after MathJax
-// has finished its initial startup. Without the startup.promise gate we hit
-// a race on first navigations where MathJax isn't ready yet and typesetPromise
-// silently fails, leaving raw \(...\) on the page until a hard reload.
+// Re-typeset on every instant-nav page swap. mkdocs-material docs use
+// exactly this form. Avoid typesetClear()/texReset() — they can strip
+// rendered math before typesetPromise() finishes, leaving blanks.
 document$.subscribe(() => {
-  if (typeof MathJax === "undefined" || !MathJax.startup) return;
-  MathJax.startup.promise.then(() => {
-    MathJax.typesetClear();
-    MathJax.texReset();
-    return MathJax.typesetPromise();
-  });
+  if (typeof MathJax !== "undefined" && MathJax.typesetPromise) {
+    MathJax.typesetPromise();
+  }
 });

--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -10,19 +10,3 @@ window.MathJax = {
     processHtmlClass: "arithmatex",
   },
 };
-
-// Re-typeset on every instant-nav page swap. The startup.promise gate
-// avoids racing the initial load. Resetting startup.document forgets
-// the previous page's element list (so stale "already typeset" tracking
-// doesn't skip new elements) without ripping rendered DOM out.
-document$.subscribe(() => {
-  if (typeof MathJax === "undefined" || !MathJax.startup) return;
-  MathJax.startup.promise = MathJax.startup.promise
-    .then(() => {
-      if (MathJax.startup.document && MathJax.startup.document.clear) {
-        MathJax.startup.document.clear();
-      }
-      return MathJax.typesetPromise();
-    })
-    .catch((err) => console.error("MathJax typeset failed:", err));
-});

--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -11,11 +11,18 @@ window.MathJax = {
   },
 };
 
-// Re-typeset on every instant-nav page swap. mkdocs-material docs use
-// exactly this form. Avoid typesetClear()/texReset() — they can strip
-// rendered math before typesetPromise() finishes, leaving blanks.
+// Re-typeset on every instant-nav page swap. The startup.promise gate
+// avoids racing the initial load. Resetting startup.document forgets
+// the previous page's element list (so stale "already typeset" tracking
+// doesn't skip new elements) without ripping rendered DOM out.
 document$.subscribe(() => {
-  if (typeof MathJax !== "undefined" && MathJax.typesetPromise) {
-    MathJax.typesetPromise();
-  }
+  if (typeof MathJax === "undefined" || !MathJax.startup) return;
+  MathJax.startup.promise = MathJax.startup.promise
+    .then(() => {
+      if (MathJax.startup.document && MathJax.startup.document.clear) {
+        MathJax.startup.document.clear();
+      }
+      return MathJax.typesetPromise();
+    })
+    .catch((err) => console.error("MathJax typeset failed:", err));
 });

--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -11,9 +11,15 @@ window.MathJax = {
   },
 };
 
+// On every instant-nav page swap, re-typeset math — but only after MathJax
+// has finished its initial startup. Without the startup.promise gate we hit
+// a race on first navigations where MathJax isn't ready yet and typesetPromise
+// silently fails, leaving raw \(...\) on the page until a hard reload.
 document$.subscribe(() => {
-  MathJax.startup.output.clearCache();
-  MathJax.typesetClear();
-  MathJax.texReset();
-  MathJax.typesetPromise();
+  if (typeof MathJax === "undefined" || !MathJax.startup) return;
+  MathJax.startup.promise.then(() => {
+    MathJax.typesetClear();
+    MathJax.texReset();
+    return MathJax.typesetPromise();
+  });
 });

--- a/docs/math/carrier-balance.md
+++ b/docs/math/carrier-balance.md
@@ -38,7 +38,7 @@ See [Notation](notation.md) for the full symbol table.
 A thermal carrier with a boiler output (3 MW) and a demand input (3 MW):
 
 \[
-\underbrace{P_{\text{boiler\_th},t}}_{+1 \times 3} + \underbrace{(-1) \cdot P_{\text{demand},t}}_{-1 \times 3} = 0 \quad \checkmark
+\underbrace{P_{\text{boilerHeat},t}}_{+1 \times 3} + \underbrace{(-1) \cdot P_{\text{demand},t}}_{-1 \times 3} = 0 \quad \checkmark
 \]
 
 ## Multi-Node Carriers
@@ -65,8 +65,8 @@ Two independent heat nodes A and B, each with its own supply and demand:
 
 \[
 \begin{aligned}
-\text{Node A:}\quad & P_{\text{src\_a(heat:A)},t} - P_{\text{sink\_a(heat:A)},t} = 0 \\
-\text{Node B:}\quad & P_{\text{src\_b(heat:B)},t} - P_{\text{sink\_b(heat:B)},t} = 0
+\text{Node A:}\quad & P_{\text{srcA(heat:A)},t} - P_{\text{sinkA(heat:A)},t} = 0 \\
+\text{Node B:}\quad & P_{\text{srcB(heat:B)},t} - P_{\text{sinkB(heat:B)},t} = 0
 \end{aligned}
 \]
 

--- a/docs/math/carrier-balance.md
+++ b/docs/math/carrier-balance.md
@@ -65,8 +65,8 @@ Two independent heat nodes A and B, each with its own supply and demand:
 
 \[
 \begin{aligned}
-\text{Node A:}\quad & P_{\text{srcA(heat:A)},t} - P_{\text{sinkA(heat:A)},t} = 0 \\
-\text{Node B:}\quad & P_{\text{srcB(heat:B)},t} - P_{\text{sinkB(heat:B)},t} = 0
+\text{Node A:}\quad & P_{\text{src\_a(heat:A)},t} - P_{\text{sink\_a(heat:A)},t} = 0 \\
+\text{Node B:}\quad & P_{\text{src\_b(heat:B)},t} - P_{\text{sink\_b(heat:B)},t} = 0
 \end{aligned}
 \]
 

--- a/docs/math/carrier-balance.md
+++ b/docs/math/carrier-balance.md
@@ -26,7 +26,7 @@ The sign convention uses coefficients: \(+1\) for flows producing into the carri
 |---|---|---|
 | \(\mathcal{F}_b^{\text{out}}\) | Flows producing into carrier \(b\) | `carrier_coeff[f.id] = +1` (port imports, converter outputs, storage discharging) |
 | \(\mathcal{F}_b^{\text{in}}\) | Flows consuming from carrier \(b\) | `carrier_coeff[f.id] = -1` (port exports, converter inputs, storage charging) |
-| \(P_{f,t}\) | Flow rate variable | `flow_rate[flow, time]` |
+| \(P_{f,t}\) | Flow rate variable | `flow--rate[flow, time]` |
 | \((b\!:\!n)\) | Compound carrier-node coordinate | e.g., `heat:A`, `heat:B` |
 | \(\mathcal{F}_{b:n}\) | Flows assigned to node \(n\) of carrier \(b\) | Subset of \(\mathcal{F}_b\) with matching `node` |
 | \(\text{coeff}_{b:n,f}\) | Coefficient of flow \(f\) in node \(n\)'s balance | `+1` or `-1`, same convention as single-node |

--- a/docs/math/carrier-balance.md
+++ b/docs/math/carrier-balance.md
@@ -74,16 +74,5 @@ Node A's supply serves only node A's demand. Node B is balanced independently.
 
 ### Usage
 
-```python
-from fluxopt import Flow, Port
-
-# Flows declare their node
-supply_a = Flow('heat', node='A', size=100)
-demand_a = Flow('heat', node='A', size=100, fixed_relative_profile=[0.5])
-
-supply_b = Flow('heat', node='B', size=100)
-demand_b = Flow('heat', node='B', size=100, fixed_relative_profile=[0.8])
-```
-
 The flow id auto-includes the node: `Flow('heat', node='A')` gets `id='heat:A'`,
 which qualifies to `src_a(heat:A)` after component qualification.

--- a/docs/math/converters.md
+++ b/docs/math/converters.md
@@ -1,9 +1,11 @@
 # Converters
 
 A `Converter` couples its input and output flows. fluxopt offers two
-conversion modes: a **linear** form (constant coefficients per equation)
-and a **piecewise-linear** form (`PiecewiseConversion`) for part-load
-efficiency, varying COP, or non-constant heat-to-power ratios.
+conversion modes: a **linear** form (coefficients fixed against the
+operating point — they may still vary in time) and a
+**piecewise-linear** form (`PiecewiseConversion`) for behaviour that
+depends on the operating point itself — part-load efficiency curves,
+load-dependent heat-to-power ratios.
 
 ## Linear Conversion
 
@@ -12,7 +14,7 @@ efficiency, varying COP, or non-constant heat-to-power ratios.
 Each conversion equation enforces a linear coupling between flows:
 
 \[
-\sum_{f} a_{f} \cdot P_{f,t} = 0 \quad \forall \, \text{converter}, \; \text{eq\_idx}, \; t \in \mathcal{T}
+\sum_{f} a_{f} \cdot P_{f,t} = 0 \quad \forall \, \text{conversion equation}, \; t \in \mathcal{T}
 \]
 
 where \(a_f\) is the conversion coefficient for flow \(f\). A converter can have
@@ -86,9 +88,11 @@ So 10 MW fuel input produces 4 MW electrical + 5 MW thermal.
 
 ## Piecewise Conversion
 
-For non-linear efficiency curves, varying COP, part-load behaviour, or
-combined-heat-and-power with non-constant ratios, set `conversion=PiecewiseConversion(...)`
-on the `Converter` instead of `conversion_factors`.
+When efficiency or coupling depends on the **operating point itself** —
+part-load curves, load-dependent heat-to-power ratios — set
+`conversion=PiecewiseConversion(...)` on the `Converter` instead of
+`conversion_factors`. (For coefficients that vary with *time but not load*,
+use the linear form with time-varying `conversion_factors`.)
 
 ### Formulation
 

--- a/docs/math/converters.md
+++ b/docs/math/converters.md
@@ -14,19 +14,21 @@ load-dependent heat-to-power ratios.
 Each conversion equation enforces a linear coupling between flows:
 
 \[
-\sum_{f} a_{f} \cdot P_{f,t} = 0 \quad \forall \, \text{conversion equation}, \; t \in \mathcal{T}
+\sum_{f} a_{f,i,t} \cdot P_{f,t} = 0 \quad \forall \, \text{converter}, \; i, \; t \in \mathcal{T}
 \]
 
-where \(a_f\) is the conversion coefficient for flow \(f\). A converter can have
-multiple equations (one per row in `conversion_factors`), allowing multi-output
-devices like CHP plants. Coefficients can also be time-varying — pass a list
-or array instead of a scalar.
+where \(a_{f,i,t}\) is the conversion coefficient for flow \(f\) in equation \(i\)
+at time \(t\). A converter can have multiple equations (one per row in
+`conversion_factors`), allowing multi-output devices like CHP plants. Each
+coefficient may differ per equation **and** per timestep — pass a list or
+array instead of a scalar in any dict entry.
 
 ### Parameters
 
 | Symbol | Description | Reference |
 |---|---|---|
-| \(a_f\) | Conversion coefficient | `Converter.conversion_factors` |
+| \(a_{f,i,t}\) | Conversion coefficient | `Converter.conversion_factors` |
+| \(i\) | Equation index within a converter | row in `conversion_factors` |
 | \(P_{f,t}\) | Flow rate variable | `flow_rate[flow, time]` |
 
 See [Notation](notation.md) for the full symbol table.

--- a/docs/math/converters.md
+++ b/docs/math/converters.md
@@ -14,20 +14,19 @@ load-dependent heat-to-power ratios.
 Each conversion equation enforces a linear coupling between flows:
 
 \[
-\sum_{f} a_{f,i,t} \cdot P_{f,t} = 0 \quad \forall \, \text{converter}, \; i, \; t \in \mathcal{T}
+\sum_{f} a_{f,i} \cdot P_{f,t} = 0 \quad \forall \, \text{converter}, \; i, \; t \in \mathcal{T}
 \]
 
-where \(a_{f,i,t}\) is the conversion coefficient for flow \(f\) in equation \(i\)
-at time \(t\). A converter can have multiple equations (one per row in
-`conversion_factors`), allowing multi-output devices like CHP plants. Each
-coefficient may differ per equation **and** per timestep — pass a list or
-array instead of a scalar in any dict entry.
+where \(a_{f,i}\) is the conversion coefficient for flow \(f\) in equation \(i\).
+A converter can have multiple equations (one per row in `conversion_factors`),
+allowing multi-output devices like CHP plants. Coefficients may also broadcast
+over \(t\) in the API — see [Indexing Convention](notation.md#indexing-convention).
 
 ### Parameters
 
 | Symbol | Description | Reference |
 |---|---|---|
-| \(a_{f,i,t}\) | Conversion coefficient | `Converter.conversion_factors` |
+| \(a_{f,i}\) | Conversion coefficient | `Converter.conversion_factors` |
 | \(i\) | Equation index within a converter | row in `conversion_factors` |
 | \(P_{f,t}\) | Flow rate variable | `flow_rate[flow, time]` |
 

--- a/docs/math/converters.md
+++ b/docs/math/converters.md
@@ -28,7 +28,7 @@ over \(t\) in the API — see [Indexing Convention](notation.md#indexing-convent
 |---|---|---|
 | \(\mathrm{a}_{f,i}\) | Conversion coefficient | `Converter.conversion_factors` |
 | \(i\) | Equation index within a converter | row in `conversion_factors` |
-| \(P_{f,t}\) | Flow rate variable | `flow_rate[flow, time]` |
+| \(P_{f,t}\) | Flow rate variable | `flow--rate[flow, time]` |
 
 See [Notation](notation.md) for the full symbol table.
 
@@ -134,13 +134,13 @@ Override with `method="sos2"` / `"incremental"` / `"lp"` if needed.
 
 ### Status gating
 
-When `PiecewiseConversion.status` is set, the curve is gated by a binary
-\(\delta_{c,t}\) (see [Status](status.md)) passed as `active=` to the linopy
-formulation:
+When `PiecewiseConversion.status` is set, the curve is gated by the converter's
+on/off binary \(\sigma_{c,t}\) (see [Status](status.md)) passed as `active=` to
+the linopy formulation:
 
-- All-equality curves: \(\delta = 0\) forces every \(\lambda\) to zero, which
-  pins all curve flows to \(\mathrm{b}_{f,0}\) (typically zero).
-- Inequality curves: \(\delta = 0\) drives the bounded side to zero; the
+- All-equality curves: \(\sigma_{c,t} = 0\) forces every \(\lambda\) to zero,
+  which pins all curve flows to \(\mathrm{b}_{f,0}\) (typically zero).
+- Inequality curves: \(\sigma_{c,t} = 0\) drives the bounded side to zero; the
   output's own lower bound (default \(P_f \ge 0\)) closes the loop for
   non-negative outputs.
 
@@ -150,7 +150,7 @@ A separate envelope constraint scales the upper breakpoint by a per-timestep
 availability \(\alpha_t \in [0, 1]\):
 
 \[
-P_{f^{\star},t} \le \alpha_t \cdot \mathrm{b}_{f^{\star},K-1} \cdot \delta_{c,t}
+P_{f^{\star},t} \le \alpha_t \cdot \mathrm{b}_{f^{\star},K-1} \cdot \sigma_{c,t}
 \]
 
 where \(f^{\star}\) is the first flow in the curve.
@@ -162,5 +162,5 @@ where \(f^{\star}\) is the first flow in the curve.
 | \(\mathrm{b}_{f,k}\) | Breakpoint values per flow | `PiecewiseConversion.points` |
 | \(\lambda_{k,t}\) | Interpolation weights | linopy auxiliaries |
 | \(\diamond_f\) | Curve relation | tuple bound `'=='` / `'<='` / `'>='` |
-| \(\delta_{c,t}\) | On/off binary | `PiecewiseConversion.status` |
+| \(\sigma_{c,t}\) | On/off binary | `PiecewiseConversion.status` |
 | \(\alpha_t\) | Availability scaling | `PiecewiseConversion.availability` |

--- a/docs/math/converters.md
+++ b/docs/math/converters.md
@@ -14,10 +14,10 @@ load-dependent heat-to-power ratios.
 Each conversion equation enforces a linear coupling between flows:
 
 \[
-\sum_{f} a_{f,i} \cdot P_{f,t} = 0 \quad \forall \, \text{converter}, \; i, \; t \in \mathcal{T}
+\sum_{f} \mathrm{a}_{f,i} \cdot P_{f,t} = 0 \quad \forall \, \text{converter}, \; i, \; t \in \mathcal{T}
 \]
 
-where \(a_{f,i}\) is the conversion coefficient for flow \(f\) in equation \(i\).
+where \(\mathrm{a}_{f,i}\) is the conversion coefficient for flow \(f\) in equation \(i\).
 A converter can have multiple equations (one per row in `conversion_factors`),
 allowing multi-output devices like CHP plants. Coefficients may also broadcast
 over \(t\) in the API — see [Indexing Convention](notation.md#indexing-convention).
@@ -26,7 +26,7 @@ over \(t\) in the API — see [Indexing Convention](notation.md#indexing-convent
 
 | Symbol | Description | Reference |
 |---|---|---|
-| \(a_{f,i}\) | Conversion coefficient | `Converter.conversion_factors` |
+| \(\mathrm{a}_{f,i}\) | Conversion coefficient | `Converter.conversion_factors` |
 | \(i\) | Equation index within a converter | row in `conversion_factors` |
 | \(P_{f,t}\) | Flow rate variable | `flow_rate[flow, time]` |
 
@@ -97,7 +97,7 @@ use the linear form with time-varying `conversion_factors`.)
 
 ### Formulation
 
-A `PiecewiseConversion` defines breakpoints \(b_{f,k}\) for each flow \(f\) at \(K\)
+A `PiecewiseConversion` defines breakpoints \(\mathrm{b}_{f,k}\) for each flow \(f\) at \(K\)
 piece-vertices \(k = 0, \dots, K-1\). At every timestep, a vector of
 non-negative interpolation weights \(\lambda_{k,t}\) selects the operating
 point on the curve:
@@ -113,7 +113,7 @@ For each curve flow \(f\), the rate is the corresponding weighted breakpoint
 sum:
 
 \[
-P_{f,t} \; \diamond_f \; \sum_{k} \lambda_{k,t} \cdot b_{f,k}
+P_{f,t} \; \diamond_f \; \sum_{k} \lambda_{k,t} \cdot \mathrm{b}_{f,k}
 \]
 
 where the relation \(\diamond_f \in \{=, \le, \ge\}\) is set per flow via the
@@ -139,7 +139,7 @@ When `PiecewiseConversion.status` is set, the curve is gated by a binary
 formulation:
 
 - All-equality curves: \(\delta = 0\) forces every \(\lambda\) to zero, which
-  pins all curve flows to \(b_{f,0}\) (typically zero).
+  pins all curve flows to \(\mathrm{b}_{f,0}\) (typically zero).
 - Inequality curves: \(\delta = 0\) drives the bounded side to zero; the
   output's own lower bound (default \(P_f \ge 0\)) closes the loop for
   non-negative outputs.
@@ -150,7 +150,7 @@ A separate envelope constraint scales the upper breakpoint by a per-timestep
 availability \(\alpha_t \in [0, 1]\):
 
 \[
-P_{f^{\star},t} \le \alpha_t \cdot b_{f^{\star},K-1} \cdot \delta_{c,t}
+P_{f^{\star},t} \le \alpha_t \cdot \mathrm{b}_{f^{\star},K-1} \cdot \delta_{c,t}
 \]
 
 where \(f^{\star}\) is the first flow in the curve.
@@ -159,7 +159,7 @@ where \(f^{\star}\) is the first flow in the curve.
 
 | Symbol | Description | Reference |
 |---|---|---|
-| \(b_{f,k}\) | Breakpoint values per flow | `PiecewiseConversion.points` |
+| \(\mathrm{b}_{f,k}\) | Breakpoint values per flow | `PiecewiseConversion.points` |
 | \(\lambda_{k,t}\) | Interpolation weights | linopy auxiliaries |
 | \(\diamond_f\) | Curve relation | tuple bound `'=='` / `'<='` / `'>='` |
 | \(\delta_{c,t}\) | On/off binary | `PiecewiseConversion.status` |

--- a/docs/math/converters.md
+++ b/docs/math/converters.md
@@ -26,7 +26,7 @@ over \(t\) in the API — see [Indexing Convention](notation.md#indexing-convent
 
 | Symbol | Description | Reference |
 |---|---|---|
-| \(\mathrm{a}_{f,i}\) | Conversion coefficient | `Converter.conversion_factors` |
+| \(\mathrm{a}_{f,i}\) | Conversion coefficient | [`Converter.conversion_factors`](../api/fluxopt/components.md#fluxopt.components.Converter(conversion_factors)) |
 | \(i\) | Equation index within a converter | row in `conversion_factors` |
 | \(P_{f,t}\) | Flow rate variable | `flow--rate[flow, time]` |
 
@@ -159,8 +159,8 @@ where \(f^{\star}\) is the first flow in the curve.
 
 | Symbol | Description | Reference |
 |---|---|---|
-| \(\mathrm{b}_{f,k}\) | Breakpoint values per flow | `PiecewiseConversion.points` |
+| \(\mathrm{b}_{f,k}\) | Breakpoint values per flow | [`PiecewiseConversion.points`](../api/fluxopt/elements.md#fluxopt.elements.PiecewiseConversion(points)) |
 | \(\lambda_{k,t}\) | Interpolation weights | linopy auxiliaries |
 | \(\diamond_f\) | Curve relation | tuple bound `'=='` / `'<='` / `'>='` |
-| \(\sigma_{c,t}\) | On/off binary | `PiecewiseConversion.status` |
-| \(\alpha_t\) | Availability scaling | `PiecewiseConversion.availability` |
+| \(\sigma_{c,t}\) | On/off binary | [`PiecewiseConversion.status`](../api/fluxopt/elements.md#fluxopt.elements.PiecewiseConversion(status)) |
+| \(\alpha_t\) | Availability scaling | [`PiecewiseConversion.availability`](../api/fluxopt/elements.md#fluxopt.elements.PiecewiseConversion(availability)) |

--- a/docs/math/converters.md
+++ b/docs/math/converters.md
@@ -1,9 +1,15 @@
-# Linear Conversion
+# Converters
 
-## Formulation
+A `Converter` couples its input and output flows. fluxopt offers two
+conversion modes: a **linear** form (constant coefficients per equation)
+and a **piecewise-linear** form (`PiecewiseConversion`) for part-load
+efficiency, varying COP, or non-constant heat-to-power ratios.
 
-A `Converter` enforces linear coupling between its input and output flows.
-Each conversion equation requires:
+## Linear Conversion
+
+### Formulation
+
+Each conversion equation enforces a linear coupling between flows:
 
 \[
 \sum_{f} a_{f} \cdot P_{f,t} = 0 \quad \forall \, \text{converter}, \; \text{eq\_idx}, \; t \in \mathcal{T}
@@ -11,9 +17,10 @@ Each conversion equation requires:
 
 where \(a_f\) is the conversion coefficient for flow \(f\). A converter can have
 multiple equations (one per row in `conversion_factors`), allowing multi-output
-devices like CHP plants.
+devices like CHP plants. Coefficients can also be time-varying — pass a list
+or array instead of a scalar.
 
-## Parameters
+### Parameters
 
 | Symbol | Description | Reference |
 |---|---|---|
@@ -22,9 +29,9 @@ devices like CHP plants.
 
 See [Notation](notation.md) for the full symbol table.
 
-## Examples
+### Examples
 
-### Boiler
+#### Boiler
 
 A gas boiler with thermal efficiency \(\eta_{\text{th}} = 0.9\):
 
@@ -38,7 +45,7 @@ A gas boiler with thermal efficiency \(\eta_{\text{th}} = 0.9\):
 
 So 10 MW gas input produces 9 MW thermal output.
 
-### Power-to-Heat
+#### Power-to-Heat
 
 An electric resistance heater with efficiency \(\eta = 0.99\):
 
@@ -46,7 +53,7 @@ An electric resistance heater with efficiency \(\eta = 0.99\):
 \eta \cdot P_{\text{el},t} - P_{\text{th},t} = 0
 \]
 
-### Heat Pump
+#### Heat Pump
 
 A heat pump with COP = 3.5 has **two** conversion equations — COP definition
 and energy balance:
@@ -62,7 +69,7 @@ P_{\text{el},t} + P_{\text{src},t} - P_{\text{th},t} = 0
 So 1 MW electrical input draws 2.5 MW from the environment and produces
 3.5 MW thermal output.
 
-### CHP (Combined Heat and Power)
+#### CHP (Combined Heat and Power)
 
 A CHP with \(\eta_{\text{el}} = 0.4\) and \(\eta_{\text{th}} = 0.5\) has **two**
 conversion equations:
@@ -77,25 +84,13 @@ conversion equations:
 
 So 10 MW fuel input produces 4 MW electrical + 5 MW thermal.
 
-### Custom Equations
-
-For devices not covered by factory methods, pass `conversion_factors` directly.
-Each dict in the list is one equation, mapping flow short ids to coefficients:
-
-This enforces: \(0.5 \cdot P_a + 0.3 \cdot P_b - P_c = 0\).
-
-### Time-Varying Coefficients
-
-Conversion coefficients can be time-varying (e.g., a heat pump with hourly COP from
-weather data). Pass a list or array instead of a scalar:
-
-# Piecewise Conversion
+## Piecewise Conversion
 
 For non-linear efficiency curves, varying COP, part-load behaviour, or
 combined-heat-and-power with non-constant ratios, set `conversion=PiecewiseConversion(...)`
 on the `Converter` instead of `conversion_factors`.
 
-## Formulation
+### Formulation
 
 A `PiecewiseConversion` defines breakpoints \(b_{f,k}\) for each flow \(f\) at \(K\)
 piece-vertices \(k = 0, \dots, K-1\). At every timestep, a vector of
@@ -120,7 +115,7 @@ where the relation \(\diamond_f \in \{=, \le, \ge\}\) is set per flow via the
 optional third tuple element. The default is equality (`==`); at most one
 flow may carry an inequality sign, and only with exactly two flows.
 
-## Methods
+### Methods
 
 `linopy` auto-dispatches the formulation:
 
@@ -132,7 +127,7 @@ flow may carry an inequality sign, and only with exactly two flows.
 
 Override with `method="sos2"` / `"incremental"` / `"lp"` if needed.
 
-## Status gating
+### Status gating
 
 When `PiecewiseConversion.status` is set, the curve is gated by a binary
 \(\delta_{c,t}\) (see [Status](status.md)) passed as `active=` to the linopy
@@ -144,7 +139,7 @@ formulation:
   output's own lower bound (default \(P_f \ge 0\)) closes the loop for
   non-negative outputs.
 
-## Availability
+### Availability
 
 A separate envelope constraint scales the upper breakpoint by a per-timestep
 availability \(\alpha_t \in [0, 1]\):
@@ -155,7 +150,7 @@ P_{f^{\star},t} \le \alpha_t \cdot b_{f^{\star},K-1} \cdot \delta_{c,t}
 
 where \(f^{\star}\) is the first flow in the curve.
 
-## Parameters
+### Parameters
 
 | Symbol | Description | Reference |
 |---|---|---|
@@ -164,23 +159,3 @@ where \(f^{\star}\) is the first flow in the curve.
 | \(\diamond_f\) | Curve relation | tuple bound `'=='` / `'<='` / `'>='` |
 | \(\delta_{c,t}\) | On/off binary | `PiecewiseConversion.status` |
 | \(\alpha_t\) | Availability scaling | `PiecewiseConversion.availability` |
-
-## Examples
-
-### Boiler with part-load efficiency
-
-A gas boiler runs at 90% efficiency between 0 and 50 MW (slope 0.9), then drops
-to 50% efficiency from 50 to 100 MW (slope 0.5):
-
-### CHP with joint N-flow curve
-
-A CHP plant with three flows linked by shared interpolation weights — every
-operating point lies on the same piece of the curve:
-
-### Convex curve via LP fast path
-
-A monotonic-convex fuel curve (efficiency drops at high load) with an
-inequality bound — solver picks `method='lp'` automatically and uses pure
-tangent-line constraints (no SOS2 binaries):
-
-### With on/off and startup costs

--- a/docs/math/converters.md
+++ b/docs/math/converters.md
@@ -38,11 +38,6 @@ A gas boiler with thermal efficiency \(\eta_{\text{th}} = 0.9\):
 
 So 10 MW gas input produces 9 MW thermal output.
 
-```python
-Converter.boiler("boiler", thermal_efficiency=0.9, fuel_flow=gas, thermal_flow=th)
-# conversion_factors = [{gas.id: 0.9, th.id: -1}]
-```
-
 ### Power-to-Heat
 
 An electric resistance heater with efficiency \(\eta = 0.99\):
@@ -50,11 +45,6 @@ An electric resistance heater with efficiency \(\eta = 0.99\):
 \[
 \eta \cdot P_{\text{el},t} - P_{\text{th},t} = 0
 \]
-
-```python
-Converter.power2heat("p2h", efficiency=0.99, electrical_flow=el, thermal_flow=th)
-# conversion_factors = [{el.id: 0.99, th.id: -1}]
-```
 
 ### Heat Pump
 
@@ -72,11 +62,6 @@ P_{\text{el},t} + P_{\text{src},t} - P_{\text{th},t} = 0
 So 1 MW electrical input draws 2.5 MW from the environment and produces
 3.5 MW thermal output.
 
-```python
-Converter.heat_pump("hp", cop=3.5, electrical_flow=el, source_flow=src, thermal_flow=th)
-# conversion_factors = [{el.id: 3.5, th.id: -1}, {el.id: 1, src.id: 1, th.id: -1}]
-```
-
 ### CHP (Combined Heat and Power)
 
 A CHP with \(\eta_{\text{el}} = 0.4\) and \(\eta_{\text{th}} = 0.5\) has **two**
@@ -92,32 +77,10 @@ conversion equations:
 
 So 10 MW fuel input produces 4 MW electrical + 5 MW thermal.
 
-```python
-Converter.chp("chp", eta_el=0.4, eta_th=0.5,
-                     fuel_flow=fuel, electrical_flow=el, thermal_flow=th)
-# conversion_factors = [
-#     {fuel.id: 0.4, el.id: -1},
-#     {fuel.id: 0.5, th.id: -1},
-# ]
-```
-
 ### Custom Equations
 
 For devices not covered by factory methods, pass `conversion_factors` directly.
 Each dict in the list is one equation, mapping flow short ids to coefficients:
-
-```python
-in1 = Flow('a', size=100)
-in2 = Flow('b', size=100)
-out = Flow('c', size=100)
-
-conv = Converter(
-    id='custom',
-    inputs=[in1, in2],
-    outputs=[out],
-    conversion_factors=[{'a': 0.5, 'b': 0.3, 'c': -1}],
-)
-```
 
 This enforces: \(0.5 \cdot P_a + 0.3 \cdot P_b - P_c = 0\).
 
@@ -125,11 +88,6 @@ This enforces: \(0.5 \cdot P_a + 0.3 \cdot P_b - P_c = 0\).
 
 Conversion coefficients can be time-varying (e.g., a heat pump with hourly COP from
 weather data). Pass a list or array instead of a scalar:
-
-```python
-cop_profile = [3.2, 3.5, 3.8, 3.1]  # one value per timestep
-Converter.heat_pump("hp", cop=cop_profile, electrical_flow=el, source_flow=src, thermal_flow=th)
-```
 
 # Piecewise Conversion
 
@@ -214,35 +172,10 @@ where \(f^{\star}\) is the first flow in the curve.
 A gas boiler runs at 90% efficiency between 0 and 50 MW (slope 0.9), then drops
 to 50% efficiency from 50 to 100 MW (slope 0.5):
 
-```python
-Converter(
-    'Boiler',
-    inputs=[Flow('Gas', short_id='fuel')],
-    outputs=[Flow('Heat', size=100)],
-    conversion=PiecewiseConversion({
-        'fuel': [0, 50, 100],
-        'Heat': [0, 45, 70],
-    }),
-)
-```
-
 ### CHP with joint N-flow curve
 
 A CHP plant with three flows linked by shared interpolation weights — every
 operating point lies on the same piece of the curve:
-
-```python
-Converter(
-    'CHP',
-    inputs=[Flow('Gas', short_id='fuel')],
-    outputs=[Flow('Power', size=100), Flow('Heat', size=100)],
-    conversion=PiecewiseConversion({
-        'fuel':  [0, 30, 60, 100],
-        'Power': [0, 10, 22,  40],
-        'Heat':  [0, 15, 30,  45],
-    }),
-)
-```
 
 ### Convex curve via LP fast path
 
@@ -250,31 +183,4 @@ A monotonic-convex fuel curve (efficiency drops at high load) with an
 inequality bound — solver picks `method='lp'` automatically and uses pure
 tangent-line constraints (no SOS2 binaries):
 
-```python
-Converter(
-    'Boiler',
-    inputs=[Flow('Gas', short_id='fuel')],
-    outputs=[Flow('Heat', size=100)],
-    conversion=PiecewiseConversion(
-        [
-            ('Heat', [0, 30, 60, 100]),
-            ('fuel', [0, 36, 84, 170], '>='),
-        ],
-        method='auto',
-    ),
-)
-```
-
 ### With on/off and startup costs
-
-```python
-Converter(
-    'Boiler',
-    inputs=[Flow('Gas', short_id='fuel')],
-    outputs=[Flow('Heat', size=100)],
-    conversion=PiecewiseConversion(
-        {'fuel': [0, 50, 100], 'Heat': [0, 45, 70]},
-        status=Status(min_uptime=3, effects_per_startup={'cost': 50}),
-    ),
-)
-```

--- a/docs/math/effects.md
+++ b/docs/math/effects.md
@@ -136,19 +136,19 @@ For example, `maximum_per_hour=100` (kg/h) with a 4-hour timestep allows up to
 | \(\Phi_{k,t(,p)}^{\text{temporal}}\) | Per-timestep effect variable | `effect--temporal[effect, time(, period)]` |
 | \(\Phi_{k(,p)}^{\text{lump}}\) | Lump effect variable (sizing + one-time costs) | `effect--lump[effect(, period)]` |
 | \(\Phi_{k(,p)}\) | Total effect variable | `effect--total[effect(, period)]` |
-| \(\mathrm{c}_{f,k,t}\) | Effect coefficient per flow-hour | `Flow.effects_per_flow_hour` |
-| \(\alpha_{k,j,t}\) | Cross-effect contribution factor (time-varying) | `Effect.contribution_from` (TimeSeries) |
-| \(\alpha_{k,j}\) | Cross-effect contribution factor (scalar) | `Effect.contribution_from` (scalar) |
+| \(\mathrm{c}_{f,k,t}\) | Effect coefficient per flow-hour | [`Flow.effects_per_flow_hour`](../api/fluxopt/elements.md#fluxopt.elements.Flow(effects_per_flow_hour)) |
+| \(\alpha_{k,j,t}\) | Cross-effect contribution factor (time-varying) | [`Effect.contribution_from`](../api/fluxopt/elements.md#fluxopt.elements.Effect(contribution_from)) (TimeSeries) |
+| \(\alpha_{k,j}\) | Cross-effect contribution factor (scalar) | [`Effect.contribution_from`](../api/fluxopt/elements.md#fluxopt.elements.Effect(contribution_from)) (scalar) |
 | \(P_{f,t}\) | Flow rate variable | `flow--rate[flow, time]` |
 | \(\Delta t_t\) | Timestep duration | dt |
 | \(\mathrm{w}_t\) | Timestep weight | weights |
-| \(\bar{\Phi}_k\) | Maximum aggregate (weighted sum across periods) | `Effect.maximum` |
-| \(\underline{\Phi}_k\) | Minimum aggregate (weighted sum across periods) | `Effect.minimum` |
-| \(\bar{\Phi}_k^{\text{per period}}\) | Maximum per period | `Effect.maximum_per_period` |
-| \(\underline{\Phi}_k^{\text{per period}}\) | Minimum per period | `Effect.minimum_per_period` |
-| \(\bar{\Phi}_{k,t}^{\text{per hour}}\) | Maximum per hour (rate, scaled by \(\Delta t_t\)) | `Effect.maximum_per_hour` |
-| \(\underline{\Phi}_{k,t}^{\text{per hour}}\) | Minimum per hour (rate, scaled by \(\Delta t_t\)) | `Effect.minimum_per_hour` |
-| \(\omega_{k,p}\) | Period weight (per-effect, falls back to global, then 1) | `Effect.period_weights` / global `period_weights` |
+| \(\bar{\Phi}_k\) | Maximum aggregate (weighted sum across periods) | [`Effect.maximum`](../api/fluxopt/elements.md#fluxopt.elements.Effect(maximum)) |
+| \(\underline{\Phi}_k\) | Minimum aggregate (weighted sum across periods) | [`Effect.minimum`](../api/fluxopt/elements.md#fluxopt.elements.Effect(minimum)) |
+| \(\bar{\Phi}_k^{\text{per period}}\) | Maximum per period | [`Effect.maximum_per_period`](../api/fluxopt/elements.md#fluxopt.elements.Effect(maximum_per_period)) |
+| \(\underline{\Phi}_k^{\text{per period}}\) | Minimum per period | [`Effect.minimum_per_period`](../api/fluxopt/elements.md#fluxopt.elements.Effect(minimum_per_period)) |
+| \(\bar{\Phi}_{k,t}^{\text{per hour}}\) | Maximum per hour (rate, scaled by \(\Delta t_t\)) | [`Effect.maximum_per_hour`](../api/fluxopt/elements.md#fluxopt.elements.Effect(maximum_per_hour)) |
+| \(\underline{\Phi}_{k,t}^{\text{per hour}}\) | Minimum per hour (rate, scaled by \(\Delta t_t\)) | [`Effect.minimum_per_hour`](../api/fluxopt/elements.md#fluxopt.elements.Effect(minimum_per_hour)) |
+| \(\omega_{k,p}\) | Period weight (per-effect, falls back to global, then 1) | [`Effect.period_weights`](../api/fluxopt/elements.md#fluxopt.elements.Effect(period_weights)) / global `period_weights` |
 
 See [Notation](notation.md) for the full symbol table.
 

--- a/docs/math/effects.md
+++ b/docs/math/effects.md
@@ -11,7 +11,7 @@ how they are weighted in multi-period optimization:
 
 | Domain | Dims | What goes here | Multi-period weighting |
 |---|---|---|---|
-| **Temporal** | `(effect, time)` | Flow costs, running costs, startup costs — anything that varies per timestep | Summed over time (× \(w_t\)), then weighted by `period_weights` |
+| **Temporal** | `(effect, time)` | Flow costs, running costs, startup costs — anything that varies per timestep | Summed over time (× \(\mathrm{w}_t\)), then weighted by `period_weights` |
 | **Lump** | `(effect,)` | Sizing costs, fixed O&M, one-time CAPEX — anything not per-timestep | Weighted by \(\omega_{k,p}\) (defaults to global `period_weights`) |
 
 All domains support cross-effect chains via `contribution_from`.
@@ -24,10 +24,10 @@ See [Objective](objective.md) for how the domains are weighted in the objective.
 Each effect accumulates contributions from all flows at each timestep:
 
 \[
-\Phi_{k,t}^{\text{temporal}} = \underbrace{\sum_{f \in \mathcal{F}} c_{f,k,t} \cdot P_{f,t} \cdot \Delta t_t}_{\text{direct flow contributions}} + \underbrace{\sum_{j \in \mathcal{K}} \alpha_{k,j,t} \cdot \Phi_{j,t}^{\text{temporal}}}_{\text{cross-effect contributions}} \quad \forall \, k, t
+\Phi_{k,t}^{\text{temporal}} = \underbrace{\sum_{f \in \mathcal{F}} \mathrm{c}_{f,k,t} \cdot P_{f,t} \cdot \Delta t_t}_{\text{direct flow contributions}} + \underbrace{\sum_{j \in \mathcal{K}} \alpha_{k,j,t} \cdot \Phi_{j,t}^{\text{temporal}}}_{\text{cross-effect contributions}} \quad \forall \, k, t
 \]
 
-The coefficient \(c_{f,k,t}\) specifies how much of effect \(k\) is produced per
+The coefficient \(\mathrm{c}_{f,k,t}\) specifies how much of effect \(k\) is produced per
 flow-hour of flow \(f\) (e.g., €/MWh for cost, kg/MWh for emissions).
 
 The cross-effect factor \(\alpha_{k,j,t}\) can be time-varying or constant
@@ -87,10 +87,10 @@ Contributions chain transitively. A PE → CO₂ → cost chain is modeled as:
 The total effect for each period \(p\) combines both domains:
 
 \[
-\Phi_{k,p} = \sum_{t \in \mathcal{T}} \Phi_{k,t,p}^{\text{temporal}} \cdot w_t + \Phi_{k,p}^{\text{lump}} \quad \forall \, k \in \mathcal{K}, \; p \in \mathcal{P}
+\Phi_{k,p} = \sum_{t \in \mathcal{T}} \Phi_{k,t,p}^{\text{temporal}} \cdot \mathrm{w}_t + \Phi_{k,p}^{\text{lump}} \quad \forall \, k \in \mathcal{K}, \; p \in \mathcal{P}
 \]
 
-Weights \(w_t\) allow scaling timesteps (e.g., a representative week scaled to a year).
+Weights \(\mathrm{w}_t\) allow scaling timesteps (e.g., a representative week scaled to a year).
 Single-period models drop the \(p\) index.
 
 ## Bounds
@@ -136,12 +136,12 @@ For example, `maximum_per_hour=100` (kg/h) with a 4-hour timestep allows up to
 | \(\Phi_{k,t(,p)}^{\text{temporal}}\) | Per-timestep effect variable | `effect_temporal[effect, time(, period)]` |
 | \(\Phi_{k(,p)}^{\text{lump}}\) | Lump effect variable (sizing + one-time costs) | `effect_lump[effect(, period)]` |
 | \(\Phi_{k(,p)}\) | Total effect variable | `effect_total[effect(, period)]` |
-| \(c_{f,k,t}\) | Effect coefficient per flow-hour | `Flow.effects_per_flow_hour` |
+| \(\mathrm{c}_{f,k,t}\) | Effect coefficient per flow-hour | `Flow.effects_per_flow_hour` |
 | \(\alpha_{k,j,t}\) | Cross-effect contribution factor (time-varying) | `Effect.contribution_from` (TimeSeries) |
 | \(\alpha_{k,j}\) | Cross-effect contribution factor (scalar) | `Effect.contribution_from` (scalar) |
 | \(P_{f,t}\) | Flow rate variable | `flow_rate[flow, time]` |
 | \(\Delta t_t\) | Timestep duration | dt |
-| \(w_t\) | Timestep weight | weights |
+| \(\mathrm{w}_t\) | Timestep weight | weights |
 | \(\bar{\Phi}_k\) | Maximum aggregate (weighted sum across periods) | `Effect.maximum` |
 | \(\underline{\Phi}_k\) | Minimum aggregate (weighted sum across periods) | `Effect.minimum` |
 | \(\bar{\Phi}_k^{\text{per period}}\) | Maximum per period | `Effect.maximum_per_period` |
@@ -172,7 +172,7 @@ CO₂ priced at 50 €/t into the cost effect:
 With \(\alpha_{\text{cost,co2}} = 50\), the per-timestep cost becomes:
 
 \[
-\Phi_{\text{cost},t} = c_{\text{cost}} \cdot P_t \cdot \Delta t + 50 \cdot \Phi_{\text{co2},t}
+\Phi_{\text{cost},t} = \mathrm{c}_{\text{cost}} \cdot P_t \cdot \Delta t + 50 \cdot \Phi_{\text{co2},t}
 \]
 
 The CO₂ total itself is **not** affected — `contribution_from` is one-directional.

--- a/docs/math/effects.md
+++ b/docs/math/effects.md
@@ -69,34 +69,12 @@ or a `TimeSeries`:
   (`cf_temporal.mean('time')` in `model.py`). A `UserWarning` is emitted when
   a time-varying factor is averaged for a non-trivial lump contribution.
 
-```python
-# Scalar: 50 €/kg CO2 in both domains
-effects = [
-    Effect('cost', contribution_from={'co2': 50}),
-    Effect('co2', unit='kg'),
-]
-
-# Time-varying factor
-effects = [
-    Effect('cost', contribution_from={'co2': [40, 50, 60]}),
-    Effect('co2', unit='kg'),
-]
-```
-
 If you need different cross-effect factors for the two domains, split into
 separate effects.
 
 ### Transitive Chains
 
 Contributions chain transitively. A PE → CO₂ → cost chain is modeled as:
-
-```python
-effects = [
-    Effect('cost', contribution_from={'co2': 50}),
-    Effect('co2', unit='kg', contribution_from={'pe': 0.3}),
-    Effect('pe', unit='kWh'),
-]
-```
 
 ### Validation
 
@@ -139,14 +117,6 @@ typically encode the period duration so the aggregate is a true physical sum.
 
 This is useful for emission caps or budget constraints:
 
-```python
-# CO2 budget: max 1000 kg total
-co2 = Effect('co2', unit='kg', maximum=1000)
-
-# Cost floor (e.g., minimum revenue)
-revenue = Effect('revenue', minimum=500)
-```
-
 ## Per-Hour Bounds
 
 The per-hour bounds are **rates** (e.g., kg/h, €/h) that scale with the timestep
@@ -158,14 +128,6 @@ duration \(\Delta t_t\). This ensures the constraint is resolution-independent:
 
 For example, `maximum_per_hour=100` (kg/h) with a 4-hour timestep allows up to
 400 kg of emissions in that timestep:
-
-```python
-# Max 50 kg CO2 per hour — allows 200 kg in a 4h timestep
-co2 = Effect('co2', unit='kg', maximum_per_hour=50)
-
-# Time-varying per-hour bound
-co2 = Effect('co2', unit='kg', maximum_per_hour=[50, 40, 60, 50])
-```
 
 ## Parameters
 
@@ -196,18 +158,7 @@ See [Notation](notation.md) for the full symbol table.
 
 A system with two effects — cost (objective) and CO₂ (capped at 1000 kg):
 
-```python
-effects = [
-    Effect("cost", unit="€"),
-    Effect("CO2", unit="kg", maximum=1000),
-]
-```
-
 A gas flow with both effect coefficients:
-
-```python
-gas_flow = Flow("gas", bus="gas_bus", effects_per_flow_hour={"cost": 30, "CO2": 0.2})
-```
 
 At timestep \(t\) with \(P_{\text{gas},t} = 5\) MW and \(\Delta t = 1\) h:
 
@@ -217,13 +168,6 @@ At timestep \(t\) with \(P_{\text{gas},t} = 5\) MW and \(\Delta t = 1\) h:
 ### Carbon pricing via `contribution_from`
 
 CO₂ priced at 50 €/t into the cost effect:
-
-```python
-effects = [
-    Effect("cost", contribution_from={"co2": 50}),
-    Effect("co2", unit="kg"),
-]
-```
 
 With \(\alpha_{\text{cost,co2}} = 50\), the per-timestep cost becomes:
 

--- a/docs/math/effects.md
+++ b/docs/math/effects.md
@@ -133,13 +133,13 @@ For example, `maximum_per_hour=100` (kg/h) with a 4-hour timestep allows up to
 
 | Symbol | Description | Reference |
 |---|---|---|
-| \(\Phi_{k,t(,p)}^{\text{temporal}}\) | Per-timestep effect variable | `effect_temporal[effect, time(, period)]` |
-| \(\Phi_{k(,p)}^{\text{lump}}\) | Lump effect variable (sizing + one-time costs) | `effect_lump[effect(, period)]` |
-| \(\Phi_{k(,p)}\) | Total effect variable | `effect_total[effect(, period)]` |
+| \(\Phi_{k,t(,p)}^{\text{temporal}}\) | Per-timestep effect variable | `effect--temporal[effect, time(, period)]` |
+| \(\Phi_{k(,p)}^{\text{lump}}\) | Lump effect variable (sizing + one-time costs) | `effect--lump[effect(, period)]` |
+| \(\Phi_{k(,p)}\) | Total effect variable | `effect--total[effect(, period)]` |
 | \(\mathrm{c}_{f,k,t}\) | Effect coefficient per flow-hour | `Flow.effects_per_flow_hour` |
 | \(\alpha_{k,j,t}\) | Cross-effect contribution factor (time-varying) | `Effect.contribution_from` (TimeSeries) |
 | \(\alpha_{k,j}\) | Cross-effect contribution factor (scalar) | `Effect.contribution_from` (scalar) |
-| \(P_{f,t}\) | Flow rate variable | `flow_rate[flow, time]` |
+| \(P_{f,t}\) | Flow rate variable | `flow--rate[flow, time]` |
 | \(\Delta t_t\) | Timestep duration | dt |
 | \(\mathrm{w}_t\) | Timestep weight | weights |
 | \(\bar{\Phi}_k\) | Maximum aggregate (weighted sum across periods) | `Effect.maximum` |

--- a/docs/math/flows.md
+++ b/docs/math/flows.md
@@ -91,7 +91,7 @@ where \(c_{f,k,t}\) is the effect coefficient per flow-hour
 | \(\bar{p}_{f,t}\) | Relative upper bound | `Flow.relative_maximum` |
 | \(\pi_{f,t}\) | Fixed relative profile | `Flow.fixed_relative_profile` |
 | \(c_{f,k,t}\) | Effect coefficient per flow-hour | `Flow.effects_per_flow_hour` |
-| \(\Delta t_t\) | Timestep duration | dt |
+| \(\Delta t_t\) | Timestep duration (h) | dt |
 
 See [Notation](notation.md) for the full symbol table.
 

--- a/docs/math/flows.md
+++ b/docs/math/flows.md
@@ -31,14 +31,6 @@ bounded by relative minimum and maximum profiles:
 By default, \(\underline{p}_{f,t} = 0\) and \(\bar{p}_{f,t} = 1\), so the bounds
 simplify to \(0 \leq P_{f,t} \leq \bar{P}_f\).
 
-```python
-# Minimum load 30%, maximum 100% → [30, 100] MW
-f = Flow('heat', size=100, relative_minimum=0.3)
-
-# Time-varying maximum
-f = Flow('heat', size=100, relative_maximum=[1.0, 0.8, 0.6, 1.0])
-```
-
 ### Unsized Flows
 
 When no capacity is specified (\(\bar{P}_f = \infty\)), the flow is unbounded above:
@@ -128,5 +120,5 @@ A gas flow with cost coefficient \(c = 0.04\) €/MWh, rate \(P = 5\) MW,
 duration \(\Delta t = 1\) h:
 
 \[
-0.04 \times 5 \times 1 = 0.2 \; \text{€}
+\underbrace{0.04}_{c_{f,k,t}} \times \underbrace{5}_{P_{f,t}} \times \underbrace{1}_{\Delta t_t} = 0.2 \; \text{€}
 \]

--- a/docs/math/flows.md
+++ b/docs/math/flows.md
@@ -49,7 +49,7 @@ Units cancel: e.g. €/MWh × MW × h = €. Contributions feed into the
 
 | Symbol | Description | API |
 |---|---|---|
-| \(P_{f,t}\) | Flow rate variable | `flow_rate[flow, time]` |
+| \(P_{f,t}\) | Flow rate variable | `flow--rate[flow, time]` |
 | \(\bar{\mathrm{P}}_f\) | Nominal capacity | [`Flow.size`](../api/fluxopt/elements.md#fluxopt.elements.Flow(size)) |
 | \(\underline{\mathrm{p}}_{f,t}\) | Relative lower bound | [`Flow.relative_minimum`](../api/fluxopt/elements.md#fluxopt.elements.Flow(relative_minimum)) |
 | \(\bar{\mathrm{p}}_{f,t}\) | Relative upper bound | [`Flow.relative_maximum`](../api/fluxopt/elements.md#fluxopt.elements.Flow(relative_maximum)) |

--- a/docs/math/flows.md
+++ b/docs/math/flows.md
@@ -1,124 +1,61 @@
 # Flows
 
-A flow represents energy transfer on a bus. This page covers the full
-mathematical model: sizing, bounds, fixed profiles, and effect contributions.
-
-## Flow Rate Variable
-
-Each flow \(f\) has a non-negative rate variable \(P_{f,t}\) at each timestep:
-
-\[
-P_{f,t} \geq 0 \quad \forall \, f \in \mathcal{F}, \; t \in \mathcal{T}
-\]
-
-## Sizing
-
-The nominal capacity \(\bar{P}_f\) (`Flow.size`) sets the scale for all
-relative parameters. When no capacity is specified (\(\bar{P}_f = \infty\)),
-the flow is unbounded above.
+A flow represents energy transfer on a bus. Each flow \(f\) has a non-negative
+rate variable \(P_{f,t}\) bounded by an optional nominal capacity \(\bar{\mathrm{P}}_f\).
 
 ## Bounds
 
-### Sized Flows
-
-When a flow has a nominal capacity \(\bar{P}_f\), the flow rate is
-bounded by relative minimum and maximum profiles:
+When `Flow.size` is set, the rate is bounded by relative minimum and maximum
+profiles:
 
 \[
-\bar{P}_f \cdot \underline{p}_{f,t} \leq P_{f,t} \leq \bar{P}_f \cdot \bar{p}_{f,t} \quad \forall \, f, t
+\bar{\mathrm{P}}_f \cdot \underline{\mathrm{p}}_{f,t} \leq P_{f,t} \leq \bar{\mathrm{P}}_f \cdot \bar{\mathrm{p}}_{f,t} \quad \forall \, f, t
 \]
 
-By default, \(\underline{p}_{f,t} = 0\) and \(\bar{p}_{f,t} = 1\), so the bounds
-simplify to \(0 \leq P_{f,t} \leq \bar{P}_f\).
-
-### Unsized Flows
-
-When no capacity is specified (\(\bar{P}_f = \infty\)), the flow is unbounded above:
-
-\[
-0 \leq P_{f,t} \quad \forall \, f, t
-\]
+By default \(\underline{\mathrm{p}}_{f,t} = 0\) and \(\bar{\mathrm{p}}_{f,t} = 1\), so the bounds
+simplify to \(0 \leq P_{f,t} \leq \bar{\mathrm{P}}_f\). With no capacity
+(\(\bar{\mathrm{P}}_f = \infty\)) the flow is just \(P_{f,t} \geq 0\).
 
 ## Fixed Profile
 
-When `Flow.fixed_relative_profile` (\(\pi_{f,t}\)) is set, the flow rate is fixed to a
-profile scaled by the capacity:
+When `Flow.fixed_relative_profile` (\(\pi_{f,t}\)) is set, the rate is pinned
+to a profile scaled by the capacity:
 
 \[
-P_{f,t} = \bar{P}_f \cdot \pi_{f,t} \quad \forall \, f, t
+P_{f,t} = \bar{\mathrm{P}}_f \cdot \pi_{f,t} \quad \forall \, f, t
 \]
 
-This is implemented by setting both lower and upper bounds equal to the profile value.
-
-## Sizing (Investment)
-
-When `Flow.size` is a `Sizing` object, the fixed capacity is replaced by a
-decision variable. See [Sizing](sizing.md) for the full formulation.
-
-## Status (On/Off)
-
-When `Flow.status` is set, binary on/off behavior is added. The flow becomes
-semi-continuous: \(\{0\} \cup [\underline{P}, \bar{P}]\). See [Status](status.md)
-for the full formulation.
-
-## Multi-Node Carriers
-
-Flows can target a specific node of a multi-node carrier via `Flow.node`.
-Each node gets an independent balance constraint. See
-[Carrier Balance — Multi-Node](carrier-balance.md#multi-node-carriers) for
-the formulation.
+Implemented by setting both bounds equal to the profile value.
 
 ## Effect Contributions
 
-Each flow can contribute to tracked effects (cost, emissions, ...). The
-per-timestep contribution of flow \(f\) to effect \(k\) is:
+Each flow contributes to tracked effects (cost, emissions, …). Per-timestep:
 
 \[
-c_{f,k,t} \cdot P_{f,t} \cdot \Delta t_t
+\mathrm{c}_{f,k,t} \cdot P_{f,t} \cdot \Delta t_t
 \]
 
-where \(c_{f,k,t}\) is the effect coefficient per flow-hour
-(`Flow.effects_per_flow_hour`). These contributions feed into the
+\(\mathrm{c}_{f,k,t}\) is the per-flow-hour coefficient (`Flow.effects_per_flow_hour`).
+Units cancel: e.g. €/MWh × MW × h = €. Contributions feed into the
 [effect tracking](effects.md) equations.
+
+## See also
+
+- [Sizing](sizing.md) — when `Flow.size` is a `Sizing` object instead of a fixed value.
+- [Status](status.md) — when `Flow.status` is set, the flow becomes semi-continuous \(\{0\} \cup [\underline{\mathrm{P}}, \bar{\mathrm{P}}]\).
+- [Carrier Balance — Multi-Node](carrier-balance.md#multi-node-carriers) — when `Flow.node` targets a specific node.
 
 ## Parameters
 
-| Symbol | Description | Reference |
+| Symbol | Description | API |
 |---|---|---|
 | \(P_{f,t}\) | Flow rate variable | `flow_rate[flow, time]` |
-| \(\bar{P}_f\) | Nominal capacity | `Flow.size` |
-| \(\underline{p}_{f,t}\) | Relative lower bound | `Flow.relative_minimum` |
-| \(\bar{p}_{f,t}\) | Relative upper bound | `Flow.relative_maximum` |
-| \(\pi_{f,t}\) | Fixed relative profile | `Flow.fixed_relative_profile` |
-| \(c_{f,k,t}\) | Effect coefficient per flow-hour | `Flow.effects_per_flow_hour` |
+| \(\bar{\mathrm{P}}_f\) | Nominal capacity | [`Flow.size`](../api/fluxopt/elements.md#fluxopt.elements.Flow(size)) |
+| \(\underline{\mathrm{p}}_{f,t}\) | Relative lower bound | [`Flow.relative_minimum`](../api/fluxopt/elements.md#fluxopt.elements.Flow(relative_minimum)) |
+| \(\bar{\mathrm{p}}_{f,t}\) | Relative upper bound | [`Flow.relative_maximum`](../api/fluxopt/elements.md#fluxopt.elements.Flow(relative_maximum)) |
+| \(\pi_{f,t}\) | Fixed relative profile | [`Flow.fixed_relative_profile`](../api/fluxopt/elements.md#fluxopt.elements.Flow(fixed_relative_profile)) |
+| \(\mathrm{c}_{f,k,t}\) | Effect coefficient per flow-hour | [`Flow.effects_per_flow_hour`](../api/fluxopt/elements.md#fluxopt.elements.Flow(effects_per_flow_hour)) |
 | \(\Delta t_t\) | Timestep duration (h) | dt |
 
-See [Notation](notation.md) for the full symbol table.
-
-## Examples
-
-### Sized Flow with Minimum Load
-
-A boiler with capacity \(\bar{P} = 10\) MW, minimum load
-\(\underline{p} = 0.3\), maximum load \(\bar{p} = 1.0\):
-
-\[
-10 \times 0.3 \leq P_t \leq 10 \times 1.0 \quad \Rightarrow \quad 3 \leq P_t \leq 10 \; \text{MW}
-\]
-
-### Fixed Demand Profile
-
-A demand of 100 MW capacity with profile \(\pi = [0.4, 0.7, 0.5, 0.6]\):
-
-\[
-P_t = 100 \cdot \pi_t \quad \Rightarrow \quad P = [40, 70, 50, 60] \; \text{MW}
-\]
-
-### Effect Contribution
-
-A gas flow with cost coefficient \(c = 0.04\) €/MWh, rate \(P = 5\) MW,
-duration \(\Delta t = 1\) h:
-
-\[
-\underbrace{0.04}_{c_{f,k,t}} \times \underbrace{5}_{P_{f,t}} \times \underbrace{1}_{\Delta t_t} = 0.2 \; \text{€}
-\]
+See [Notation](notation.md) for the full symbol table and [Indexing
+Convention](notation.md#indexing-convention) for how indices broadcast.

--- a/docs/math/notation.md
+++ b/docs/math/notation.md
@@ -38,9 +38,16 @@ Each symbol maps to a specific field or variable in the code.
 
 **Variables** (the table above) are shown with **all** dimensions they
 live on. There's no broadcasting for decision variables — every
-\((\text{flow}, \text{time}, \ldots)\) cell is its own variable. The
-`(,p)` notation marks the period dim as optional (present in
-multi-period models, absent otherwise); scenarios would add `(,s)`.
+\((\text{flow}, \text{time}, \ldots)\) cell is its own variable.
+
+**Optional dims** — currently just period — exist in some models and
+not others. We mark them in parentheses, e.g. \(P_{f,t(,p)}\): the
+period subscript is *present* in multi-period models, *absent* in
+single-period ones. To keep formulas readable, constraint derivations
+that aren't specifically about multi-period dynamics drop the
+parenthetical and treat \(p\) as implicit context — the constraint
+applies pointwise across whichever optional dims happen to be in the
+model.
 
 **Parameters** are different. Symbol subscripts show only the indices
 the formulation **structurally requires** — the dims a constraint
@@ -51,11 +58,11 @@ into pyramids of subscripts.
 
 The broadcast hierarchy:
 
-- **Period (\(p\))** and **scenario** (when added) — almost every
-  parameter accepts these: even "scalar" things like \(\bar{P}_f\),
-  \(D^{\text{up,min}}\), or \(S^-\) become \(\bar{P}_{f,p}\) etc. in
-  multi-period models. Variables already reflect this in the table
-  above (e.g. \(P_{f,t(,p)}\)).
+- **Period (\(p\))** — almost every parameter accepts this: even
+  "scalar" things like \(\bar{P}_f\), \(D^{\text{up,min}}\), or
+  \(S^-\) become \(\bar{P}_{f,p}\) etc. in multi-period models.
+  Variables already reflect this in the table above (e.g.
+  \(P_{f,t(,p)}\)).
 - **Time (\(t\))** — only fields typed `TimeSeries` accept this: bounds
   \(\underline{p}_{f,t}, \bar{p}_{f,t}\), profiles \(\pi_{f,t}\),
   efficiencies \(\eta^c_s, \eta^d_s\), losses \(\delta_s\), conversion

--- a/docs/math/notation.md
+++ b/docs/math/notation.md
@@ -37,35 +37,32 @@ Each symbol maps to a specific field or variable in the code.
 ## Indexing Convention
 
 Symbol subscripts show only the indices the formulation **structurally
-requires** — i.e. the dims a constraint iterates over and that change
-its meaning. Most parameters may also **broadcast over time (and
-period)** in the API: anywhere a field is typed `TimeSeries`, you can
-pass a scalar (broadcast) or an array (per-timestep). To keep formulas
-readable, we don't decorate every parameter with every dimension it
-*can* take.
+requires** — the dims a constraint iterates over and that change its
+meaning. Most parameters may also **broadcast over additional dims**
+in the API; we don't decorate the symbols with every dim they *could*
+take, because that turns formulas into pyramids of subscripts.
 
-A rough taxonomy of the parameters below:
+The broadcast hierarchy:
 
-- **Inherently scalar** (per object — flow, storage, converter):
-  nominal capacity \(\bar{P}_f\), storage capacity \(\bar{E}_s\),
-  sizing bounds \(S^-, S^+\), min/max run durations
-  \(D^{\text{up,min}}, D^{\text{down,max}}, …\). These don't have a
-  meaningful time dependence.
-- **May broadcast over \(t\)** (`TimeSeries` in the API):
-  efficiencies \(\eta^c_s, \eta^d_s\), self-discharge \(\delta_s\),
-  conversion coefficients \(a_{f,i}\), bounds and profiles
-  \(\underline{p}_{f,t}, \bar{p}_{f,t}, \pi_{f,t}\), effect / running /
-  startup costs \(c_{f,k,t}, r_{f,k,t}, u_{f,k,t}\), cross-effects
-  \(\alpha_{k,j,t}\). We show the \(t\) index only where it's
-  structurally important to the constraint (e.g. profiles, where time
-  variation is the whole point).
-- **Per period only** (multi-period models): period weights
-  \(\omega_p, \omega_{k,p}\); investment-domain coefficients
-  (\(\gamma^{\text{build}}_{f,k}, \phi^{\text{rec}}_{f,k}, …\)) attach
-  to a build period rather than to time.
+- **Period (\(p\))** and **scenario** (when added) — almost every
+  parameter accepts these: even "scalar" things like \(\bar{P}_f\),
+  \(D^{\text{up,min}}\), or \(S^-\) become \(\bar{P}_{f,p}\) etc. in
+  multi-period models. Variables already reflect this in the table
+  above (e.g. \(P_{f,t(,p)}\)).
+- **Time (\(t\))** — only fields typed `TimeSeries` accept this: bounds
+  \(\underline{p}_{f,t}, \bar{p}_{f,t}\), profiles \(\pi_{f,t}\),
+  efficiencies \(\eta^c_s, \eta^d_s\), losses \(\delta_s\), conversion
+  coefficients \(a_{f,i}\), effect / running / startup costs
+  \(c_{f,k,t}, r_{f,k,t}, u_{f,k,t}\), cross-effects \(\alpha_{k,j,t}\).
+- **Build period (\(p_b\))** — investment-domain coefficients only:
+  \(\gamma^{\text{build}}_{f,k}, \phi^{\text{rec}}_{f,k}\), …
 
-Absence of a \(t\) subscript on a parameter doesn't mean it must be
-scalar — check the API field's type.
+When a formula shows a \(t\) subscript on a parameter, it's because
+time variation is structurally meaningful for that constraint (e.g. a
+fixed profile is meaningless without time). Parameters without a \(t\)
+subscript may still be time-varying when the API field accepts it —
+the constraint just reads it pointwise. The same applies for \(p\):
+omit unless we're discussing multi-period dynamics specifically.
 
 ## Parameters
 

--- a/docs/math/notation.md
+++ b/docs/math/notation.md
@@ -24,9 +24,9 @@ Each symbol maps to a specific field or variable in the code.
 | \(\Phi_{k,t(,p)}^{\text{temporal}}\) | `effect--temporal[effect, time(, period)]` | \(\mathbb{R}\) | varies | Temporal (per-timestep) effect |
 | \(\Phi_{k(,p)}^{\text{lump}}\) | `effect--lump[effect(, period)]` | \(\mathbb{R}\) | varies | Lump (sizing + one-time) effect |
 | \(\Phi_{k(,p)}\) | `effect--total[effect(, period)]` | \(\mathbb{R}\) | varies | Total effect per period |
-| \(S_{f(,p)}\) | `flow--size[flow(, period)]` | \(\geq 0\) | MW | Flow capacity |
+| \(S_{f(,p)}\) | `flow--size[flow(, period)]` | \(\geq 0\) | MW | Invested flow capacity |
 | \(y_{f(,p)}\) | `flow--size_indicator[flow(, period)]` | \(\{0, 1\}\) | — | Binary invest indicator (flow) |
-| \(S_{s(,p)}\) | `storage--capacity[storage(, period)]` | \(\geq 0\) | MWh | Storage capacity |
+| \(S_{s(,p)}\) | `storage--capacity[storage(, period)]` | \(\geq 0\) | MWh | Invested storage capacity |
 | \(y_{s(,p)}\) | `storage--size_indicator[storage(, period)]` | \(\{0, 1\}\) | — | Binary invest indicator (storage) |
 | \(\sigma_{f,t(,p)}\) | `flow--on[flow, time(, period)]` | \(\{0, 1\}\) | — | On/off indicator |
 | \(\tau^+_{f,t(,p)}\) | `flow--startup[flow, time(, period)]` | \(\{0, 1\}\) | — | Startup event indicator |
@@ -104,8 +104,8 @@ omit unless we're discussing multi-period dynamics specifically.
 | \(\underline{\Phi}_{k,t}^{\text{per hour}}\) | [`Effect.minimum_per_hour`](../api/fluxopt/elements.md#fluxopt.elements.Effect(minimum_per_hour)) | \(\mathbb{R}\) | varies/h | Minimum per hour (rate, scaled by \(\Delta t_t\)) |
 | \(\mathrm{S}^-\) | [`Sizing.min_size`](../api/fluxopt/elements.md#fluxopt.elements.Sizing(min_size)) | \(\geq 0\) | MW or MWh | Minimum invested size (flow or storage) |
 | \(\mathrm{S}^+\) | [`Sizing.max_size`](../api/fluxopt/elements.md#fluxopt.elements.Sizing(max_size)) | \(\geq 0\) | MW or MWh | Maximum invested size (flow or storage) |
-| \(\gamma_{f,k}\) | [`Sizing.effects_per_size`](../api/fluxopt/elements.md#fluxopt.elements.Sizing(effects_per_size)) | \(\mathbb{R}\) | varies | Per-size investment cost (one-time, sized) |
-| \(\phi_{f,k}\) | [`Sizing.effects_fixed`](../api/fluxopt/elements.md#fluxopt.elements.Sizing(effects_fixed)) | \(\mathbb{R}\) | varies | Fixed investment cost (one-time, sized) |
+| \(\gamma_{f,k}\), \(\gamma_{s,k}\) | [`Sizing.effects_per_size`](../api/fluxopt/elements.md#fluxopt.elements.Sizing(effects_per_size)) | \(\mathbb{R}\) | varies | Per-size investment cost (flow or storage; one-time, sized) |
+| \(\phi_{f,k}\), \(\phi_{s,k}\) | [`Sizing.effects_fixed`](../api/fluxopt/elements.md#fluxopt.elements.Sizing(effects_fixed)) | \(\mathbb{R}\) | varies | Fixed investment cost (flow or storage; one-time, sized) |
 | \(\gamma^{\text{build}}_{f,k}\) | [`Investment.effects_per_size_at_build`](../api/fluxopt/elements.md#fluxopt.elements.Investment(effects_per_size_at_build)) | \(\mathbb{R}\) | varies | Per-size CAPEX charged in the build period |
 | \(\phi^{\text{build}}_{f,k}\) | [`Investment.effects_fixed_at_build`](../api/fluxopt/elements.md#fluxopt.elements.Investment(effects_fixed_at_build)) | \(\mathbb{R}\) | varies | Fixed CAPEX charged in the build period |
 | \(\gamma^{\text{rec}}_{f,k}\) | [`Investment.effects_per_size_recurring`](../api/fluxopt/elements.md#fluxopt.elements.Investment(effects_per_size_recurring)) | \(\mathbb{R}\) | varies | Recurring per-size cost (each active period) |
@@ -133,6 +133,7 @@ parameter that bounds it.
 | Italic (default math mode) | Decision variables | \(P\) (flow rate), \(E\) (stored energy), \(S\) (size) |
 | Upright (`\mathrm{}`) | Parameters | \(\mathrm{c}_{f,k,t}\) (cost coefficient), \(\bar{\mathrm{P}}_f\) (capacity), \(\mathrm{a}_{f,i}\) (conversion coefficient) |
 | Overbar / underbar | Bound (paired with the variable's letter) | \(\bar{\mathrm{P}}\) (upper bound on \(P\)), \(\underline{\mathrm{P}}\) (lower bound) |
+| Lowercase variant | Relative bound (fraction of size/capacity) | \(\bar{\mathrm{p}}_{f,t}\), \(\underline{\mathrm{p}}_{f,t}\) (fraction of \(\bar{\mathrm{P}}_f\)); \(\bar{\mathrm{e}}_s\), \(\underline{\mathrm{e}}_s\) (fraction of \(\bar{\mathrm{E}}_s\)) |
 | Greek | Parameters with established physical meaning | \(\eta\) (efficiency), \(\delta\) (loss), \(\pi\) (profile), \(\gamma\) (per-size cost) |
 | Subscripts | Indexing | \(f\) (flow), \(t\) (time), \(s\) (storage), \(b\) (bus), \(k\) (effect), \(j\) (source effect) |
 | Superscripts | Qualification | \(\eta^{\text{c}}\) (charge), \(\eta^{\text{d}}\) (discharge) |

--- a/docs/math/notation.md
+++ b/docs/math/notation.md
@@ -68,8 +68,8 @@ The broadcast hierarchy:
   efficiencies \(\eta^c_s, \eta^d_s\), losses \(\delta_s\), conversion
   coefficients \(\mathrm{a}_{f,i}\), effect / running / startup costs
   \(\mathrm{c}_{f,k,t}, \mathrm{r}_{f,k,t}, \mathrm{u}_{f,k,t}\), cross-effects \(\alpha_{k,j,t}\).
-- **Build period (\(p_b\))** — investment-domain coefficients only:
-  \(\gamma^{\text{build}}_{f,k}, \phi^{\text{rec}}_{f,k}\), …
+- **Build period (\(p_b\))** — at-build investment coefficients only:
+  \(\gamma^{\text{build}}_{f,k}, \phi^{\text{build}}_{f,k}\), …
 
 When a formula shows a \(t\) subscript on a parameter, it's because
 time variation is structurally meaningful for that constraint (e.g. a

--- a/docs/math/notation.md
+++ b/docs/math/notation.md
@@ -95,7 +95,7 @@ omit unless we're discussing multi-period dynamics specifically.
 | \(\bar{\mathrm{e}}_s\) | [`Storage.relative_maximum_level`](../api/fluxopt/elements.md#fluxopt.elements.Storage(relative_maximum_level)) | \([0, 1]\) | — | Relative max SOC |
 | \(\mathrm{a}_{f,i}\) | [`Converter.conversion_factors`](../api/fluxopt/components.md#fluxopt.components.Converter(conversion_factors)) | \(\mathbb{R}\) | — | Conversion coefficient (per flow, per equation) |
 | \(\alpha_{k,j}\) | [`Effect.contribution_from`](../api/fluxopt/elements.md#fluxopt.elements.Effect(contribution_from)) | \(\mathbb{R}\) | varies | Cross-effect factor (scalar) |
-| \(\alpha_{k,j,t}\) | `Effect.contribution_from` (TimeSeries) | \(\mathbb{R}\) | varies | Cross-effect factor (time-varying; lump uses time-mean) |
+| \(\alpha_{k,j,t}\) | [`Effect.contribution_from`](../api/fluxopt/elements.md#fluxopt.elements.Effect(contribution_from)) (TimeSeries) | \(\mathbb{R}\) | varies | Cross-effect factor (time-varying; lump uses time-mean) |
 | \(\bar{\Phi}_k\) | [`Effect.maximum`](../api/fluxopt/elements.md#fluxopt.elements.Effect(maximum)) | \(\mathbb{R}\) | varies | Maximum aggregate (weighted sum across periods) |
 | \(\underline{\Phi}_k\) | [`Effect.minimum`](../api/fluxopt/elements.md#fluxopt.elements.Effect(minimum)) | \(\mathbb{R}\) | varies | Minimum aggregate (weighted sum across periods) |
 | \(\bar{\Phi}_k^{\text{per period}}\) | [`Effect.maximum_per_period`](../api/fluxopt/elements.md#fluxopt.elements.Effect(maximum_per_period)) | \(\mathbb{R}\) | varies | Maximum per period |
@@ -118,7 +118,7 @@ omit unless we're discussing multi-period dynamics specifically.
 | \(\mathrm{u}_{f,k,t}\) | [`Status.effects_per_startup`](../api/fluxopt/elements.md#fluxopt.elements.Status(effects_per_startup)) | \(\mathbb{R}\) | varies | Startup cost coefficient |
 | \(\mathrm{w}_t\) | weights | \(> 0\) | — | Timestep weight |
 | \(\Delta t_t\) | dt | \(> 0\) | h | Timestep duration |
-| \(\omega_p\) | `Dims.period_weights` | \(> 0\) | — | Global period weight (multi-period only) |
+| \(\omega_p\) | [`optimize(period_weights=...)`](../api/fluxopt/index.md#fluxopt.optimize(period_weights)) | \(> 0\) | — | Global period weight (multi-period only) |
 | \(\omega_{k,p}\) | [`Effect.period_weights`](../api/fluxopt/elements.md#fluxopt.elements.Effect(period_weights)) | \(> 0\) | — | Per-effect period weight |
 
 ## Naming Conventions

--- a/docs/math/notation.md
+++ b/docs/math/notation.md
@@ -82,44 +82,44 @@ omit unless we're discussing multi-period dynamics specifically.
 
 | Symbol | Code | Domain | Unit | Description |
 |---|---|---|---|---|
-| \(\bar{\mathrm{P}}_f\) | `Flow.size` | \(\geq 0\) or \(\infty\) | MW | Nominal capacity |
-| \(\underline{\mathrm{p}}_{f,t}\) | `Flow.relative_minimum` | \([0, 1]\) | — | Relative lower bound |
-| \(\bar{\mathrm{p}}_{f,t}\) | `Flow.relative_maximum` | \([0, 1]\) | — | Relative upper bound |
-| \(\pi_{f,t}\) | `Flow.fixed_relative_profile` | \([0, 1]\) | — | Fixed profile |
-| \(\mathrm{c}_{f,k,t}\) | `Flow.effects_per_flow_hour` | \(\mathbb{R}\) | varies | Effect coefficient per flow-hour |
-| \(\bar{\mathrm{E}}_s\) | `Storage.capacity` | \(\geq 0\) | MWh | Storage capacity |
-| \(\eta^{\text{c}}_s\) | `Storage.eta_charge` | \((0, 1]\) | — | Charging efficiency |
-| \(\eta^{\text{d}}_s\) | `Storage.eta_discharge` | \((0, 1]\) | — | Discharging efficiency |
-| \(\delta_s\) | `Storage.relative_loss_per_hour` | \([0, 1]\) | 1/h | Self-discharge rate |
-| \(\underline{\mathrm{e}}_s\) | `Storage.relative_minimum_level` | \([0, 1]\) | — | Relative min SOC |
-| \(\bar{\mathrm{e}}_s\) | `Storage.relative_maximum_level` | \([0, 1]\) | — | Relative max SOC |
-| \(\mathrm{a}_{f,i}\) | `Converter.conversion_factors` | \(\mathbb{R}\) | — | Conversion coefficient (per flow, per equation) |
-| \(\alpha_{k,j}\) | `Effect.contribution_from` | \(\mathbb{R}\) | varies | Cross-effect factor (scalar) |
+| \(\bar{\mathrm{P}}_f\) | [`Flow.size`](../api/fluxopt/elements.md#fluxopt.elements.Flow(size)) | \(\geq 0\) or \(\infty\) | MW | Nominal capacity |
+| \(\underline{\mathrm{p}}_{f,t}\) | [`Flow.relative_minimum`](../api/fluxopt/elements.md#fluxopt.elements.Flow(relative_minimum)) | \([0, 1]\) | — | Relative lower bound |
+| \(\bar{\mathrm{p}}_{f,t}\) | [`Flow.relative_maximum`](../api/fluxopt/elements.md#fluxopt.elements.Flow(relative_maximum)) | \([0, 1]\) | — | Relative upper bound |
+| \(\pi_{f,t}\) | [`Flow.fixed_relative_profile`](../api/fluxopt/elements.md#fluxopt.elements.Flow(fixed_relative_profile)) | \([0, 1]\) | — | Fixed profile |
+| \(\mathrm{c}_{f,k,t}\) | [`Flow.effects_per_flow_hour`](../api/fluxopt/elements.md#fluxopt.elements.Flow(effects_per_flow_hour)) | \(\mathbb{R}\) | varies | Effect coefficient per flow-hour |
+| \(\bar{\mathrm{E}}_s\) | [`Storage.capacity`](../api/fluxopt/elements.md#fluxopt.elements.Storage(capacity)) | \(\geq 0\) | MWh | Storage capacity |
+| \(\eta^{\text{c}}_s\) | [`Storage.eta_charge`](../api/fluxopt/elements.md#fluxopt.elements.Storage(eta_charge)) | \((0, 1]\) | — | Charging efficiency |
+| \(\eta^{\text{d}}_s\) | [`Storage.eta_discharge`](../api/fluxopt/elements.md#fluxopt.elements.Storage(eta_discharge)) | \((0, 1]\) | — | Discharging efficiency |
+| \(\delta_s\) | [`Storage.relative_loss_per_hour`](../api/fluxopt/elements.md#fluxopt.elements.Storage(relative_loss_per_hour)) | \([0, 1]\) | 1/h | Self-discharge rate |
+| \(\underline{\mathrm{e}}_s\) | [`Storage.relative_minimum_level`](../api/fluxopt/elements.md#fluxopt.elements.Storage(relative_minimum_level)) | \([0, 1]\) | — | Relative min SOC |
+| \(\bar{\mathrm{e}}_s\) | [`Storage.relative_maximum_level`](../api/fluxopt/elements.md#fluxopt.elements.Storage(relative_maximum_level)) | \([0, 1]\) | — | Relative max SOC |
+| \(\mathrm{a}_{f,i}\) | [`Converter.conversion_factors`](../api/fluxopt/components.md#fluxopt.components.Converter(conversion_factors)) | \(\mathbb{R}\) | — | Conversion coefficient (per flow, per equation) |
+| \(\alpha_{k,j}\) | [`Effect.contribution_from`](../api/fluxopt/elements.md#fluxopt.elements.Effect(contribution_from)) | \(\mathbb{R}\) | varies | Cross-effect factor (scalar) |
 | \(\alpha_{k,j,t}\) | `Effect.contribution_from` (TimeSeries) | \(\mathbb{R}\) | varies | Cross-effect factor (time-varying; lump uses time-mean) |
-| \(\bar{\Phi}_k\) | `Effect.maximum` | \(\mathbb{R}\) | varies | Maximum aggregate (weighted sum across periods) |
-| \(\underline{\Phi}_k\) | `Effect.minimum` | \(\mathbb{R}\) | varies | Minimum aggregate (weighted sum across periods) |
-| \(\bar{\Phi}_k^{\text{per period}}\) | `Effect.maximum_per_period` | \(\mathbb{R}\) | varies | Maximum per period |
-| \(\underline{\Phi}_k^{\text{per period}}\) | `Effect.minimum_per_period` | \(\mathbb{R}\) | varies | Minimum per period |
-| \(\bar{\Phi}_{k,t}^{\text{per hour}}\) | `Effect.maximum_per_hour` | \(\mathbb{R}\) | varies/h | Maximum per hour (rate, scaled by \(\Delta t_t\)) |
-| \(\underline{\Phi}_{k,t}^{\text{per hour}}\) | `Effect.minimum_per_hour` | \(\mathbb{R}\) | varies/h | Minimum per hour (rate, scaled by \(\Delta t_t\)) |
-| \(\mathrm{S}^-\) | `Sizing.min_size` | \(\geq 0\) | MW or MWh | Minimum invested size (flow or storage) |
-| \(\mathrm{S}^+\) | `Sizing.max_size` | \(\geq 0\) | MW or MWh | Maximum invested size (flow or storage) |
-| \(\gamma_{f,k}\) | `Sizing.effects_per_size` | \(\mathbb{R}\) | varies | Per-size investment cost (one-time, sized) |
-| \(\phi_{f,k}\) | `Sizing.effects_fixed` | \(\mathbb{R}\) | varies | Fixed investment cost (one-time, sized) |
-| \(\gamma^{\text{build}}_{f,k}\) | `Investment.effects_per_size_at_build` | \(\mathbb{R}\) | varies | Per-size CAPEX charged in the build period |
-| \(\phi^{\text{build}}_{f,k}\) | `Investment.effects_fixed_at_build` | \(\mathbb{R}\) | varies | Fixed CAPEX charged in the build period |
-| \(\gamma^{\text{rec}}_{f,k}\) | `Investment.effects_per_size_recurring` | \(\mathbb{R}\) | varies | Recurring per-size cost (each active period) |
-| \(\phi^{\text{rec}}_{f,k}\) | `Investment.effects_fixed_recurring` | \(\mathbb{R}\) | varies | Recurring fixed cost (each active period) |
-| \(\mathrm{D}^{\text{up,min}}\) | `Status.min_uptime` | \(\geq 0\) | h | Minimum consecutive uptime |
-| \(\mathrm{D}^{\text{up,max}}\) | `Status.max_uptime` | \(\geq 0\) | h | Maximum consecutive uptime |
-| \(\mathrm{D}^{\text{down,min}}\) | `Status.min_downtime` | \(\geq 0\) | h | Minimum consecutive downtime |
-| \(\mathrm{D}^{\text{down,max}}\) | `Status.max_downtime` | \(\geq 0\) | h | Maximum consecutive downtime |
-| \(\mathrm{r}_{f,k,t}\) | `Status.effects_per_running_hour` | \(\mathbb{R}\) | varies | Running cost coefficient |
-| \(\mathrm{u}_{f,k,t}\) | `Status.effects_per_startup` | \(\mathbb{R}\) | varies | Startup cost coefficient |
+| \(\bar{\Phi}_k\) | [`Effect.maximum`](../api/fluxopt/elements.md#fluxopt.elements.Effect(maximum)) | \(\mathbb{R}\) | varies | Maximum aggregate (weighted sum across periods) |
+| \(\underline{\Phi}_k\) | [`Effect.minimum`](../api/fluxopt/elements.md#fluxopt.elements.Effect(minimum)) | \(\mathbb{R}\) | varies | Minimum aggregate (weighted sum across periods) |
+| \(\bar{\Phi}_k^{\text{per period}}\) | [`Effect.maximum_per_period`](../api/fluxopt/elements.md#fluxopt.elements.Effect(maximum_per_period)) | \(\mathbb{R}\) | varies | Maximum per period |
+| \(\underline{\Phi}_k^{\text{per period}}\) | [`Effect.minimum_per_period`](../api/fluxopt/elements.md#fluxopt.elements.Effect(minimum_per_period)) | \(\mathbb{R}\) | varies | Minimum per period |
+| \(\bar{\Phi}_{k,t}^{\text{per hour}}\) | [`Effect.maximum_per_hour`](../api/fluxopt/elements.md#fluxopt.elements.Effect(maximum_per_hour)) | \(\mathbb{R}\) | varies/h | Maximum per hour (rate, scaled by \(\Delta t_t\)) |
+| \(\underline{\Phi}_{k,t}^{\text{per hour}}\) | [`Effect.minimum_per_hour`](../api/fluxopt/elements.md#fluxopt.elements.Effect(minimum_per_hour)) | \(\mathbb{R}\) | varies/h | Minimum per hour (rate, scaled by \(\Delta t_t\)) |
+| \(\mathrm{S}^-\) | [`Sizing.min_size`](../api/fluxopt/elements.md#fluxopt.elements.Sizing(min_size)) | \(\geq 0\) | MW or MWh | Minimum invested size (flow or storage) |
+| \(\mathrm{S}^+\) | [`Sizing.max_size`](../api/fluxopt/elements.md#fluxopt.elements.Sizing(max_size)) | \(\geq 0\) | MW or MWh | Maximum invested size (flow or storage) |
+| \(\gamma_{f,k}\) | [`Sizing.effects_per_size`](../api/fluxopt/elements.md#fluxopt.elements.Sizing(effects_per_size)) | \(\mathbb{R}\) | varies | Per-size investment cost (one-time, sized) |
+| \(\phi_{f,k}\) | [`Sizing.effects_fixed`](../api/fluxopt/elements.md#fluxopt.elements.Sizing(effects_fixed)) | \(\mathbb{R}\) | varies | Fixed investment cost (one-time, sized) |
+| \(\gamma^{\text{build}}_{f,k}\) | [`Investment.effects_per_size_at_build`](../api/fluxopt/elements.md#fluxopt.elements.Investment(effects_per_size_at_build)) | \(\mathbb{R}\) | varies | Per-size CAPEX charged in the build period |
+| \(\phi^{\text{build}}_{f,k}\) | [`Investment.effects_fixed_at_build`](../api/fluxopt/elements.md#fluxopt.elements.Investment(effects_fixed_at_build)) | \(\mathbb{R}\) | varies | Fixed CAPEX charged in the build period |
+| \(\gamma^{\text{rec}}_{f,k}\) | [`Investment.effects_per_size_recurring`](../api/fluxopt/elements.md#fluxopt.elements.Investment(effects_per_size_recurring)) | \(\mathbb{R}\) | varies | Recurring per-size cost (each active period) |
+| \(\phi^{\text{rec}}_{f,k}\) | [`Investment.effects_fixed_recurring`](../api/fluxopt/elements.md#fluxopt.elements.Investment(effects_fixed_recurring)) | \(\mathbb{R}\) | varies | Recurring fixed cost (each active period) |
+| \(\mathrm{D}^{\text{up,min}}\) | [`Status.min_uptime`](../api/fluxopt/elements.md#fluxopt.elements.Status(min_uptime)) | \(\geq 0\) | h | Minimum consecutive uptime |
+| \(\mathrm{D}^{\text{up,max}}\) | [`Status.max_uptime`](../api/fluxopt/elements.md#fluxopt.elements.Status(max_uptime)) | \(\geq 0\) | h | Maximum consecutive uptime |
+| \(\mathrm{D}^{\text{down,min}}\) | [`Status.min_downtime`](../api/fluxopt/elements.md#fluxopt.elements.Status(min_downtime)) | \(\geq 0\) | h | Minimum consecutive downtime |
+| \(\mathrm{D}^{\text{down,max}}\) | [`Status.max_downtime`](../api/fluxopt/elements.md#fluxopt.elements.Status(max_downtime)) | \(\geq 0\) | h | Maximum consecutive downtime |
+| \(\mathrm{r}_{f,k,t}\) | [`Status.effects_per_running_hour`](../api/fluxopt/elements.md#fluxopt.elements.Status(effects_per_running_hour)) | \(\mathbb{R}\) | varies | Running cost coefficient |
+| \(\mathrm{u}_{f,k,t}\) | [`Status.effects_per_startup`](../api/fluxopt/elements.md#fluxopt.elements.Status(effects_per_startup)) | \(\mathbb{R}\) | varies | Startup cost coefficient |
 | \(\mathrm{w}_t\) | weights | \(> 0\) | — | Timestep weight |
 | \(\Delta t_t\) | dt | \(> 0\) | h | Timestep duration |
 | \(\omega_p\) | `Dims.period_weights` | \(> 0\) | — | Global period weight (multi-period only) |
-| \(\omega_{k,p}\) | `Effect.period_weights` | \(> 0\) | — | Per-effect period weight |
+| \(\omega_{k,p}\) | [`Effect.period_weights`](../api/fluxopt/elements.md#fluxopt.elements.Effect(period_weights)) | \(> 0\) | — | Per-effect period weight |
 
 ## Naming Conventions
 

--- a/docs/math/notation.md
+++ b/docs/math/notation.md
@@ -31,8 +31,8 @@ Each symbol maps to a specific field or variable in the code.
 | \(\sigma_{f,t(,p)}\) | `flow--on[flow, time(, period)]` | \(\{0, 1\}\) | — | On/off indicator |
 | \(\tau^+_{f,t(,p)}\) | `flow--startup[flow, time(, period)]` | \(\{0, 1\}\) | — | Startup event indicator |
 | \(\tau^-_{f,t(,p)}\) | `flow--shutdown[flow, time(, period)]` | \(\{0, 1\}\) | — | Shutdown event indicator |
-| \(D^{\text{up}}_{f,t(,p)}\) | `uptime[flow, time(, period)]` | \(\geq 0\) | h | Consecutive uptime |
-| \(D^{\text{down}}_{f,t(,p)}\) | `downtime[flow, time(, period)]` | \(\geq 0\) | h | Consecutive downtime |
+| \(\mathrm{D}^{\text{up}}_{f,t(,p)}\) | `uptime[flow, time(, period)]` | \(\geq 0\) | h | Consecutive uptime |
+| \(\mathrm{D}^{\text{down}}_{f,t(,p)}\) | `downtime[flow, time(, period)]` | \(\geq 0\) | h | Consecutive downtime |
 
 ## Indexing Convention
 
@@ -59,15 +59,15 @@ into pyramids of subscripts.
 The broadcast hierarchy:
 
 - **Period (\(p\))** — almost every parameter accepts this: even
-  "scalar" things like \(\bar{P}_f\), \(D^{\text{up,min}}\), or
-  \(S^-\) become \(\bar{P}_{f,p}\) etc. in multi-period models.
+  "scalar" things like \(\bar{\mathrm{P}}_f\), \(\mathrm{D}^{\text{up,min}}\), or
+  \(\mathrm{S}^-\) become \(\bar{\mathrm{P}}_{f,p}\) etc. in multi-period models.
   Variables already reflect this in the table above (e.g.
   \(P_{f,t(,p)}\)).
 - **Time (\(t\))** — only fields typed `TimeSeries` accept this: bounds
-  \(\underline{p}_{f,t}, \bar{p}_{f,t}\), profiles \(\pi_{f,t}\),
+  \(\underline{\mathrm{p}}_{f,t}, \bar{\mathrm{p}}_{f,t}\), profiles \(\pi_{f,t}\),
   efficiencies \(\eta^c_s, \eta^d_s\), losses \(\delta_s\), conversion
-  coefficients \(a_{f,i}\), effect / running / startup costs
-  \(c_{f,k,t}, r_{f,k,t}, u_{f,k,t}\), cross-effects \(\alpha_{k,j,t}\).
+  coefficients \(\mathrm{a}_{f,i}\), effect / running / startup costs
+  \(\mathrm{c}_{f,k,t}, \mathrm{r}_{f,k,t}, \mathrm{u}_{f,k,t}\), cross-effects \(\alpha_{k,j,t}\).
 - **Build period (\(p_b\))** — investment-domain coefficients only:
   \(\gamma^{\text{build}}_{f,k}, \phi^{\text{rec}}_{f,k}\), …
 
@@ -82,18 +82,18 @@ omit unless we're discussing multi-period dynamics specifically.
 
 | Symbol | Code | Domain | Unit | Description |
 |---|---|---|---|---|
-| \(\bar{P}_f\) | `Flow.size` | \(\geq 0\) or \(\infty\) | MW | Nominal capacity |
-| \(\underline{p}_{f,t}\) | `Flow.relative_minimum` | \([0, 1]\) | — | Relative lower bound |
-| \(\bar{p}_{f,t}\) | `Flow.relative_maximum` | \([0, 1]\) | — | Relative upper bound |
+| \(\bar{\mathrm{P}}_f\) | `Flow.size` | \(\geq 0\) or \(\infty\) | MW | Nominal capacity |
+| \(\underline{\mathrm{p}}_{f,t}\) | `Flow.relative_minimum` | \([0, 1]\) | — | Relative lower bound |
+| \(\bar{\mathrm{p}}_{f,t}\) | `Flow.relative_maximum` | \([0, 1]\) | — | Relative upper bound |
 | \(\pi_{f,t}\) | `Flow.fixed_relative_profile` | \([0, 1]\) | — | Fixed profile |
-| \(c_{f,k,t}\) | `Flow.effects_per_flow_hour` | \(\mathbb{R}\) | varies | Effect coefficient per flow-hour |
-| \(\bar{E}_s\) | `Storage.capacity` | \(\geq 0\) | MWh | Storage capacity |
+| \(\mathrm{c}_{f,k,t}\) | `Flow.effects_per_flow_hour` | \(\mathbb{R}\) | varies | Effect coefficient per flow-hour |
+| \(\bar{\mathrm{E}}_s\) | `Storage.capacity` | \(\geq 0\) | MWh | Storage capacity |
 | \(\eta^{\text{c}}_s\) | `Storage.eta_charge` | \((0, 1]\) | — | Charging efficiency |
 | \(\eta^{\text{d}}_s\) | `Storage.eta_discharge` | \((0, 1]\) | — | Discharging efficiency |
 | \(\delta_s\) | `Storage.relative_loss_per_hour` | \([0, 1]\) | 1/h | Self-discharge rate |
-| \(\underline{e}_s\) | `Storage.relative_minimum_level` | \([0, 1]\) | — | Relative min SOC |
-| \(\bar{e}_s\) | `Storage.relative_maximum_level` | \([0, 1]\) | — | Relative max SOC |
-| \(a_{f,i}\) | `Converter.conversion_factors` | \(\mathbb{R}\) | — | Conversion coefficient (per flow, per equation) |
+| \(\underline{\mathrm{e}}_s\) | `Storage.relative_minimum_level` | \([0, 1]\) | — | Relative min SOC |
+| \(\bar{\mathrm{e}}_s\) | `Storage.relative_maximum_level` | \([0, 1]\) | — | Relative max SOC |
+| \(\mathrm{a}_{f,i}\) | `Converter.conversion_factors` | \(\mathbb{R}\) | — | Conversion coefficient (per flow, per equation) |
 | \(\alpha_{k,j}\) | `Effect.contribution_from` | \(\mathbb{R}\) | varies | Cross-effect factor (scalar) |
 | \(\alpha_{k,j,t}\) | `Effect.contribution_from` (TimeSeries) | \(\mathbb{R}\) | varies | Cross-effect factor (time-varying; lump uses time-mean) |
 | \(\bar{\Phi}_k\) | `Effect.maximum` | \(\mathbb{R}\) | varies | Maximum aggregate (weighted sum across periods) |
@@ -102,21 +102,21 @@ omit unless we're discussing multi-period dynamics specifically.
 | \(\underline{\Phi}_k^{\text{per period}}\) | `Effect.minimum_per_period` | \(\mathbb{R}\) | varies | Minimum per period |
 | \(\bar{\Phi}_{k,t}^{\text{per hour}}\) | `Effect.maximum_per_hour` | \(\mathbb{R}\) | varies/h | Maximum per hour (rate, scaled by \(\Delta t_t\)) |
 | \(\underline{\Phi}_{k,t}^{\text{per hour}}\) | `Effect.minimum_per_hour` | \(\mathbb{R}\) | varies/h | Minimum per hour (rate, scaled by \(\Delta t_t\)) |
-| \(S^-\) | `Sizing.min_size` | \(\geq 0\) | MW or MWh | Minimum invested size (flow or storage) |
-| \(S^+\) | `Sizing.max_size` | \(\geq 0\) | MW or MWh | Maximum invested size (flow or storage) |
+| \(\mathrm{S}^-\) | `Sizing.min_size` | \(\geq 0\) | MW or MWh | Minimum invested size (flow or storage) |
+| \(\mathrm{S}^+\) | `Sizing.max_size` | \(\geq 0\) | MW or MWh | Maximum invested size (flow or storage) |
 | \(\gamma_{f,k}\) | `Sizing.effects_per_size` | \(\mathbb{R}\) | varies | Per-size investment cost (one-time, sized) |
 | \(\phi_{f,k}\) | `Sizing.effects_fixed` | \(\mathbb{R}\) | varies | Fixed investment cost (one-time, sized) |
 | \(\gamma^{\text{build}}_{f,k}\) | `Investment.effects_per_size_at_build` | \(\mathbb{R}\) | varies | Per-size CAPEX charged in the build period |
 | \(\phi^{\text{build}}_{f,k}\) | `Investment.effects_fixed_at_build` | \(\mathbb{R}\) | varies | Fixed CAPEX charged in the build period |
 | \(\gamma^{\text{rec}}_{f,k}\) | `Investment.effects_per_size_recurring` | \(\mathbb{R}\) | varies | Recurring per-size cost (each active period) |
 | \(\phi^{\text{rec}}_{f,k}\) | `Investment.effects_fixed_recurring` | \(\mathbb{R}\) | varies | Recurring fixed cost (each active period) |
-| \(D^{\text{up,min}}\) | `Status.min_uptime` | \(\geq 0\) | h | Minimum consecutive uptime |
-| \(D^{\text{up,max}}\) | `Status.max_uptime` | \(\geq 0\) | h | Maximum consecutive uptime |
-| \(D^{\text{down,min}}\) | `Status.min_downtime` | \(\geq 0\) | h | Minimum consecutive downtime |
-| \(D^{\text{down,max}}\) | `Status.max_downtime` | \(\geq 0\) | h | Maximum consecutive downtime |
-| \(r_{f,k,t}\) | `Status.effects_per_running_hour` | \(\mathbb{R}\) | varies | Running cost coefficient |
-| \(u_{f,k,t}\) | `Status.effects_per_startup` | \(\mathbb{R}\) | varies | Startup cost coefficient |
-| \(w_t\) | weights | \(> 0\) | — | Timestep weight |
+| \(\mathrm{D}^{\text{up,min}}\) | `Status.min_uptime` | \(\geq 0\) | h | Minimum consecutive uptime |
+| \(\mathrm{D}^{\text{up,max}}\) | `Status.max_uptime` | \(\geq 0\) | h | Maximum consecutive uptime |
+| \(\mathrm{D}^{\text{down,min}}\) | `Status.min_downtime` | \(\geq 0\) | h | Minimum consecutive downtime |
+| \(\mathrm{D}^{\text{down,max}}\) | `Status.max_downtime` | \(\geq 0\) | h | Maximum consecutive downtime |
+| \(\mathrm{r}_{f,k,t}\) | `Status.effects_per_running_hour` | \(\mathbb{R}\) | varies | Running cost coefficient |
+| \(\mathrm{u}_{f,k,t}\) | `Status.effects_per_startup` | \(\mathbb{R}\) | varies | Startup cost coefficient |
+| \(\mathrm{w}_t\) | weights | \(> 0\) | — | Timestep weight |
 | \(\Delta t_t\) | dt | \(> 0\) | h | Timestep duration |
 | \(\omega_p\) | `Dims.period_weights` | \(> 0\) | — | Global period weight (multi-period only) |
 | \(\omega_{k,p}\) | `Effect.period_weights` | \(> 0\) | — | Per-effect period weight |

--- a/docs/math/notation.md
+++ b/docs/math/notation.md
@@ -36,11 +36,18 @@ Each symbol maps to a specific field or variable in the code.
 
 ## Indexing Convention
 
-Symbol subscripts show only the indices the formulation **structurally
-requires** — the dims a constraint iterates over and that change its
-meaning. Most parameters may also **broadcast over additional dims**
-in the API; we don't decorate the symbols with every dim they *could*
-take, because that turns formulas into pyramids of subscripts.
+**Variables** (the table above) are shown with **all** dimensions they
+live on. There's no broadcasting for decision variables — every
+\((\text{flow}, \text{time}, \ldots)\) cell is its own variable. The
+`(,p)` notation marks the period dim as optional (present in
+multi-period models, absent otherwise); scenarios would add `(,s)`.
+
+**Parameters** are different. Symbol subscripts show only the indices
+the formulation **structurally requires** — the dims a constraint
+iterates over and that change its meaning. Most parameters also
+**broadcast over additional dims** in the API; we don't decorate the
+symbols with every dim they *could* take, because that turns formulas
+into pyramids of subscripts.
 
 The broadcast hierarchy:
 

--- a/docs/math/notation.md
+++ b/docs/math/notation.md
@@ -34,6 +34,39 @@ Each symbol maps to a specific field or variable in the code.
 | \(D^{\text{up}}_{f,t(,p)}\) | `uptime[flow, time(, period)]` | \(\geq 0\) | h | Consecutive uptime |
 | \(D^{\text{down}}_{f,t(,p)}\) | `downtime[flow, time(, period)]` | \(\geq 0\) | h | Consecutive downtime |
 
+## Indexing Convention
+
+Symbol subscripts show only the indices the formulation **structurally
+requires** — i.e. the dims a constraint iterates over and that change
+its meaning. Most parameters may also **broadcast over time (and
+period)** in the API: anywhere a field is typed `TimeSeries`, you can
+pass a scalar (broadcast) or an array (per-timestep). To keep formulas
+readable, we don't decorate every parameter with every dimension it
+*can* take.
+
+A rough taxonomy of the parameters below:
+
+- **Inherently scalar** (per object — flow, storage, converter):
+  nominal capacity \(\bar{P}_f\), storage capacity \(\bar{E}_s\),
+  sizing bounds \(S^-, S^+\), min/max run durations
+  \(D^{\text{up,min}}, D^{\text{down,max}}, …\). These don't have a
+  meaningful time dependence.
+- **May broadcast over \(t\)** (`TimeSeries` in the API):
+  efficiencies \(\eta^c_s, \eta^d_s\), self-discharge \(\delta_s\),
+  conversion coefficients \(a_{f,i}\), bounds and profiles
+  \(\underline{p}_{f,t}, \bar{p}_{f,t}, \pi_{f,t}\), effect / running /
+  startup costs \(c_{f,k,t}, r_{f,k,t}, u_{f,k,t}\), cross-effects
+  \(\alpha_{k,j,t}\). We show the \(t\) index only where it's
+  structurally important to the constraint (e.g. profiles, where time
+  variation is the whole point).
+- **Per period only** (multi-period models): period weights
+  \(\omega_p, \omega_{k,p}\); investment-domain coefficients
+  (\(\gamma^{\text{build}}_{f,k}, \phi^{\text{rec}}_{f,k}, …\)) attach
+  to a build period rather than to time.
+
+Absence of a \(t\) subscript on a parameter doesn't mean it must be
+scalar — check the API field's type.
+
 ## Parameters
 
 | Symbol | Code | Domain | Unit | Description |
@@ -49,7 +82,7 @@ Each symbol maps to a specific field or variable in the code.
 | \(\delta_s\) | `Storage.relative_loss_per_hour` | \([0, 1]\) | 1/h | Self-discharge rate |
 | \(\underline{e}_s\) | `Storage.relative_minimum_level` | \([0, 1]\) | — | Relative min SOC |
 | \(\bar{e}_s\) | `Storage.relative_maximum_level` | \([0, 1]\) | — | Relative max SOC |
-| \(a_{f}\) | `Converter.conversion_factors` | \(\mathbb{R}\) | — | Conversion coefficient |
+| \(a_{f,i}\) | `Converter.conversion_factors` | \(\mathbb{R}\) | — | Conversion coefficient (per flow, per equation) |
 | \(\alpha_{k,j}\) | `Effect.contribution_from` | \(\mathbb{R}\) | varies | Cross-effect factor (scalar) |
 | \(\alpha_{k,j,t}\) | `Effect.contribution_from` (TimeSeries) | \(\mathbb{R}\) | varies | Cross-effect factor (time-varying; lump uses time-mean) |
 | \(\bar{\Phi}_k\) | `Effect.maximum` | \(\mathbb{R}\) | varies | Maximum aggregate (weighted sum across periods) |

--- a/docs/math/notation.md
+++ b/docs/math/notation.md
@@ -123,11 +123,19 @@ omit unless we're discussing multi-period dynamics specifically.
 
 ## Naming Conventions
 
+**Italic letters denote decision variables; upright (`\mathrm{}`) letters
+denote parameters** — following ISO 80000-2. So \(P_{f,t}\) (italic) is the
+flow rate variable, while \(\bar{\mathrm{P}}_f\) (upright with overbar) is the
+parameter that bounds it.
+
 | Convention | Meaning | Example |
 |---|---|---|
-| Uppercase Latin | Decision variables | \(P\) (power/flow rate), \(E\) (stored energy) |
-| Lowercase Latin | Relative/dimensionless parameters | \(\underline{p}\) (rel. min), \(\bar{p}\) (rel. max) |
-| Greek | Physical properties | \(\eta\) (efficiency), \(\delta\) (loss rate) |
-| Overbar / underbar | Bounds | \(\bar{P}\) (capacity), \(\underline{P}\) (lower bound) |
+| Italic (default math mode) | Decision variables | \(P\) (flow rate), \(E\) (stored energy), \(S\) (size) |
+| Upright (`\mathrm{}`) | Parameters | \(\mathrm{c}_{f,k,t}\) (cost coefficient), \(\bar{\mathrm{P}}_f\) (capacity), \(\mathrm{a}_{f,i}\) (conversion coefficient) |
+| Overbar / underbar | Bound (paired with the variable's letter) | \(\bar{\mathrm{P}}\) (upper bound on \(P\)), \(\underline{\mathrm{P}}\) (lower bound) |
+| Greek | Parameters with established physical meaning | \(\eta\) (efficiency), \(\delta\) (loss), \(\pi\) (profile), \(\gamma\) (per-size cost) |
 | Subscripts | Indexing | \(f\) (flow), \(t\) (time), \(s\) (storage), \(b\) (bus), \(k\) (effect), \(j\) (source effect) |
 | Superscripts | Qualification | \(\eta^{\text{c}}\) (charge), \(\eta^{\text{d}}\) (discharge) |
+
+Greek letters render with their conventional shape regardless of `\mathrm{}`,
+so we use them as-is for parameters without further wrapping.

--- a/docs/math/objective.md
+++ b/docs/math/objective.md
@@ -18,7 +18,7 @@ Without periods, the objective is simply:
 With periods \(p \in \mathcal{P}\), the objective weights each period's total effect:
 
 \[
-\min \; \sum_{p \in \mathcal{P}} \omega_{k^*,p} \cdot \left(\sum_t \Phi_{k^*,t,p}^{\text{temporal}} \cdot w_t + \Phi_{k^*,p}^{\text{lump}}\right)
+\min \; \sum_{p \in \mathcal{P}} \omega_{k^*,p} \cdot \left(\sum_t \Phi_{k^*,t,p}^{\text{temporal}} \cdot \mathrm{w}_t + \Phi_{k^*,p}^{\text{lump}}\right)
 \]
 
 - \(\omega_{k,p}\) defaults to the global `period_weights` (inferred from
@@ -32,14 +32,14 @@ flat weights for emissions).
 The total effect per period combines both domains:
 
 \[
-\Phi_{k(,p)} = \sum_{t \in \mathcal{T}} \Phi_{k,t(,p)}^{\text{temporal}} \cdot w_t + \Phi_{k(,p)}^{\text{lump}}
+\Phi_{k(,p)} = \sum_{t \in \mathcal{T}} \Phi_{k,t(,p)}^{\text{temporal}} \cdot \mathrm{w}_t + \Phi_{k(,p)}^{\text{lump}}
 \]
 
 The **temporal** domain accumulates flow contributions, running costs,
 startup costs, and cross-effect contributions per timestep:
 
 \[
-\Phi_{k,t}^{\text{temporal}} = \underbrace{\sum_{f} c_{f,k,t} \cdot P_{f,t} \cdot \Delta t_t}_{\text{flow}} + \underbrace{\sum_{f} r_{f,k,t} \cdot \sigma_{f,t} \cdot \Delta t_t}_{\text{running}} + \underbrace{\sum_{f} u_{f,k,t} \cdot \tau^+_{f,t}}_{\text{startup}} + \underbrace{\sum_{j} \alpha_{k,j,t} \cdot \Phi_{j,t}^{\text{temporal}}}_{\text{cross-effect}}
+\Phi_{k,t}^{\text{temporal}} = \underbrace{\sum_{f} \mathrm{c}_{f,k,t} \cdot P_{f,t} \cdot \Delta t_t}_{\text{flow}} + \underbrace{\sum_{f} \mathrm{r}_{f,k,t} \cdot \sigma_{f,t} \cdot \Delta t_t}_{\text{running}} + \underbrace{\sum_{f} \mathrm{u}_{f,k,t} \cdot \tau^+_{f,t}}_{\text{startup}} + \underbrace{\sum_{j} \alpha_{k,j,t} \cdot \Phi_{j,t}^{\text{temporal}}}_{\text{cross-effect}}
 \]
 
 The **lump** domain accumulates sizing costs, fixed costs, one-time costs, and cross-effect contributions:
@@ -56,10 +56,10 @@ full formulations of each term.
 | Symbol | Description | Reference |
 |---|---|---|
 | \(k^*\) | Objective effect | `optimize(objective_effects='cost')` |
-| \(c_{f,k,t}\) | Effect coefficient per flow-hour | `Flow.effects_per_flow_hour` |
+| \(\mathrm{c}_{f,k,t}\) | Effect coefficient per flow-hour | `Flow.effects_per_flow_hour` |
 | \(P_{f,t}\) | Flow rate variable | `flow--rate[flow, time]` |
 | \(\Delta t_t\) | Timestep duration | dt |
-| \(w_t\) | Timestep weight | weights |
+| \(\mathrm{w}_t\) | Timestep weight | weights |
 | \(\omega_{k,p}\) | Period weight | `Effect.period_weights` (fallback: `Dims.period_weights`) |
 | \(\Phi_{k,t(,p)}^{\text{temporal}}\) | Temporal (per-timestep) effect variable | `effect--temporal[effect, time(, period)]` |
 | \(\Phi_{k(,p)}^{\text{lump}}\) | Lump effect variable (sizing + one-time costs) | `effect--lump[effect(, period)]` |
@@ -73,7 +73,7 @@ See [Notation](notation.md) for the full symbol table.
 
 Consider a gas boiler over 3 timesteps (\(\Delta t = 1\,\text{h}\), \(w = 1\)):
 
-| \(t\) | \(P_{\text{gas},t}\) (MW) | \(c_{\text{gas,cost}}\) (€/MWh) | \(\Phi_{\text{cost},t}^{\text{temporal}}\) (€) |
+| \(t\) | \(P_{\text{gas},t}\) (MW) | \(\mathrm{c}_{\text{gas,cost}}\) (€/MWh) | \(\Phi_{\text{cost},t}^{\text{temporal}}\) (€) |
 |---|---|---|---|
 | 1 | 2.0 | 30 | \(30 \times 2.0 \times 1 = 60\) |
 | 2 | 3.0 | 30 | \(30 \times 3.0 \times 1 = 90\) |

--- a/docs/math/objective.md
+++ b/docs/math/objective.md
@@ -56,11 +56,11 @@ full formulations of each term.
 | Symbol | Description | Reference |
 |---|---|---|
 | \(k^*\) | Objective effect | `optimize(objective_effects='cost')` |
-| \(\mathrm{c}_{f,k,t}\) | Effect coefficient per flow-hour | `Flow.effects_per_flow_hour` |
+| \(\mathrm{c}_{f,k,t}\) | Effect coefficient per flow-hour | [`Flow.effects_per_flow_hour`](../api/fluxopt/elements.md#fluxopt.elements.Flow(effects_per_flow_hour)) |
 | \(P_{f,t}\) | Flow rate variable | `flow--rate[flow, time]` |
 | \(\Delta t_t\) | Timestep duration | dt |
 | \(\mathrm{w}_t\) | Timestep weight | weights |
-| \(\omega_{k,p}\) | Period weight | `Effect.period_weights` (fallback: `Dims.period_weights`) |
+| \(\omega_{k,p}\) | Period weight | [`Effect.period_weights`](../api/fluxopt/elements.md#fluxopt.elements.Effect(period_weights)) (fallback: [`optimize(period_weights=...)`](../api/fluxopt/index.md#fluxopt.optimize(period_weights))) |
 | \(\Phi_{k,t(,p)}^{\text{temporal}}\) | Temporal (per-timestep) effect variable | `effect--temporal[effect, time(, period)]` |
 | \(\Phi_{k(,p)}^{\text{lump}}\) | Lump effect variable (sizing + one-time costs) | `effect--lump[effect(, period)]` |
 | \(\Phi_{k(,p)}\) | Total effect variable | `effect--total[effect(, period)]` |

--- a/docs/math/sizing.md
+++ b/docs/math/sizing.md
@@ -123,9 +123,9 @@ for the constraints.
 | \(S_f\) | Flow capacity variable | `flow--size[flow]` |
 | \(S_s\) | Storage capacity variable | `storage--capacity[storage]` |
 | \(y_f\), \(y_s\) | Binary invest indicator | `flow--size_indicator`, `storage--size_indicator` |
-| \(\mathrm{S}^-\) | Minimum size | `Sizing.min_size` |
-| \(\mathrm{S}^+\) | Maximum size | `Sizing.max_size` |
-| \(\gamma_{f,k}\) | Per-size investment cost | `Sizing.effects_per_size` |
-| \(\phi_{f,k}\) | Fixed investment cost | `Sizing.effects_fixed` |
+| \(\mathrm{S}^-\) | Minimum size | [`Sizing.min_size`](../api/fluxopt/elements.md#fluxopt.elements.Sizing(min_size)) |
+| \(\mathrm{S}^+\) | Maximum size | [`Sizing.max_size`](../api/fluxopt/elements.md#fluxopt.elements.Sizing(max_size)) |
+| \(\gamma_{f,k}\) | Per-size investment cost | [`Sizing.effects_per_size`](../api/fluxopt/elements.md#fluxopt.elements.Sizing(effects_per_size)) |
+| \(\phi_{f,k}\) | Fixed investment cost | [`Sizing.effects_fixed`](../api/fluxopt/elements.md#fluxopt.elements.Sizing(effects_fixed)) |
 
 See [Notation](notation.md) for the full symbol table.

--- a/docs/math/sizing.md
+++ b/docs/math/sizing.md
@@ -10,10 +10,10 @@ dispatch simultaneously.
 
 | Symbol | Code | Domain | Description |
 |---|---|---|---|
-| \(S_f\) | `flow_size[flow]` | \(\geq 0\) | Invested flow capacity |
-| \(y_f\) | `flow_size_indicator[flow]` | \(\{0, 1\}\) | Binary: invest yes/no (optional only) |
-| \(S_s\) | `storage_capacity[storage]` | \(\geq 0\) | Invested storage capacity |
-| \(y_s\) | `storage_size_indicator[storage]` | \(\{0, 1\}\) | Binary: invest yes/no (optional only) |
+| \(S_f\) | `flow--size[flow]` | \(\geq 0\) | Invested flow capacity |
+| \(y_f\) | `flow--size_indicator[flow]` | \(\{0, 1\}\) | Binary: invest yes/no (optional only) |
+| \(S_s\) | `storage--capacity[storage]` | \(\geq 0\) | Invested storage capacity |
+| \(y_s\) | `storage--size_indicator[storage]` | \(\{0, 1\}\) | Binary: invest yes/no (optional only) |
 
 ## Mandatory Sizing
 
@@ -120,9 +120,9 @@ for the constraints.
 
 | Symbol | Description | Reference |
 |---|---|---|
-| \(S_f\) | Flow capacity variable | `flow_size[flow]` |
-| \(S_s\) | Storage capacity variable | `storage_capacity[storage]` |
-| \(y_f\), \(y_s\) | Binary invest indicator | `flow_size_indicator`, `storage_size_indicator` |
+| \(S_f\) | Flow capacity variable | `flow--size[flow]` |
+| \(S_s\) | Storage capacity variable | `storage--capacity[storage]` |
+| \(y_f\), \(y_s\) | Binary invest indicator | `flow--size_indicator`, `storage--size_indicator` |
 | \(\mathrm{S}^-\) | Minimum size | `Sizing.min_size` |
 | \(\mathrm{S}^+\) | Maximum size | `Sizing.max_size` |
 | \(\gamma_{f,k}\) | Per-size investment cost | `Sizing.effects_per_size` |

--- a/docs/math/sizing.md
+++ b/docs/math/sizing.md
@@ -3,7 +3,7 @@
 ## Overview
 
 Sizing introduces a capacity decision variable \(S\) that replaces the fixed
-nominal capacity \(\bar{P}_f\). The solver optimizes both the capacity and the
+nominal capacity \(\bar{\mathrm{P}}_f\). The solver optimizes both the capacity and the
 dispatch simultaneously.
 
 ## Variables
@@ -20,10 +20,10 @@ dispatch simultaneously.
 When `mandatory=True`, the component must be built. The capacity is continuous:
 
 \[
-S^- \leq S_f \leq S^+ \quad \text{(mandatory)}
+\mathrm{S}^- \leq S_f \leq \mathrm{S}^+ \quad \text{(mandatory)}
 \]
 
-where \(S^-\) = `min_size` and \(S^+\) = `max_size`. No binary variable is needed,
+where \(\mathrm{S}^-\) = `min_size` and \(\mathrm{S}^+\) = `max_size`. No binary variable is needed,
 so the problem is faster to solve:
 
 ## Optional Sizing
@@ -31,25 +31,25 @@ so the problem is faster to solve:
 When `mandatory=False`, a binary indicator \(y_f\) gates the capacity:
 
 \[
-S^- \cdot y_f \leq S_f \leq S^+ \cdot y_f
+\mathrm{S}^- \cdot y_f \leq S_f \leq \mathrm{S}^+ \cdot y_f
 \]
 
-When \(y_f = 0\): \(S_f = 0\) (not built). When \(y_f = 1\): \(S_f \in [S^-, S^+]\).
+When \(y_f = 0\): \(S_f = 0\) (not built). When \(y_f = 1\): \(S_f \in [\mathrm{S}^-, \mathrm{S}^+]\).
 Use this when you need `effects_fixed` (one-time costs gated by the indicator)
 or when `min_size > 0` must be enforced only if built:
 
 ### Binary Invest
 
-When \(S^- = S^+\), the sizing reduces to a binary yes/no decision at exactly
+When \(\mathrm{S}^- = \mathrm{S}^+\), the sizing reduces to a binary yes/no decision at exactly
 that capacity:
 
 ## Flow Rate Bounds with Sizing
 
-With sizing, the fixed capacity \(\bar{P}_f\) is replaced by the variable \(S_f\).
+With sizing, the fixed capacity \(\bar{\mathrm{P}}_f\) is replaced by the variable \(S_f\).
 The relative bounds scale by the invested size:
 
 \[
-S_f \cdot \underline{p}_{f,t} \leq P_{f,t} \leq S_f \cdot \bar{p}_{f,t} \quad \forall \, t
+S_f \cdot \underline{\mathrm{p}}_{f,t} \leq P_{f,t} \leq S_f \cdot \bar{\mathrm{p}}_{f,t} \quad \forall \, t
 \]
 
 Similarly for fixed profiles:
@@ -63,7 +63,7 @@ P_{f,t} = S_f \cdot \pi_{f,t} \quad \forall \, t
 The same pattern applies to storage capacity. The charge state bounds become:
 
 \[
-S_s \cdot \underline{e}_s \leq E_{s,t} \leq S_s \cdot \bar{e}_s \quad \forall \, t
+S_s \cdot \underline{\mathrm{e}}_s \leq E_{s,t} \leq S_s \cdot \bar{\mathrm{e}}_s \quad \forall \, t
 \]
 
 ## Investment Effects
@@ -123,8 +123,8 @@ for the constraints.
 | \(S_f\) | Flow capacity variable | `flow_size[flow]` |
 | \(S_s\) | Storage capacity variable | `storage_capacity[storage]` |
 | \(y_f\), \(y_s\) | Binary invest indicator | `flow_size_indicator`, `storage_size_indicator` |
-| \(S^-\) | Minimum size | `Sizing.min_size` |
-| \(S^+\) | Maximum size | `Sizing.max_size` |
+| \(\mathrm{S}^-\) | Minimum size | `Sizing.min_size` |
+| \(\mathrm{S}^+\) | Maximum size | `Sizing.max_size` |
 | \(\gamma_{f,k}\) | Per-size investment cost | `Sizing.effects_per_size` |
 | \(\phi_{f,k}\) | Fixed investment cost | `Sizing.effects_fixed` |
 

--- a/docs/math/sizing.md
+++ b/docs/math/sizing.md
@@ -75,7 +75,7 @@ Investment costs contribute to effect totals. For each effect \(k\):
 Cost proportional to the invested size (e.g. €/MW):
 
 \[
-\Phi_k^{\text{invest,per\_size}} = \sum_{f} \gamma_{f,k} \cdot S_f + \sum_{s} \gamma_{s,k} \cdot S_s
+\Phi_k^{\text{invest,perSize}} = \sum_{f} \gamma_{f,k} \cdot S_f + \sum_{s} \gamma_{s,k} \cdot S_s
 \]
 
 where \(\gamma_{f,k}\) is `Sizing.effects_per_size[k]`.
@@ -96,7 +96,7 @@ where \(\phi_{f,k}\) is `Sizing.effects_fixed[k]`. Only applies when
 The direct investment contribution to effect \(k\) is:
 
 \[
-\Phi_k^{\text{invest}} = \Phi_k^{\text{invest,per\_size}} + \Phi_k^{\text{invest,fixed}}
+\Phi_k^{\text{invest}} = \Phi_k^{\text{invest,perSize}} + \Phi_k^{\text{invest,fixed}}
 \]
 
 This feeds into the [effect total](effects.md) equation and can be further

--- a/docs/math/sizing.md
+++ b/docs/math/sizing.md
@@ -26,14 +26,6 @@ S^- \leq S_f \leq S^+ \quad \text{(mandatory)}
 where \(S^-\) = `min_size` and \(S^+\) = `max_size`. No binary variable is needed,
 so the problem is faster to solve:
 
-```python
-# Always built, size in [50, 200] MW
-Flow('elec', size=Sizing(min_size=50, max_size=200))
-
-# min_size=0 lets the solver pick size=0 without a binary variable
-Flow('elec', size=Sizing(min_size=0, max_size=200))
-```
-
 ## Optional Sizing
 
 When `mandatory=False`, a binary indicator \(y_f\) gates the capacity:
@@ -46,20 +38,10 @@ When \(y_f = 0\): \(S_f = 0\) (not built). When \(y_f = 1\): \(S_f \in [S^-, S^+
 Use this when you need `effects_fixed` (one-time costs gated by the indicator)
 or when `min_size > 0` must be enforced only if built:
 
-```python
-# Built at [50, 200] MW or not built at all
-Flow('elec', size=Sizing(min_size=50, max_size=200, mandatory=False))
-```
-
 ### Binary Invest
 
 When \(S^- = S^+\), the sizing reduces to a binary yes/no decision at exactly
 that capacity:
-
-```python
-# Either build a 100 MW unit or nothing
-Flow('elec', size=Sizing(min_size=100, max_size=100, mandatory=False))
-```
 
 ## Flow Rate Bounds with Sizing
 
@@ -98,11 +80,6 @@ Cost proportional to the invested size (e.g. €/MW):
 
 where \(\gamma_{f,k}\) is `Sizing.effects_per_size[k]`.
 
-```python
-# 500 €/MW investment cost
-Flow('elec', size=Sizing(min_size=50, max_size=200, effects_per_size={'cost': 500}))
-```
-
 ### Fixed
 
 One-time cost charged when the component is built, gated by the binary indicator:
@@ -113,15 +90,6 @@ One-time cost charged when the component is built, gated by the binary indicator
 
 where \(\phi_{f,k}\) is `Sizing.effects_fixed[k]`. Only applies when
 `mandatory=False` (binary indicator exists).
-
-```python
-# 10,000 € fixed cost if built, plus 500 €/MW
-Flow('elec', size=Sizing(
-    min_size=50, max_size=200, mandatory=False,
-    effects_per_size={'cost': 500},
-    effects_fixed={'cost': 10_000},
-))
-```
 
 ### Total
 

--- a/docs/math/status.md
+++ b/docs/math/status.md
@@ -25,9 +25,9 @@ With fixed size, the on/off indicator gates the flow rate bounds:
 \]
 
 When \(\sigma_{f,t} = 0\): \(P_{f,t} = 0\). When \(\sigma_{f,t} = 1\):
-\(P_{f,t} \in [\bar{\mathrm{P}}_f \underline{\mathrm{p}}, \bar{\mathrm{P}}_f \bar{\mathrm{p}}]\).
+\(P_{f,t} \in [\bar{\mathrm{P}}_f \underline{\mathrm{p}}_{f,t}, \bar{\mathrm{P}}_f \bar{\mathrm{p}}_{f,t}]\).
 
-This gives the semi-continuous behavior \(\{0\} \cup [\underline{\mathrm{P}}, \bar{\mathrm{P}}]\).
+This gives the semi-continuous behavior \(\{0\} \cup [\underline{\mathrm{P}}_{f,t}, \bar{\mathrm{P}}_{f,t}]\).
 
 ## Switch Transitions
 

--- a/docs/math/status.md
+++ b/docs/math/status.md
@@ -184,12 +184,12 @@ An additional constraint prevents the unit from being "on" with zero size:
 | \(\tau^-_{f,t}\) | Shutdown indicator | `flow--shutdown[flow, time]` |
 | \(\mathrm{D}^{\text{up}}_{f,t}\) | Consecutive uptime | `uptime[flow, time]` |
 | \(\mathrm{D}^{\text{down}}_{f,t}\) | Consecutive downtime | `downtime[flow, time]` |
-| \(\mathrm{D}^{\text{up,min}}\) | Minimum uptime | `Status.min_uptime` |
-| \(\mathrm{D}^{\text{up,max}}\) | Maximum uptime | `Status.max_uptime` |
-| \(\mathrm{D}^{\text{down,min}}\) | Minimum downtime | `Status.min_downtime` |
-| \(\mathrm{D}^{\text{down,max}}\) | Maximum downtime | `Status.max_downtime` |
-| \(\mathrm{r}_{f,k,t}\) | Running cost coefficient | `Status.effects_per_running_hour` |
-| \(\mathrm{u}_{f,k,t}\) | Startup cost coefficient | `Status.effects_per_startup` |
+| \(\mathrm{D}^{\text{up,min}}\) | Minimum uptime | [`Status.min_uptime`](../api/fluxopt/elements.md#fluxopt.elements.Status(min_uptime)) |
+| \(\mathrm{D}^{\text{up,max}}\) | Maximum uptime | [`Status.max_uptime`](../api/fluxopt/elements.md#fluxopt.elements.Status(max_uptime)) |
+| \(\mathrm{D}^{\text{down,min}}\) | Minimum downtime | [`Status.min_downtime`](../api/fluxopt/elements.md#fluxopt.elements.Status(min_downtime)) |
+| \(\mathrm{D}^{\text{down,max}}\) | Maximum downtime | [`Status.max_downtime`](../api/fluxopt/elements.md#fluxopt.elements.Status(max_downtime)) |
+| \(\mathrm{r}_{f,k,t}\) | Running cost coefficient | [`Status.effects_per_running_hour`](../api/fluxopt/elements.md#fluxopt.elements.Status(effects_per_running_hour)) |
+| \(\mathrm{u}_{f,k,t}\) | Startup cost coefficient | [`Status.effects_per_startup`](../api/fluxopt/elements.md#fluxopt.elements.Status(effects_per_startup)) |
 | \(M\) | Big-M (horizon length) | computed |
 
 See [Notation](notation.md) for the full symbol table.

--- a/docs/math/status.md
+++ b/docs/math/status.md
@@ -10,9 +10,9 @@ variables enforce minimum and maximum consecutive up- and downtime.
 
 | Symbol | Code | Domain | Description |
 |---|---|---|---|
-| \(\sigma_{f,t}\) | `flow_on[flow, time]` | \(\{0, 1\}\) | On/off indicator |
-| \(\tau^+_{f,t}\) | `flow_startup[flow, time]` | \(\{0, 1\}\) | Startup event indicator |
-| \(\tau^-_{f,t}\) | `flow_shutdown[flow, time]` | \(\{0, 1\}\) | Shutdown event indicator |
+| \(\sigma_{f,t}\) | `flow--on[flow, time]` | \(\{0, 1\}\) | On/off indicator |
+| \(\tau^+_{f,t}\) | `flow--startup[flow, time]` | \(\{0, 1\}\) | Startup event indicator |
+| \(\tau^-_{f,t}\) | `flow--shutdown[flow, time]` | \(\{0, 1\}\) | Shutdown event indicator |
 | \(\mathrm{D}^{\text{up}}_{f,t}\) | `uptime[flow, time]` | \(\geq 0\) | Consecutive uptime [h] |
 | \(\mathrm{D}^{\text{down}}_{f,t}\) | `downtime[flow, time]` | \(\geq 0\) | Consecutive downtime [h] |
 
@@ -179,9 +179,9 @@ An additional constraint prevents the unit from being "on" with zero size:
 
 | Symbol | Description | Reference |
 |---|---|---|
-| \(\sigma_{f,t}\) | On/off binary | `flow_on[flow, time]` |
-| \(\tau^+_{f,t}\) | Startup indicator | `flow_startup[flow, time]` |
-| \(\tau^-_{f,t}\) | Shutdown indicator | `flow_shutdown[flow, time]` |
+| \(\sigma_{f,t}\) | On/off binary | `flow--on[flow, time]` |
+| \(\tau^+_{f,t}\) | Startup indicator | `flow--startup[flow, time]` |
+| \(\tau^-_{f,t}\) | Shutdown indicator | `flow--shutdown[flow, time]` |
 | \(\mathrm{D}^{\text{up}}_{f,t}\) | Consecutive uptime | `uptime[flow, time]` |
 | \(\mathrm{D}^{\text{down}}_{f,t}\) | Consecutive downtime | `downtime[flow, time]` |
 | \(\mathrm{D}^{\text{up,min}}\) | Minimum uptime | `Status.min_uptime` |

--- a/docs/math/status.md
+++ b/docs/math/status.md
@@ -100,23 +100,11 @@ Maximum duration is enforced as an upper bound on the duration variable itself.
 Duration values are in **hours**. With sub-hourly timesteps (e.g., `dt=0.5`),
 a `min_uptime=2` means the unit must stay on for 4 consecutive timesteps.
 
-```python
-Status(min_uptime=3, max_uptime=8, min_downtime=2)
-```
-
 ### Previous Duration Carryover
 
 `Flow.prior_rates` provides the flow rates from timesteps **before** the
 optimization horizon. This lets the solver know the initial on/off state
 and how long the unit has been running or idle:
-
-```python
-# Unit was running at 80 MW in the previous timestep
-Flow('heat', size=100, status=Status(min_uptime=3), prior_rates=[80])
-
-# Unit was off in the previous 2 timesteps
-Flow('heat', size=100, status=Status(min_downtime=2), prior_rates=[0, 0])
-```
 
 The prior rates determine:
 
@@ -149,11 +137,6 @@ A per-hour cost while the unit is on, independent of the flow rate:
 
 where \(r_{f,k,t}\) is `Status.effects_per_running_hour[k]`.
 
-```python
-# 5 €/h while running (regardless of load)
-Flow('heat', size=100, status=Status(effects_per_running_hour={'cost': 5}))
-```
-
 ### Startup Costs
 
 A one-time cost charged each time the unit switches from off to on:
@@ -163,11 +146,6 @@ A one-time cost charged each time the unit switches from off to on:
 \]
 
 where \(u_{f,k,t}\) is `Status.effects_per_startup[k]`.
-
-```python
-# 50 € per startup event
-Flow('heat', size=100, status=Status(effects_per_startup={'cost': 50}))
-```
 
 Both feed into the [per-timestep effect equation](effects.md).
 

--- a/docs/math/status.md
+++ b/docs/math/status.md
@@ -13,21 +13,21 @@ variables enforce minimum and maximum consecutive up- and downtime.
 | \(\sigma_{f,t}\) | `flow_on[flow, time]` | \(\{0, 1\}\) | On/off indicator |
 | \(\tau^+_{f,t}\) | `flow_startup[flow, time]` | \(\{0, 1\}\) | Startup event indicator |
 | \(\tau^-_{f,t}\) | `flow_shutdown[flow, time]` | \(\{0, 1\}\) | Shutdown event indicator |
-| \(D^{\text{up}}_{f,t}\) | `uptime[flow, time]` | \(\geq 0\) | Consecutive uptime [h] |
-| \(D^{\text{down}}_{f,t}\) | `downtime[flow, time]` | \(\geq 0\) | Consecutive downtime [h] |
+| \(\mathrm{D}^{\text{up}}_{f,t}\) | `uptime[flow, time]` | \(\geq 0\) | Consecutive uptime [h] |
+| \(\mathrm{D}^{\text{down}}_{f,t}\) | `downtime[flow, time]` | \(\geq 0\) | Consecutive downtime [h] |
 
 ## Semi-Continuous Flow Rates
 
 With fixed size, the on/off indicator gates the flow rate bounds:
 
 \[
-\bar{P}_f \cdot \underline{p}_{f,t} \cdot \sigma_{f,t} \leq P_{f,t} \leq \bar{P}_f \cdot \bar{p}_{f,t} \cdot \sigma_{f,t}
+\bar{\mathrm{P}}_f \cdot \underline{\mathrm{p}}_{f,t} \cdot \sigma_{f,t} \leq P_{f,t} \leq \bar{\mathrm{P}}_f \cdot \bar{\mathrm{p}}_{f,t} \cdot \sigma_{f,t}
 \]
 
 When \(\sigma_{f,t} = 0\): \(P_{f,t} = 0\). When \(\sigma_{f,t} = 1\):
-\(P_{f,t} \in [\bar{P}_f \underline{p}, \bar{P}_f \bar{p}]\).
+\(P_{f,t} \in [\bar{\mathrm{P}}_f \underline{\mathrm{p}}, \bar{\mathrm{P}}_f \bar{\mathrm{p}}]\).
 
-This gives the semi-continuous behavior \(\{0\} \cup [\underline{P}, \bar{P}]\).
+This gives the semi-continuous behavior \(\{0\} \cup [\underline{\mathrm{P}}, \bar{\mathrm{P}}]\).
 
 ## Switch Transitions
 
@@ -52,24 +52,24 @@ Duration tracking uses a Big-M formulation to count consecutive hours in a state
 
 ### Uptime
 
-The uptime variable \(D^{\text{up}}_{f,t}\) tracks consecutive on-hours:
+The uptime variable \(\mathrm{D}^{\text{up}}_{f,t}\) tracks consecutive on-hours:
 
 **Reset when off:**
 
 \[
-D^{\text{up}}_{f,t} \leq \sigma_{f,t} \cdot M \quad \forall \, t
+\mathrm{D}^{\text{up}}_{f,t} \leq \sigma_{f,t} \cdot M \quad \forall \, t
 \]
 
 **Forward accumulation:**
 
 \[
-D^{\text{up}}_{f,t+1} \leq D^{\text{up}}_{f,t} + \Delta t_t \quad \forall \, t
+\mathrm{D}^{\text{up}}_{f,t+1} \leq \mathrm{D}^{\text{up}}_{f,t} + \Delta t_t \quad \forall \, t
 \]
 
 **Backward tightening (force accumulation when on):**
 
 \[
-D^{\text{up}}_{f,t+1} \geq D^{\text{up}}_{f,t} + \Delta t_t + (\sigma_{f,t+1} - 1) \cdot M \quad \forall \, t
+\mathrm{D}^{\text{up}}_{f,t+1} \geq \mathrm{D}^{\text{up}}_{f,t} + \Delta t_t + (\sigma_{f,t+1} - 1) \cdot M \quad \forall \, t
 \]
 
 where \(M\) is the total horizon length (Big-M constant).
@@ -85,11 +85,11 @@ Minimum uptime is enforced at shutdown transitions — the accumulated duration
 must meet the minimum before turning off:
 
 \[
-D^{\text{up}}_{f,t} \geq D^{\text{up,min}} \cdot (\sigma_{f,t} - \sigma_{f,t+1}) \quad \forall \, t < |\mathcal{T}|
+\mathrm{D}^{\text{up}}_{f,t} \geq \mathrm{D}^{\text{up,min}} \cdot (\sigma_{f,t} - \sigma_{f,t+1}) \quad \forall \, t < |\mathcal{T}|
 \]
 
 The term \((\sigma_{f,t} - \sigma_{f,t+1})\) equals 1 only at shutdown
-(on → off), enforcing \(D^{\text{up}}_{f,t} \geq D^{\text{up,min}}\).
+(on → off), enforcing \(\mathrm{D}^{\text{up}}_{f,t} \geq \mathrm{D}^{\text{up,min}}\).
 
 Minimum downtime follows the same pattern on \((1 - \sigma)\).
 
@@ -116,13 +116,13 @@ When prior provides historical state, the previous duration is computed
 by counting consecutive matching timesteps at the end of the prior. At \(t=0\):
 
 \[
-D^{\text{up}}_{f,0} = \sigma_{f,0} \cdot (D^{\text{up,prev}} + \Delta t_0)
+\mathrm{D}^{\text{up}}_{f,0} = \sigma_{f,0} \cdot (\mathrm{D}^{\text{up,prev}} + \Delta t_0)
 \]
 
 If the previous uptime hasn't yet met the minimum, the unit is forced to stay on:
 
 \[
-\sigma_{f,0} \geq 1 \quad \text{if } 0 < D^{\text{up,prev}} < D^{\text{up,min}}
+\sigma_{f,0} \geq 1 \quad \text{if } 0 < \mathrm{D}^{\text{up,prev}} < \mathrm{D}^{\text{up,min}}
 \]
 
 ## Effect Contributions
@@ -132,20 +132,20 @@ If the previous uptime hasn't yet met the minimum, the unit is forced to stay on
 A per-hour cost while the unit is on, independent of the flow rate:
 
 \[
-\Phi_{k,t}^{\text{running}} = \sum_{f} r_{f,k,t} \cdot \sigma_{f,t} \cdot \Delta t_t
+\Phi_{k,t}^{\text{running}} = \sum_{f} \mathrm{r}_{f,k,t} \cdot \sigma_{f,t} \cdot \Delta t_t
 \]
 
-where \(r_{f,k,t}\) is `Status.effects_per_running_hour[k]`.
+where \(\mathrm{r}_{f,k,t}\) is `Status.effects_per_running_hour[k]`.
 
 ### Startup Costs
 
 A one-time cost charged each time the unit switches from off to on:
 
 \[
-\Phi_{k,t}^{\text{startup}} = \sum_{f} u_{f,k,t} \cdot \tau^+_{f,t}
+\Phi_{k,t}^{\text{startup}} = \sum_{f} \mathrm{u}_{f,k,t} \cdot \tau^+_{f,t}
 \]
 
-where \(u_{f,k,t}\) is `Status.effects_per_startup[k]`.
+where \(\mathrm{u}_{f,k,t}\) is `Status.effects_per_startup[k]`.
 
 Both feed into the [per-timestep effect equation](effects.md).
 
@@ -159,15 +159,15 @@ P_{f,t} \leq \sigma_{f,t} \cdot M^+ \qquad \text{(on-indicator gates flow)}
 \]
 
 \[
-P_{f,t} \leq S_f \cdot \bar{p}_{f,t} \qquad \text{(rate limited by size)}
+P_{f,t} \leq S_f \cdot \bar{\mathrm{p}}_{f,t} \qquad \text{(rate limited by size)}
 \]
 
 \[
-P_{f,t} \geq (\sigma_{f,t} - 1) \cdot M^- + S_f \cdot \underline{p}_{f,t} \qquad \text{(minimum when on)}
+P_{f,t} \geq (\sigma_{f,t} - 1) \cdot M^- + S_f \cdot \underline{\mathrm{p}}_{f,t} \qquad \text{(minimum when on)}
 \]
 
-where \(M^+ = S^+ \cdot \bar{p}_{f,t}\) and \(M^- = S^+ \cdot \underline{p}_{f,t}\),
-using the maximum possible size \(S^+\) as Big-M.
+where \(M^+ = \mathrm{S}^+ \cdot \bar{\mathrm{p}}_{f,t}\) and \(M^- = \mathrm{S}^+ \cdot \underline{\mathrm{p}}_{f,t}\),
+using the maximum possible size \(\mathrm{S}^+\) as Big-M.
 
 An additional constraint prevents the unit from being "on" with zero size:
 
@@ -182,14 +182,14 @@ An additional constraint prevents the unit from being "on" with zero size:
 | \(\sigma_{f,t}\) | On/off binary | `flow_on[flow, time]` |
 | \(\tau^+_{f,t}\) | Startup indicator | `flow_startup[flow, time]` |
 | \(\tau^-_{f,t}\) | Shutdown indicator | `flow_shutdown[flow, time]` |
-| \(D^{\text{up}}_{f,t}\) | Consecutive uptime | `uptime[flow, time]` |
-| \(D^{\text{down}}_{f,t}\) | Consecutive downtime | `downtime[flow, time]` |
-| \(D^{\text{up,min}}\) | Minimum uptime | `Status.min_uptime` |
-| \(D^{\text{up,max}}\) | Maximum uptime | `Status.max_uptime` |
-| \(D^{\text{down,min}}\) | Minimum downtime | `Status.min_downtime` |
-| \(D^{\text{down,max}}\) | Maximum downtime | `Status.max_downtime` |
-| \(r_{f,k,t}\) | Running cost coefficient | `Status.effects_per_running_hour` |
-| \(u_{f,k,t}\) | Startup cost coefficient | `Status.effects_per_startup` |
+| \(\mathrm{D}^{\text{up}}_{f,t}\) | Consecutive uptime | `uptime[flow, time]` |
+| \(\mathrm{D}^{\text{down}}_{f,t}\) | Consecutive downtime | `downtime[flow, time]` |
+| \(\mathrm{D}^{\text{up,min}}\) | Minimum uptime | `Status.min_uptime` |
+| \(\mathrm{D}^{\text{up,max}}\) | Maximum uptime | `Status.max_uptime` |
+| \(\mathrm{D}^{\text{down,min}}\) | Minimum downtime | `Status.min_downtime` |
+| \(\mathrm{D}^{\text{down,max}}\) | Maximum downtime | `Status.max_downtime` |
+| \(\mathrm{r}_{f,k,t}\) | Running cost coefficient | `Status.effects_per_running_hour` |
+| \(\mathrm{u}_{f,k,t}\) | Startup cost coefficient | `Status.effects_per_startup` |
 | \(M\) | Big-M (horizon length) | computed |
 
 See [Notation](notation.md) for the full symbol table.

--- a/docs/math/storage.md
+++ b/docs/math/storage.md
@@ -27,7 +27,7 @@ after the last timestep).
 The charge state is bounded by relative SOC limits scaled by the storage capacity:
 
 \[
-\bar{E}_s \cdot \underline{e}_s \leq E_{s,t} \leq \bar{E}_s \cdot \bar{e}_s \quad \forall \, s, t
+\bar{\mathrm{E}}_s \cdot \underline{\mathrm{e}}_s \leq E_{s,t} \leq \bar{\mathrm{E}}_s \cdot \bar{\mathrm{e}}_s \quad \forall \, s, t
 \]
 
 ## Initial & Cyclic Conditions
@@ -56,19 +56,19 @@ This ensures the storage ends at the same level it started.
 | \(E_{s,t}\) | Stored energy variable | `storage--level[storage, time]` |
 | \(P^{\text{c}}_{s,t}\) | Charging flow rate | `flow_rate[charge_flow, time]` |
 | \(P^{\text{d}}_{s,t}\) | Discharging flow rate | `flow_rate[discharge_flow, time]` |
-| \(\bar{E}_s\) | Storage capacity | `Storage.capacity` |
+| \(\bar{\mathrm{E}}_s\) | Storage capacity | `Storage.capacity` |
 | \(\eta^{\text{c}}_s\) | Charging efficiency | `Storage.eta_charge` |
 | \(\eta^{\text{d}}_s\) | Discharging efficiency | `Storage.eta_discharge` |
 | \(\delta_s\) | Self-discharge rate | `Storage.relative_loss_per_hour` |
-| \(\underline{e}_s\) | Relative min SOC | `Storage.relative_minimum_level` |
-| \(\bar{e}_s\) | Relative max SOC | `Storage.relative_maximum_level` |
+| \(\underline{\mathrm{e}}_s\) | Relative min SOC | `Storage.relative_minimum_level` |
+| \(\bar{\mathrm{e}}_s\) | Relative max SOC | `Storage.relative_maximum_level` |
 | \(\Delta t_t\) | Timestep duration | dt |
 
 See [Notation](notation.md) for the full symbol table.
 
 ## Example
 
-A battery with \(\bar{E} = 10\) MWh, \(\eta^{\text{c}} = 0.95\),
+A battery with \(\bar{\mathrm{E}} = 10\) MWh, \(\eta^{\text{c}} = 0.95\),
 \(\eta^{\text{d}} = 0.95\), \(\delta = 0.001\)/h, \(\Delta t = 1\) h:
 
 Starting at \(E_0 = 5\) MWh, charging at \(P^{\text{c}} = 2\) MW:

--- a/docs/math/storage.md
+++ b/docs/math/storage.md
@@ -56,12 +56,12 @@ This ensures the storage ends at the same level it started.
 | \(E_{s,t}\) | Stored energy variable | `storage--level[storage, time]` |
 | \(P^{\text{c}}_{s,t}\) | Charging flow rate | `flow--rate[charge_flow, time]` |
 | \(P^{\text{d}}_{s,t}\) | Discharging flow rate | `flow--rate[discharge_flow, time]` |
-| \(\bar{\mathrm{E}}_s\) | Storage capacity | `Storage.capacity` |
-| \(\eta^{\text{c}}_s\) | Charging efficiency | `Storage.eta_charge` |
-| \(\eta^{\text{d}}_s\) | Discharging efficiency | `Storage.eta_discharge` |
-| \(\delta_s\) | Self-discharge rate | `Storage.relative_loss_per_hour` |
-| \(\underline{\mathrm{e}}_s\) | Relative min SOC | `Storage.relative_minimum_level` |
-| \(\bar{\mathrm{e}}_s\) | Relative max SOC | `Storage.relative_maximum_level` |
+| \(\bar{\mathrm{E}}_s\) | Storage capacity | [`Storage.capacity`](../api/fluxopt/elements.md#fluxopt.elements.Storage(capacity)) |
+| \(\eta^{\text{c}}_s\) | Charging efficiency | [`Storage.eta_charge`](../api/fluxopt/elements.md#fluxopt.elements.Storage(eta_charge)) |
+| \(\eta^{\text{d}}_s\) | Discharging efficiency | [`Storage.eta_discharge`](../api/fluxopt/elements.md#fluxopt.elements.Storage(eta_discharge)) |
+| \(\delta_s\) | Self-discharge rate | [`Storage.relative_loss_per_hour`](../api/fluxopt/elements.md#fluxopt.elements.Storage(relative_loss_per_hour)) |
+| \(\underline{\mathrm{e}}_s\) | Relative min SOC | [`Storage.relative_minimum_level`](../api/fluxopt/elements.md#fluxopt.elements.Storage(relative_minimum_level)) |
+| \(\bar{\mathrm{e}}_s\) | Relative max SOC | [`Storage.relative_maximum_level`](../api/fluxopt/elements.md#fluxopt.elements.Storage(relative_maximum_level)) |
 | \(\Delta t_t\) | Timestep duration | dt |
 
 See [Notation](notation.md) for the full symbol table.

--- a/docs/math/storage.md
+++ b/docs/math/storage.md
@@ -19,16 +19,6 @@ where:
 - \(\delta_s \in [0, 1]\) — self-discharge rate per hour
 - \(\Delta t_t\) — timestep duration in hours
 
-```python
-battery = Storage(
-    'battery', charging=charge, discharging=discharge,
-    capacity=100.0,
-    eta_charge=0.95,        # 95% charging efficiency
-    eta_discharge=0.95,     # 95% discharging efficiency
-    relative_loss_per_hour=0.001,  # 0.1%/h self-discharge
-)
-```
-
 The charge state has \(|\mathcal{T}| + 1\) values (one before each timestep plus one
 after the last timestep).
 
@@ -39,15 +29,6 @@ The charge state is bounded by relative SOC limits scaled by the storage capacit
 \[
 \bar{E}_s \cdot \underline{e}_s \leq E_{s,t} \leq \bar{E}_s \cdot \bar{e}_s \quad \forall \, s, t
 \]
-
-```python
-battery = Storage(
-    'battery', charging=charge, discharging=discharge,
-    capacity=100.0,
-    relative_minimum_level=0.2,  # never below 20%
-    relative_maximum_level=0.9,  # never above 90%
-)
-```
 
 ## Initial & Cyclic Conditions
 
@@ -67,14 +48,6 @@ E_{s,t_{\text{end}}} = E_{s,t_0}
 \]
 
 This ensures the storage ends at the same level it started.
-
-```python
-# Fixed initial level (absolute MWh), no cyclic constraint
-battery = Storage(..., prior_level=50.0, cyclic=False)
-
-# Unconstrained initial level (optimizer chooses), cyclic (default)
-battery = Storage(..., prior_level=None, cyclic=True)
-```
 
 ## Parameters
 

--- a/docs/math/storage.md
+++ b/docs/math/storage.md
@@ -54,8 +54,8 @@ This ensures the storage ends at the same level it started.
 | Symbol | Description | Reference |
 |---|---|---|
 | \(E_{s,t}\) | Stored energy variable | `storage--level[storage, time]` |
-| \(P^{\text{c}}_{s,t}\) | Charging flow rate | `flow_rate[charge_flow, time]` |
-| \(P^{\text{d}}_{s,t}\) | Discharging flow rate | `flow_rate[discharge_flow, time]` |
+| \(P^{\text{c}}_{s,t}\) | Charging flow rate | `flow--rate[charge_flow, time]` |
+| \(P^{\text{d}}_{s,t}\) | Discharging flow rate | `flow--rate[discharge_flow, time]` |
 | \(\bar{\mathrm{E}}_s\) | Storage capacity | `Storage.capacity` |
 | \(\eta^{\text{c}}_s\) | Charging efficiency | `Storage.eta_charge` |
 | \(\eta^{\text{d}}_s\) | Discharging efficiency | `Storage.eta_discharge` |

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -791,8 +791,8 @@ body[data-md-color-scheme="slate"] .jupyter-wrapper {
     box-shadow: -0.4rem 0 0 0 transparent;
   }
   25%, 65% {
-    background-color: rgba(255, 213, 79, 0.55);
-    box-shadow: -0.4rem 0 0 0 rgba(255, 213, 79, 0.9);
+    background-color: rgba(2, 132, 199, 0.35);    /* sky-600 — matches accent */
+    box-shadow: -0.4rem 0 0 0 rgba(2, 132, 199, 0.75);
   }
   45% {
     background-color: transparent;
@@ -802,7 +802,7 @@ body[data-md-color-scheme="slate"] .jupyter-wrapper {
 
 @keyframes target-row-flash {
   0%, 100% { background-color: transparent; }
-  25%, 65% { background-color: rgba(255, 213, 79, 0.5); }
+  25%, 65% { background-color: rgba(2, 132, 199, 0.3); }
   45% { background-color: transparent; }
 }
 
@@ -820,8 +820,8 @@ body[data-md-color-scheme="slate"] .jupyter-wrapper {
     box-shadow: -0.4rem 0 0 0 transparent;
   }
   25%, 65% {
-    background-color: rgba(255, 213, 79, 0.3);
-    box-shadow: -0.4rem 0 0 0 rgba(255, 213, 79, 0.75);
+    background-color: rgba(56, 189, 248, 0.22);   /* sky-400 — matches dark accent */
+    box-shadow: -0.4rem 0 0 0 rgba(56, 189, 248, 0.65);
   }
   45% {
     background-color: transparent;
@@ -831,6 +831,6 @@ body[data-md-color-scheme="slate"] .jupyter-wrapper {
 
 @keyframes target-row-flash-dark {
   0%, 100% { background-color: transparent; }
-  25%, 65% { background-color: rgba(255, 213, 79, 0.22); }
+  25%, 65% { background-color: rgba(56, 189, 248, 0.18); }
   45% { background-color: transparent; }
 }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -766,3 +766,71 @@ body[data-md-color-scheme="slate"] .jupyter-wrapper {
   border-color: #38bdf8;
   color: #0c1620;                          /* dark text on bright sky bg */
 }
+
+/* --- Anchor target highlight ---
+ * When the URL has a #hash, the matching element gets :target. Flash the
+ * background once on arrival so it's obvious where the page jumped to.
+ *
+ * Class/method headings (h2/h3 outside tables) get a left-border flash.
+ * Parameter headings live inside <td> cells of a docstring table — there
+ * the h3 has constrained layout so its own background is barely visible.
+ * The :has(:target) selector lights the entire <tr> instead, which is
+ * much more legible for parameters. */
+.md-content :target {
+  animation: target-flash 1.5s ease-in-out;
+  scroll-margin-top: 4rem;
+}
+
+.md-content tr:has(:target) {
+  animation: target-row-flash 1.5s ease-in-out;
+}
+
+@keyframes target-flash {
+  0%, 100% {
+    background-color: transparent;
+    box-shadow: -0.4rem 0 0 0 transparent;
+  }
+  25%, 65% {
+    background-color: rgba(255, 213, 79, 0.55);
+    box-shadow: -0.4rem 0 0 0 rgba(255, 213, 79, 0.9);
+  }
+  45% {
+    background-color: transparent;
+    box-shadow: -0.4rem 0 0 0 transparent;
+  }
+}
+
+@keyframes target-row-flash {
+  0%, 100% { background-color: transparent; }
+  25%, 65% { background-color: rgba(255, 213, 79, 0.5); }
+  45% { background-color: transparent; }
+}
+
+[data-md-color-scheme="slate"] .md-content :target {
+  animation: target-flash-dark 1.5s ease-in-out;
+}
+
+[data-md-color-scheme="slate"] .md-content tr:has(:target) {
+  animation: target-row-flash-dark 1.5s ease-in-out;
+}
+
+@keyframes target-flash-dark {
+  0%, 100% {
+    background-color: transparent;
+    box-shadow: -0.4rem 0 0 0 transparent;
+  }
+  25%, 65% {
+    background-color: rgba(255, 213, 79, 0.3);
+    box-shadow: -0.4rem 0 0 0 rgba(255, 213, 79, 0.75);
+  }
+  45% {
+    background-color: transparent;
+    box-shadow: -0.4rem 0 0 0 transparent;
+  }
+}
+
+@keyframes target-row-flash-dark {
+  0%, 100% { background-color: transparent; }
+  25%, 65% { background-color: rgba(255, 213, 79, 0.22); }
+  45% { background-color: transparent; }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,13 @@ repo_name: FBumann/fluxopt
 edit_uri: edit/main/docs/
 strict: true
 
+validation:
+  links:
+    not_found: warn
+    anchors: warn
+    absolute_links: warn
+    unrecognized_links: warn
+
 nav:
   - Home: index.md
   - Tutorials:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,8 +73,8 @@ theme:
 
   features:
     - header.autohide
-    - navigation.instant
-    - navigation.instant.progress
+    # navigation.instant left off — MathJax fails to re-typeset on
+    # no-math → math swaps, and no documented reset recipe fixes it.
     - navigation.tracking
     - navigation.tabs
     - navigation.tabs.sticky

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_description: Energy system optimization with linopy
 repo_url: https://github.com/FBumann/fluxopt
 repo_name: FBumann/fluxopt
 edit_uri: edit/main/docs/
+strict: true
 
 nav:
   - Home: index.md


### PR DESCRIPTION
## Summary
The math docs section is now self-consistent and cross-linked into the API reference. Started as a pass to remove code examples from formula pages; grew into a full notation cleanup, anchor-link wiring, and a few site-wide papercut fixes that surfaced along the way.

## What changed

**Math content & notation**
- Dropped ~240 lines of code blocks across all 7 math pages (`flows`, `effects`, `carrier-balance`, `converters`, `status`, `sizing`, `storage`); tutorial notebooks cover the API in motion.
- Italic = decision variables, upright (`\mathrm{}`) = parameters, applied throughout (ISO 80000-2).
- `notation.md` rewritten around an explicit indexing/broadcast convention (period / time / build period); table descriptions disambiguate "Invested capacity" (variable) from "Nominal capacity" (parameter); lowercase relative-bound shorthand documented.
- Variable code names in tables match the actual linopy names (`flow--rate`, `storage--level`, `effect--temporal`, ...), not the old `_` form.
- Piecewise on/off binary renamed `δ_{c,t}` → `σ_{c,t}` to match `status.md` and avoid clashing with `δ_s` (self-discharge).
- `converters.md` reorganized under a single H1 with linear vs piecewise framing.

**API cross-linking**
- Every `Class.attr` reference in a math-doc parameter table is now a hyperlink to its mkdocstrings anchor (`Flow.size`, `Storage.eta_charge`, `Sizing.effects_per_size`, `PiecewiseConversion.points`, etc.).
- Global period weight points to `optimize(period_weights=...)` (user-facing), not the internal `Dims` field.
- Strict-mode anchor validation enabled in `mkdocs.yml` so future broken links fail the build.

**Anchor-target highlight**
- Clicking an API link from a math page now pulses the destination heading (and surrounding `<tr>` for parameter headings inside docstring tables). Two quick pulses over 1.5s in the site's accent sky color, then fade.

**MathJax + instant-nav**
- After several attempts to make MathJax re-typeset across `navigation.instant` page swaps (none reliable on no-math → math navigations), `navigation.instant` is disabled and `mathjax.js` reverted to a config-only file. Full page loads, math always renders.

## Test plan
- [x] `mkdocs build --strict` passes (anchor validation enforced).
- [ ] Reviewer: spot-check a few `/math/*` pages — every Reference column entry should be a working link to the API page; pulse highlight visible on click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)