### PR TITLE
feat(effects): add direct (no-Leontief) view of effect contributions

### DIFF
--- a/src/fluxopt/contributions.py
+++ b/src/fluxopt/contributions.py
@@ -4,8 +4,14 @@ Decomposes solver effect totals into per-contributor (flow/storage) parts,
 split into temporal (per-timestep) and lump (sizing + investment costs) domains —
 matching the model's own temporal/lump structure.
 
-Cross-effects use the Leontief inverse: total = (I - C)^-1 * direct,
-where C is the cross-effect coefficient matrix.
+Two views are supported via the ``cross_effects`` parameter on
+``compute_effect_contributions``:
+
+- **with cross-effects** (default): propagates ``contribution_from`` chains
+  via the Leontief inverse — ``total = (I - C)^-1 * direct`` — so each
+  contributor is charged the full priced-in cost (e.g. CO₂ → cost).
+- **direct**: skips Leontief; each contributor shows only effects it
+  directly emits.
 """
 
 from __future__ import annotations
@@ -144,21 +150,11 @@ def _compute_investment_lump(
     return result
 
 
-def compute_effect_contributions(solution: xr.Dataset, data: ModelData) -> xr.Dataset:
-    """Compute per-contributor effect breakdown from solved values.
+def _compute_direct(solution: xr.Dataset, data: ModelData) -> tuple[xr.DataArray, xr.DataArray, list[str]]:
+    """Compute direct (no cross-effect propagation) per-contributor temporal and lump.
 
-    Decomposes solver totals into per-contributor parts on a unified
-    ``contributor`` dimension (flow IDs + storage IDs).
-
-    Args:
-        solution: Solved variable dataset from ``Result.solution``.
-        data: Model data used to build the optimization.
-
-    Returns:
-        Dataset with:
-        - ``temporal`` (contributor, effect, time) — per-timestep contributions
-        - ``lump`` (contributor, effect) — lump contributions (flows + storages)
-        - ``total`` (contributor, effect) — temporal summed over time + lump
+    Returns ``(temporal, lump, all_ids)`` where each contributor's effects are
+    only those it directly emits — independent of ``contribution_from`` chains.
     """
     flow_ids: list[str] = list(data.flows.effect_coeff.coords['flow'].values)
     effect_ids: list[str] = list(data.effects.min_bound.coords['effect'].values)
@@ -206,11 +202,6 @@ def compute_effect_contributions(solution: xr.Dataset, data: ModelData) -> xr.Da
                     add = comp_startup.sel(component=comp_id).drop_vars('component')
                     temporal_flow.loc[{'flow': fid}] = temporal_flow.sel(flow=fid) + add
 
-    # Cross-effects on temporal via Leontief inverse
-    if data.effects.cf_temporal is not None:
-        temporal_flow = _apply_leontief(_leontief(data.effects.cf_temporal), temporal_flow)
-
-    # Rename to contributor dim
     temporal = temporal_flow.rename({'flow': 'contributor'})
 
     # --- Lump: flow sizing costs ---
@@ -248,23 +239,71 @@ def compute_effect_contributions(solution: xr.Dataset, data: ModelData) -> xr.Da
     else:
         lump = flow_lump
 
-    # Cross-effects on lump via Leontief inverse (using mean of temporal cross-effect)
-    if data.effects.cf_temporal is not None:
-        cf_lump = data.effects.cf_temporal.mean('time')
-        lump = _apply_leontief(_leontief(cf_lump), lump)
+    return temporal, lump, all_ids
 
-    # --- Total: temporal (weighted sum over time) + lump ---
+
+def _apply_cross_effects(
+    temporal: xr.DataArray, lump: xr.DataArray, data: ModelData
+) -> tuple[xr.DataArray, xr.DataArray]:
+    """Propagate effects along ``contribution_from`` chains via Leontief inverse.
+
+    Time-varying ``contribution_from`` is averaged over time for the lump domain
+    (mirroring the model's own treatment in ``model.py``).
+    """
+    if data.effects.cf_temporal is None:
+        return temporal, lump
+    temporal_out = _apply_leontief(_leontief(data.effects.cf_temporal), temporal)
+    cf_lump = data.effects.cf_temporal.mean('time')
+    lump_out = _apply_leontief(_leontief(cf_lump), lump)
+    return temporal_out, lump_out
+
+
+def compute_effect_contributions(
+    solution: xr.Dataset,
+    data: ModelData,
+    *,
+    cross_effects: bool = True,
+) -> xr.Dataset:
+    """Compute per-contributor effect breakdown from solved values.
+
+    Decomposes effect totals into per-contributor parts on a unified
+    ``contributor`` dimension (flow IDs + storage IDs).
+
+    Args:
+        solution: Solved variable dataset from ``Result.solution``.
+        data: Model data used to build the optimization.
+        cross_effects: When True (default), propagates effects along
+            ``contribution_from`` chains via the Leontief inverse so each
+            contributor is charged the full priced-in cost (e.g. CO₂ → cost).
+            When False, returns *direct* contributions only — each contributor
+            shows only effects it directly emits, ignoring cross-effects.
+
+    Returns:
+        Dataset with:
+        - ``temporal`` (contributor, effect, time) — per-timestep contributions
+        - ``lump`` (contributor, effect) — lump contributions (flows + storages)
+        - ``total`` (contributor, effect) — temporal summed over time + lump
+
+    Raises:
+        ValueError: if ``cross_effects=True`` and the contributions don't
+            match solver totals (a sanity check on the breakdown).
+    """
+    temporal, lump, all_ids = _compute_direct(solution, data)
+    if cross_effects:
+        temporal, lump = _apply_cross_effects(temporal, lump, data)
+
     total = (temporal * data.dims.weights).sum('time').reindex(contributor=all_ids, fill_value=0.0) + lump.reindex(
         contributor=all_ids, fill_value=0.0
     )
 
-    # --- Validate: contributions must sum to solver effect totals ---
-    solver = solution['effect--total']
-    computed = total.sum('contributor')
-    if not np.allclose(computed.values, solver.values, atol=1e-6):
-        diff = abs(computed - solver)
-        raise ValueError(
-            f'Effect contributions do not sum to solver totals. Max deviation: {float(diff.max().values):.6g}'
-        )
+    if cross_effects:
+        # Solver totals already include cross-effects; only validate in this branch.
+        solver = solution['effect--total']
+        computed = total.sum('contributor')
+        if not np.allclose(computed.values, solver.values, atol=1e-6):
+            diff = abs(computed - solver)
+            raise ValueError(
+                f'Effect contributions do not sum to solver totals. Max deviation: {float(diff.max().values):.6g}'
+            )
 
     return xr.Dataset({'temporal': temporal, 'lump': lump, 'total': total})

--- a/src/fluxopt/contributions.py
+++ b/src/fluxopt/contributions.py
@@ -258,6 +258,52 @@ def _apply_cross_effects(
     return temporal_out, lump_out
 
 
+def _validate_against_solver(total: xr.DataArray, solution: xr.Dataset) -> None:
+    """Sanity check: per-contributor totals must sum to solver ``effect--total``."""
+    solver = solution['effect--total']
+    computed = total.sum('contributor')
+    if not np.allclose(computed.values, solver.values, atol=1e-6):
+        diff = abs(computed - solver)
+        raise ValueError(
+            f'Effect contributions do not sum to solver totals. Max deviation: {float(diff.max().values):.6g}'
+        )
+
+
+def _finalize(
+    temporal: xr.DataArray,
+    lump: xr.DataArray,
+    all_ids: list[str],
+    data: ModelData,
+) -> xr.Dataset:
+    """Combine temporal + lump into the public ``(temporal, lump, total)`` Dataset."""
+    total = (temporal * data.dims.weights).sum('time').reindex(contributor=all_ids, fill_value=0.0) + lump.reindex(
+        contributor=all_ids, fill_value=0.0
+    )
+    return xr.Dataset({'temporal': temporal, 'lump': lump, 'total': total})
+
+
+def _with_cross_effects(direct: xr.Dataset, data: ModelData, solution: xr.Dataset) -> xr.Dataset:
+    """Apply Leontief cross-effects on top of a precomputed direct contributions Dataset.
+
+    Validates the resulting totals against solver ``effect--total``. When the model has
+    no ``contribution_from`` chains, the direct Dataset is already the with-cross
+    answer — we just validate and return it.
+
+    Args:
+        direct: Output of :func:`compute_effect_contributions` with ``cross_effects=False``.
+        data: Model data the ``direct`` was built from.
+        solution: Solved variable dataset (used for validation).
+    """
+    if data.effects.cf_temporal is None:
+        _validate_against_solver(direct['total'], solution)
+        return direct
+    temporal, lump = _apply_cross_effects(direct['temporal'], direct['lump'], data)
+    all_ids = list(direct['total'].coords['contributor'].values)
+    out = _finalize(temporal, lump, all_ids, data)
+    _validate_against_solver(out['total'], solution)
+    return out
+
+
 def compute_effect_contributions(
     solution: xr.Dataset,
     data: ModelData,
@@ -289,21 +335,7 @@ def compute_effect_contributions(
             match solver totals (a sanity check on the breakdown).
     """
     temporal, lump, all_ids = _compute_direct(solution, data)
+    direct = _finalize(temporal, lump, all_ids, data)
     if cross_effects:
-        temporal, lump = _apply_cross_effects(temporal, lump, data)
-
-    total = (temporal * data.dims.weights).sum('time').reindex(contributor=all_ids, fill_value=0.0) + lump.reindex(
-        contributor=all_ids, fill_value=0.0
-    )
-
-    if cross_effects:
-        # Solver totals already include cross-effects; only validate in this branch.
-        solver = solution['effect--total']
-        computed = total.sum('contributor')
-        if not np.allclose(computed.values, solver.values, atol=1e-6):
-            diff = abs(computed - solver)
-            raise ValueError(
-                f'Effect contributions do not sum to solver totals. Max deviation: {float(diff.max().values):.6g}'
-            )
-
-    return xr.Dataset({'temporal': temporal, 'lump': lump, 'total': total})
+        return _with_cross_effects(direct, data, solution)
+    return direct

--- a/src/fluxopt/contributions.py
+++ b/src/fluxopt/contributions.py
@@ -247,11 +247,11 @@ def _apply_cross_effects(
 ) -> tuple[xr.DataArray, xr.DataArray]:
     """Propagate effects along ``contribution_from`` chains via Leontief inverse.
 
-    Time-varying ``contribution_from`` is averaged over time for the lump domain
-    (mirroring the model's own treatment in ``model.py``).
+    Caller must ensure ``data.effects.cf_temporal is not None``. Time-varying
+    ``contribution_from`` is averaged over time for the lump domain (mirroring
+    the model's own treatment in ``model.py``).
     """
-    if data.effects.cf_temporal is None:
-        return temporal, lump
+    assert data.effects.cf_temporal is not None
     temporal_out = _apply_leontief(_leontief(data.effects.cf_temporal), temporal)
     cf_lump = data.effects.cf_temporal.mean('time')
     lump_out = _apply_leontief(_leontief(cf_lump), lump)

--- a/src/fluxopt/contributions.py
+++ b/src/fluxopt/contributions.py
@@ -259,7 +259,11 @@ def _apply_cross_effects(
 
 
 def _validate_against_solver(total: xr.DataArray, solution: xr.Dataset) -> None:
-    """Sanity check: per-contributor totals must sum to solver ``effect--total``."""
+    """Sanity check: per-contributor totals must sum to solver ``effect--total``.
+
+    Comparison is positional — coordinate misordering or mismatch is a real
+    pipeline bug that should fail loudly here rather than be silently aligned.
+    """
     solver = solution['effect--total']
     computed = total.sum('contributor')
     if not np.allclose(computed.values, solver.values, atol=1e-6):

--- a/src/fluxopt/stats.py
+++ b/src/fluxopt/stats.py
@@ -53,23 +53,43 @@ class StatsAccessor:
 
     @cached_property
     def effect_contributions(self) -> xr.Dataset:
-        """Per-contributor breakdown of effect contributions.
+        """Per-contributor effect breakdown with cross-effects propagated.
 
         Decomposes effect totals into per-contributor parts on a unified
         ``contributor`` dimension (flow IDs + storage IDs)::
 
             contrib = result.stats.effect_contributions
-            contrib['temporal']  # (contributor, effect, time) — flows only
-            contrib['lump']  # (contributor, effect) — flows + storages
+            contrib['temporal']  # (contributor, effect, time)
+            contrib['lump']  # (contributor, effect)
             contrib['total']  # (contributor, effect) — temporal sum + lump
 
-        Cross-effects (e.g. CO₂ → cost) are attributed to the originating
-        contributor. The contributions are validated against solver totals;
-        a ``ValueError`` is raised if they don't match.
+        Cross-effects (e.g. CO₂ → cost via ``Effect.contribution_from``) are
+        propagated through the Leontief inverse, so each contributor is
+        charged the full priced-in cost. The contributions are validated
+        against solver totals; a ``ValueError`` is raised if they don't match.
+
+        For the *direct* view (no cross-effect propagation), see
+        :attr:`effect_contributions_direct`.
 
         Returns:
             Dataset with ``temporal``, ``lump``, and ``total`` DataArrays.
         """
         from fluxopt.contributions import compute_effect_contributions
 
-        return compute_effect_contributions(self._result.solution, self._result.data)
+        return compute_effect_contributions(self._result.solution, self._result.data, cross_effects=True)
+
+    @cached_property
+    def effect_contributions_direct(self) -> xr.Dataset:
+        """Per-contributor effect breakdown *without* cross-effect propagation.
+
+        Same shape as :attr:`effect_contributions`, but each contributor only
+        carries effects it directly emits — ``contribution_from`` chains are
+        ignored. Useful for attributing physical quantities (e.g. raw CO₂
+        emissions) without conflating them with priced-in monetary effects.
+
+        Returns:
+            Dataset with ``temporal``, ``lump``, and ``total`` DataArrays.
+        """
+        from fluxopt.contributions import compute_effect_contributions
+
+        return compute_effect_contributions(self._result.solution, self._result.data, cross_effects=False)

--- a/src/fluxopt/stats.py
+++ b/src/fluxopt/stats.py
@@ -52,6 +52,22 @@ class StatsAccessor:
         return coeff * self._result.flow_rates
 
     @cached_property
+    def effect_contributions_direct(self) -> xr.Dataset:
+        """Per-contributor effect breakdown *without* cross-effect propagation.
+
+        Each contributor only carries effects it directly emits —
+        ``contribution_from`` chains are ignored. Useful for attributing
+        physical quantities (e.g. raw CO₂ emissions) without conflating them
+        with priced-in monetary effects.
+
+        Returns:
+            Dataset with ``temporal``, ``lump``, and ``total`` DataArrays.
+        """
+        from fluxopt.contributions import compute_effect_contributions
+
+        return compute_effect_contributions(self._result.solution, self._result.data, cross_effects=False)
+
+    @cached_property
     def effect_contributions(self) -> xr.Dataset:
         """Per-contributor effect breakdown with cross-effects propagated.
 
@@ -68,28 +84,16 @@ class StatsAccessor:
         charged the full priced-in cost. The contributions are validated
         against solver totals; a ``ValueError`` is raised if they don't match.
 
-        For the *direct* view (no cross-effect propagation), see
-        :attr:`effect_contributions_direct`.
+        Built on top of :attr:`effect_contributions_direct` — when both views
+        are accessed, the heavy direct computation runs only once.
 
         Returns:
             Dataset with ``temporal``, ``lump``, and ``total`` DataArrays.
         """
-        from fluxopt.contributions import compute_effect_contributions
+        from fluxopt.contributions import _with_cross_effects
 
-        return compute_effect_contributions(self._result.solution, self._result.data, cross_effects=True)
-
-    @cached_property
-    def effect_contributions_direct(self) -> xr.Dataset:
-        """Per-contributor effect breakdown *without* cross-effect propagation.
-
-        Same shape as :attr:`effect_contributions`, but each contributor only
-        carries effects it directly emits — ``contribution_from`` chains are
-        ignored. Useful for attributing physical quantities (e.g. raw CO₂
-        emissions) without conflating them with priced-in monetary effects.
-
-        Returns:
-            Dataset with ``temporal``, ``lump``, and ``total`` DataArrays.
-        """
-        from fluxopt.contributions import compute_effect_contributions
-
-        return compute_effect_contributions(self._result.solution, self._result.data, cross_effects=False)
+        return _with_cross_effects(
+            self.effect_contributions_direct,
+            self._result.data,
+            self._result.solution,
+        )

--- a/tests/math/test_contributions.py
+++ b/tests/math/test_contributions.py
@@ -721,3 +721,33 @@ class TestComputeEffectContributionsAPI:
         xr.testing.assert_allclose(via_function['total'], via_stats['total'])
         xr.testing.assert_allclose(via_function['temporal'], via_stats['temporal'])
         xr.testing.assert_allclose(via_function['lump'], via_stats['lump'])
+
+    def test_direct_call_no_cross_effects(self):
+        """Calling compute_effect_contributions(cross_effects=False) yields the same
+        direct result as accessing result.stats.effect_contributions_direct.
+
+        This locks in the public-API contract for direct mode — if the stats
+        accessor ever grows post-processing on top of the function call, this
+        test catches the drift.
+        """
+        from fluxopt.contributions import compute_effect_contributions
+
+        source = Flow('elec', size=200, effects_per_flow_hour={'cost': 0.04, 'co2': 0.5})
+        sink = Flow('elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])
+
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('elec')],
+            effects=[
+                Effect('cost', contribution_from={'co2': 50}),
+                Effect('co2', unit='kg'),
+            ],
+            objective_effects='cost',
+            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+        )
+
+        via_function = compute_effect_contributions(result.solution, result.data, cross_effects=False)
+        via_stats = result.stats.effect_contributions_direct
+        xr.testing.assert_allclose(via_function['total'], via_stats['total'])
+        xr.testing.assert_allclose(via_function['temporal'], via_stats['temporal'])
+        xr.testing.assert_allclose(via_function['lump'], via_stats['lump'])

--- a/tests/math/test_contributions.py
+++ b/tests/math/test_contributions.py
@@ -480,3 +480,180 @@ class TestEdgeCases:
 
         assert result.stats is result.stats
         assert result.stats.effect_contributions is result.stats.effect_contributions
+        assert result.stats.effect_contributions_direct is result.stats.effect_contributions_direct
+
+
+class TestDirectContributions:
+    """Direct contributions skip Leontief — each contributor only shows what it
+    directly emits, independent of ``contribution_from`` chains."""
+
+    def test_direct_equals_with_cross_when_no_contribution_from(self):
+        """Without contribution_from, direct and with-cross views match."""
+
+        source = Flow('elec', size=200, effects_per_flow_hour={'cost': 0.04, 'co2': 0.5})
+        sink = Flow('elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])
+
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('elec')],
+            effects=[Effect('cost'), Effect('co2', unit='kg')],
+            objective_effects='cost',
+            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+        )
+
+        with_cross = result.stats.effect_contributions
+        direct = result.stats.effect_contributions_direct
+        xr.testing.assert_allclose(with_cross['temporal'], direct['temporal'])
+        xr.testing.assert_allclose(with_cross['lump'], direct['lump'])
+        xr.testing.assert_allclose(with_cross['total'], direct['total'])
+
+    def test_direct_strips_carbon_tax_propagation(self):
+        """Direct cost = direct flow cost only, ignoring CO₂→cost cross-effect."""
+
+        demand = [50.0, 80.0, 60.0]
+        source = Flow('elec', size=200, effects_per_flow_hour={'cost': 0.04, 'co2': 0.5})
+        sink = Flow('elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])
+
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('elec')],
+            effects=[
+                Effect('cost', contribution_from={'co2': 50}),
+                Effect('co2', unit='kg'),
+            ],
+            objective_effects='cost',
+            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+        )
+
+        direct = result.stats.effect_contributions_direct
+        with_cross = result.stats.effect_contributions
+
+        total_energy = sum(demand)
+        # Direct view: grid pays only its own per-flow-hour cost (no CO2 markup)
+        grid_direct_cost = float(direct['total'].sel(contributor='grid(elec)', effect='cost').values)
+        assert grid_direct_cost == pytest.approx(total_energy * 0.04, abs=1e-6)
+
+        # With-cross view: grid pays direct cost + CO2 priced in at 50/kg
+        grid_xc_cost = float(with_cross['total'].sel(contributor='grid(elec)', effect='cost').values)
+        assert grid_xc_cost == pytest.approx(total_energy * 0.04 + total_energy * 0.5 * 50, abs=1e-6)
+
+        # CO2 attribution itself doesn't change between the two views
+        # (CO2 is a leaf with no contribution_from — Leontief is identity for it)
+        xr.testing.assert_allclose(direct['total'].sel(effect='co2'), with_cross['total'].sel(effect='co2'))
+
+    def test_direct_sum_equals_raw_emission_total(self):
+        """Direct co2 contributions sum to the raw integrated emissions
+        (no cross-effects mean physical totals are unchanged)."""
+
+        demand = [50.0, 80.0, 60.0]
+        source = Flow('elec', size=200, effects_per_flow_hour={'cost': 0.04, 'co2': 0.5})
+        sink = Flow('elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])
+
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('elec')],
+            effects=[
+                Effect('cost', contribution_from={'co2': 50}),
+                Effect('co2', unit='kg'),
+            ],
+            objective_effects='cost',
+            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+        )
+
+        direct = result.stats.effect_contributions_direct
+        co2_direct = float(direct['total'].sel(effect='co2').sum('contributor').values)
+        assert co2_direct == pytest.approx(sum(demand) * 0.5, abs=1e-6)
+
+    def test_direct_drops_transitive_propagation(self):
+        """PE → CO₂ → cost: direct view shows zero direct cost from grid,
+        full chain only appears in the with-cross view."""
+
+        demand = [50.0, 80.0, 60.0]
+        source = Flow('elec', size=200, effects_per_flow_hour={'pe': 2.0})
+        sink = Flow('elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])
+
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('elec')],
+            effects=[
+                Effect('cost', contribution_from={'co2': 50}),
+                Effect('co2', unit='kg', contribution_from={'pe': 0.3}),
+                Effect('pe', unit='kWh'),
+            ],
+            objective_effects='cost',
+            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+        )
+
+        direct = result.stats.effect_contributions_direct
+        with_cross = result.stats.effect_contributions
+
+        total_energy = sum(demand)
+        # Direct: grid only directly emits PE — no direct co2, no direct cost
+        grid_direct_pe = float(direct['total'].sel(contributor='grid(elec)', effect='pe').values)
+        grid_direct_co2 = float(direct['total'].sel(contributor='grid(elec)', effect='co2').values)
+        grid_direct_cost = float(direct['total'].sel(contributor='grid(elec)', effect='cost').values)
+        assert grid_direct_pe == pytest.approx(total_energy * 2.0, abs=1e-6)
+        assert grid_direct_co2 == pytest.approx(0.0, abs=1e-6)
+        assert grid_direct_cost == pytest.approx(0.0, abs=1e-6)
+
+        # With-cross: chain propagates pe→co2→cost
+        grid_xc_co2 = float(with_cross['total'].sel(contributor='grid(elec)', effect='co2').values)
+        grid_xc_cost = float(with_cross['total'].sel(contributor='grid(elec)', effect='cost').values)
+        assert grid_xc_co2 == pytest.approx(total_energy * 2.0 * 0.3, abs=1e-6)
+        assert grid_xc_cost == pytest.approx(total_energy * 2.0 * 0.3 * 50, abs=1e-6)
+
+    def test_direct_does_not_validate_against_solver_total(self):
+        """Direct totals can differ from solver totals (which include cross-effects).
+        Sanity: direct cost total is less than solver cost total when CO₂→cost is set."""
+
+        demand = [50.0, 80.0, 60.0]
+        source = Flow('elec', size=200, effects_per_flow_hour={'cost': 0.04, 'co2': 0.5})
+        sink = Flow('elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])
+
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('elec')],
+            effects=[
+                Effect('cost', contribution_from={'co2': 50}),
+                Effect('co2', unit='kg'),
+            ],
+            objective_effects='cost',
+            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+        )
+
+        direct = result.stats.effect_contributions_direct
+        direct_cost_total = float(direct['total'].sel(effect='cost').sum('contributor').values)
+        solver_cost_total = float(result.effect_totals.sel(effect='cost').values)
+        # Strict inequality: there's a non-zero CO₂→cost contribution
+        assert direct_cost_total < solver_cost_total
+        assert direct_cost_total == pytest.approx(sum(demand) * 0.04, abs=1e-6)
+
+    def test_direct_lump_strips_sizing_cross_effect(self):
+        """Sizing CO₂ stays as CO₂ in direct view, not priced into cost."""
+
+        source = Flow(
+            'elec',
+            size=Sizing(min_size=50, max_size=200, mandatory=True, effects_per_size={'co2': 10}),
+            effects_per_flow_hour={'cost': 0.04},
+        )
+        sink = Flow('elec', size=100, fixed_relative_profile=[0.5, 0.5, 0.5])
+
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('elec')],
+            effects=[
+                Effect('cost', contribution_from={'co2': 50}),
+                Effect('co2', unit='kg'),
+            ],
+            objective_effects='cost',
+            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+        )
+
+        direct = result.stats.effect_contributions_direct
+        invest_size = float(result.sizes.sel(flow='grid(elec)').values)
+
+        grid_direct_co2_lump = float(direct['lump'].sel(contributor='grid(elec)', effect='co2').values)
+        grid_direct_cost_lump = float(direct['lump'].sel(contributor='grid(elec)', effect='cost').values)
+        assert grid_direct_co2_lump == pytest.approx(invest_size * 10, abs=1e-6)
+        # No direct sizing cost — only CO₂ → cost via cross-effect, which direct strips
+        assert grid_direct_cost_lump == pytest.approx(0.0, abs=1e-6)

--- a/tests/math/test_contributions.py
+++ b/tests/math/test_contributions.py
@@ -657,3 +657,67 @@ class TestDirectContributions:
         assert grid_direct_co2_lump == pytest.approx(invest_size * 10, abs=1e-6)
         # No direct sizing cost — only CO₂ → cost via cross-effect, which direct strips
         assert grid_direct_cost_lump == pytest.approx(0.0, abs=1e-6)
+
+
+class TestValidateAgainstSolver:
+    """The validation helper raises when per-contributor totals don't sum to solver totals."""
+
+    def test_raises_on_mismatch(self):
+        from fluxopt.contributions import _validate_against_solver
+
+        total = xr.DataArray(
+            [[1.0, 2.0], [3.0, 4.0]],
+            dims=['contributor', 'effect'],
+            coords={'contributor': ['a', 'b'], 'effect': ['cost', 'co2']},
+        )
+        solution = xr.Dataset(
+            {
+                'effect--total': xr.DataArray([100.0, 200.0], dims=['effect'], coords={'effect': ['cost', 'co2']}),
+            }
+        )
+        with pytest.raises(ValueError, match='Effect contributions do not sum to solver totals'):
+            _validate_against_solver(total, solution)
+
+    def test_passes_on_exact_match(self):
+        from fluxopt.contributions import _validate_against_solver
+
+        total = xr.DataArray(
+            [[1.0, 2.0], [3.0, 4.0]],
+            dims=['contributor', 'effect'],
+            coords={'contributor': ['a', 'b'], 'effect': ['cost', 'co2']},
+        )
+        solution = xr.Dataset(
+            {
+                'effect--total': xr.DataArray([4.0, 6.0], dims=['effect'], coords={'effect': ['cost', 'co2']}),
+            }
+        )
+        _validate_against_solver(total, solution)  # no exception
+
+
+class TestComputeEffectContributionsAPI:
+    """Public ``compute_effect_contributions`` works directly (not just via stats)."""
+
+    def test_direct_call_with_cross_effects(self):
+        """Calling compute_effect_contributions(cross_effects=True) yields the same
+        with-cross result as accessing result.stats.effect_contributions."""
+        from fluxopt.contributions import compute_effect_contributions
+
+        source = Flow('elec', size=200, effects_per_flow_hour={'cost': 0.04, 'co2': 0.5})
+        sink = Flow('elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])
+
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('elec')],
+            effects=[
+                Effect('cost', contribution_from={'co2': 50}),
+                Effect('co2', unit='kg'),
+            ],
+            objective_effects='cost',
+            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+        )
+
+        via_function = compute_effect_contributions(result.solution, result.data, cross_effects=True)
+        via_stats = result.stats.effect_contributions
+        xr.testing.assert_allclose(via_function['total'], via_stats['total'])
+        xr.testing.assert_allclose(via_function['temporal'], via_stats['temporal'])
+        xr.testing.assert_allclose(via_function['lump'], via_stats['lump'])

--- a/tests/math/test_contributions.py
+++ b/tests/math/test_contributions.py
@@ -507,6 +507,30 @@ class TestDirectContributions:
         xr.testing.assert_allclose(with_cross['lump'], direct['lump'])
         xr.testing.assert_allclose(with_cross['total'], direct['total'])
 
+    def test_direct_and_with_cross_differ_when_contribution_from_present(self):
+        """Sanity invariant: when contribution_from is set, the two views must
+        disagree on at least one (contributor, effect) — otherwise the direct
+        accessor is silently returning the with-cross result (or vice versa)."""
+
+        source = Flow('elec', size=200, effects_per_flow_hour={'cost': 0.04, 'co2': 0.5})
+        sink = Flow('elec', size=100, fixed_relative_profile=[0.5, 0.8, 0.6])
+
+        result = optimize(
+            timesteps=ts(3),
+            carriers=[Carrier('elec')],
+            effects=[
+                Effect('cost', contribution_from={'co2': 50}),
+                Effect('co2', unit='kg'),
+            ],
+            objective_effects='cost',
+            ports=[Port('grid', imports=[source]), Port('demand', exports=[sink])],
+        )
+
+        with_cross = result.stats.effect_contributions
+        direct = result.stats.effect_contributions_direct
+        assert not direct['total'].equals(with_cross['total'])
+        assert not direct['temporal'].equals(with_cross['temporal'])
+
     def test_direct_strips_carbon_tax_propagation(self):
         """Direct cost = direct flow cost only, ignoring CO₂→cost cross-effect."""
 


### PR DESCRIPTION
## Summary

- Adds a *direct* view of per-contributor effect contributions that skips the Leontief inverse — each contributor only carries effects it directly emits, ignoring `Effect.contribution_from` chains.
- Existing `result.stats.effect_contributions` keeps its current with-cross semantics (Leontief applied).
- New `result.stats.effect_contributions_direct` returns the direct view.

Useful for attributing physical quantities (raw CO₂ emissions, primary energy) to their source flows without conflating them with priced-in monetary effects.

## Details

`compute_effect_contributions(solution, data, *, cross_effects: bool = True)` is the single entry point. The function is split into two helpers:

- `_compute_direct` — per-contributor temporal + lump from solved values; no Leontief.
- `_apply_cross_effects` — propagates effects along `contribution_from` chains via Leontief inverse.

Validation against solver `effect--total` only runs when `cross_effects=True`, since solver totals already include cross-effect propagation.

## API

```python
result = optimize(...)

# With cross-effects (current behaviour, e.g. CO₂ priced into cost):
result.stats.effect_contributions['total'].sel(contributor='grid', effect='cost')

# Direct only (no Leontief — grid's CO₂ stays as CO₂, not rolled into cost):
result.stats.effect_contributions_direct['total'].sel(contributor='grid', effect='co2')
```

Both return a Dataset with `temporal`, `lump`, `total` DataArrays of the same shape.

## Test plan

- [x] `pytest tests/math/test_contributions.py` — 17 existing + 6 new tests pass
- [x] `pytest -q` — 451 passed, 227 skipped
- [x] `mypy src/` — clean
- [x] `ruff check . && ruff format .` — clean

New test class `TestDirectContributions` covers:

- Direct == with-cross when no `contribution_from` is set
- CO₂ → cost cross-effect stripped from direct view
- Raw integrated CO₂ totals match direct sum
- Transitive PE → CO₂ → cost: direct shows only direct PE; with-cross propagates the chain
- Direct sum < solver total when cross-effects exist
- Sizing CO₂ stays as CO₂ in direct lump (not priced into cost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Effect contributions can now be calculated in two modes: with or without cross-effect propagation.
  * Added a direct contributions view showing effects independent of propagated impacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->