### PR TITLE
docs: dedupe quickstart between README and docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,27 +21,39 @@ Includes the [HiGHS](https://highs.dev/) solver out of the box.
 
 ## Quick Start
 
+<!--quickstart-start-->
 ```python
-from datetime import datetime, timedelta
+# A gas boiler covers a heat demand, minimizing fuel cost
+from datetime import datetime
+from fluxopt import Carrier, Converter, Effect, Flow, Port, optimize
 
-import fluxopt as fx
-
-timesteps = [datetime(2024, 1, 1) + timedelta(hours=i) for i in range(4)]
-
-result = fx.optimize(
-    timesteps=timesteps,
-    carriers=[fx.Carrier('electricity')],
-    effects=[fx.Effect('cost', is_objective=True)],
+result = optimize(
+    timesteps=[datetime(2024, 1, 1, h) for h in range(4)],
+    carriers=[Carrier('gas'), Carrier('heat')],
+    effects=[Effect('cost')],
     ports=[
-        fx.Port('grid', imports=[
-            fx.Flow('electricity', size=200, effects_per_flow_hour={'cost': 0.04}),
+        Port('grid', imports=[
+            Flow('gas', size=500, effects_per_flow_hour={'cost': 0.04})
         ]),
-        fx.Port('demand', exports=[
-            fx.Flow('electricity', size=100, fixed_relative_profile=[0.5, 0.8, 1.0, 0.6]),
-        ]),
+        Port('demand', exports=[
+            Flow('heat', size=100, fixed_relative_profile=[0.4, 0.7, 0.5, 0.6])
+        ])
     ],
+    converters=[
+        Converter.boiler(
+            'boiler',
+            thermal_efficiency=0.9,
+            fuel_flow=Flow('gas', size=300),
+            thermal_flow=Flow('heat', size=200)
+        )
+    ],
+    objective_effects='cost',
 )
+
+print(f"Total cost: {result.objective:.2f}")
+print(result.flow_rates)
 ```
+<!--quickstart-end-->
 
 ## Roadmap
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,37 +67,11 @@ Energy system optimization with [linopy](https://github.com/PyPSA/linopy) — de
 
 
 
-```python
-# A gas boiler covers a heat demand, minimizing fuel cost
-from datetime import datetime
-from fluxopt import Carrier, Converter, Effect, Flow, Port, optimize
-
-result = optimize(
-    timesteps=[datetime(2024, 1, 1, h) for h in range(4)],
-    carriers=[Carrier('gas'), Carrier('heat')],
-    effects=[Effect('cost')],
-    ports=[
-        Port('grid', imports=[
-            Flow('gas', size=500, effects_per_flow_hour={'cost': 0.04})
-        ]),
-        Port('demand', exports=[
-            Flow('heat', size=100, fixed_relative_profile=[0.4, 0.7, 0.5, 0.6])
-        ])
-    ],
-    converters=[
-        Converter.boiler(
-            'boiler',
-            thermal_efficiency=0.9,
-            fuel_flow=Flow('gas', size=300),
-            thermal_flow=Flow('heat', size=200)
-        )
-    ],
-    objective_effects='cost',
-)
-
-print(f"Total cost: {result.objective:.2f}")
-print(result.flow_rates)
-```
+{%
+   include-markdown "../README.md"
+   start="<!--quickstart-start-->"
+   end="<!--quickstart-end-->"
+%}
 
 ## Where to next
 


### PR DESCRIPTION
## Summary

- Fix the README quickstart — it used a non-existent ``Effect(is_objective=True)`` parameter and would have errored on first run.
- Replace it with the boiler example from the docs landing page (verified to run end-to-end).
- Make README the canonical source for the quickstart code block, marked with ``<!--quickstart-start-->`` / ``<!--quickstart-end-->``.
- Have ``docs/index.md`` pull the same block via the already-configured ``mkdocs-include-markdown`` plugin (same pattern as ``docs/contributing.md``).

Future edits to the quickstart only need to land in one place; the docs site picks them up automatically.

## Test plan

- [x] Ran the README's quickstart code standalone — solves, prints ``Total cost: 9.78``.
- [x] ``mkdocs build --strict`` — clean build; the included code block renders syntax-highlighted in ``site/index.html`` identical to the inline version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)