### PR TITLE
chore: drop alpha prerelease from release-please config

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -9,8 +9,6 @@
       "bump-minor-for-major-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "changelog-path": "CHANGELOG.md",
-      "prerelease": true,
-      "prerelease-type": "alpha",
       "initial-version": "0.0.2-alpha.0"
     }
   }


### PR DESCRIPTION
## Summary

- Remove ``\"prerelease\": true`` and ``\"prerelease-type\": \"alpha\"`` from ``.release-please-config.json``.
- The next release-please PR (and every one after) will produce a clean ``0.0.x`` tag instead of ``0.0.x-alpha.N``.

## Why

Pre-1.0 (0.0.x) already encodes \"API may break between releases\" by SemVer convention. Tagging ``0.0.7-alpha.0`` is a belt over a belt — the version number already says everything ``alpha`` would say.

**Real user impact today:** ``pip install fluxopt`` returns nothing useful because pip skips prereleases by default. Users have to know to add ``--pre``. After this change, ``pip install fluxopt`` just works on the latest 0.0.x.

## Notes

- The publish workflow already handles both cases — hyphenated tags get ``--prerelease`` on GitHub releases, plain tags don't (``.github/workflows/publish.yaml`` lines 59-63). No workflow changes needed.
- The manifest still says ``0.0.6-alpha.0`` — the next release-please run will compute the next version itself based on commits since.
- ``initial-version`` left as-is (only used at bootstrap; never re-applied).
- Classifier ``Development Status :: 3 - Alpha`` left as-is — pre-1.0 is correctly described as alpha-stage even without the alpha tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)