### PR TITLE
docs: add fluxopt-marimo to ecosystem roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,16 +72,29 @@ fluxopt is evolving into a family of packages with a lean core and optional comp
 
 Companion packages depend on core — core has no knowledge of companions.
 
+### Companion packages
+
+| Package | Role | Versioning · Tier | `fluxopt` pin | Status |
+|---------|------|-------------------|---------------|--------|
+| `fluxopt-plot` | Result visualization (Plotly) | Semver · Experimental — method signatures may change | Tight (`>=A.B,<A.C`), validated per release | Scaffolded — [docs](https://fbumann.github.io/fluxopt-plot/latest/) · [#51](https://github.com/FBumann/fluxopt/issues/51) |
+| `fluxopt-yaml` | Declarative model loader (YAML + CSV → `Element`s) | Semver · Experimental — YAML schema may change | Tight (`>=A.B,<A.C`), validated per release | Scaffolded — [docs](https://fbumann.github.io/fluxopt-yaml/latest/) · [#52](https://github.com/FBumann/fluxopt/issues/52) |
+| `fluxopt-tsam` | Time series aggregation — input pre-processing, possibly result disaggregation | Semver · Experimental — round-trip schema may evolve | **Undecided** — depends on whether period primitives live in core (→ loose) or in this package (→ tight) | Planned |
+| `fluxopt-marimo` | Interactive exploration & dashboards (marimo apps) | CalVer (`YYYY.MM.PATCH`) · Experimental — apps are templates | Tight (`>=A.B,<A.C`), validated per release | Planned |
+
+Tight-pinned companions release on every `fluxopt` minor; validation is
+automated via scheduled CI. `fluxopt-tsam`'s pin policy is blocked on an
+architectural decision — if period primitives live in core, tsam stays
+a thin adapter (loose pin); if they live in tsam, the package owns deep
+round-trip behavior (tight pin).
+
 ### Milestones
+
+Cross-cutting work not tied to a single companion package:
 
 | Milestone | Description | Status | Issue |
 |-----------|-------------|--------|-------|
 | `Result.stats` accessor | Cached xarray properties for post-processing | Planned | [#49](https://github.com/FBumann/fluxopt/issues/49) |
 | `.plot` stub on `Result` | Discoverable property, helpful error if plot package absent | Planned | [#50](https://github.com/FBumann/fluxopt/issues/50) |
-| `fluxopt-plot` package | Interactive plotly visualization as companion package | [Scaffolded](https://fbumann.github.io/fluxopt-plot/latest/) | [#51](https://github.com/FBumann/fluxopt/issues/51) |
-| `fluxopt-yaml` package | Declarative model definition via YAML + CSV | [Scaffolded](https://fbumann.github.io/fluxopt-yaml/latest/) | [#52](https://github.com/FBumann/fluxopt/issues/52) |
-| `fluxopt-tsam` package | Time series aggregation preprocessing | Planned | — |
-| `fluxopt-marimo` package | Interactive marimo apps for result exploration & dashboards | Planned | — |
 | ReadTheDocs migration | Automatic versioned docs from git tags | Planned | [#53](https://github.com/FBumann/fluxopt/issues/53) |
 | Remove plotly from core | Keep core lean — plotting deps in `fluxopt-plot` only | Planned | [#54](https://github.com/FBumann/fluxopt/issues/54) |
 
@@ -91,10 +104,8 @@ Companion packages depend on core — core has no knowledge of companions.
 |-----------|------|--------|
 | Core modeling API | **Stable** | Semver. Deprecation warnings before removal. |
 | Stats accessor | **Semi-stable** | Breaking changes allowed between minor versions with changelog entry. |
-| `fluxopt-yaml` | **Experimental** | Own versioning. YAML schema may change. |
-| `fluxopt-plot` | **Experimental** | Own versioning. Method signatures may change. |
-| `fluxopt-marimo` | **Experimental** | CalVer. Apps are templates, not a stable API. |
-| `fluxopt-tsam` | **Independent** | Fully independent semver. |
+
+Companion packages have their own stability policies — see the table above.
 
 See [#47](https://github.com/FBumann/fluxopt/issues/47) for the full architecture discussion.
 

--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ Companion packages depend on core — core has no knowledge of companions.
 |---------|------|-------------------|---------------|--------|
 | `fluxopt-plot` | Result visualization (Plotly) | Semver · Experimental — method signatures may change | Tight (`>=A.B,<A.C`), validated per release | Scaffolded — [docs](https://fbumann.github.io/fluxopt-plot/latest/) · [#51](https://github.com/FBumann/fluxopt/issues/51) |
 | `fluxopt-yaml` | Declarative model loader (YAML + CSV → `Element`s) | Semver · Experimental — YAML schema may change | Tight (`>=A.B,<A.C`), validated per release | Scaffolded — [docs](https://fbumann.github.io/fluxopt-yaml/latest/) · [#52](https://github.com/FBumann/fluxopt/issues/52) |
-| `fluxopt-tsam` | Time series aggregation — input pre-processing, possibly result disaggregation | Semver · Experimental — round-trip schema may evolve | **Undecided** — depends on whether period primitives live in core (→ loose) or in this package (→ tight) | Planned |
+| `fluxopt-tsam` | Time series aggregation — input pre-processing, possibly result disaggregation | Semver · Experimental — round-trip schema may evolve | **Undecided** — depends on whether representative-period primitives live in core (→ loose) or in this package (→ tight) | Planned |
 | `fluxopt-marimo` | Interactive exploration & dashboards (marimo apps) | CalVer (`YYYY.MM.PATCH`) · Experimental — apps are templates | Tight (`>=A.B,<A.C`), validated per release | Planned |
 
 Tight-pinned companions release on every `fluxopt` minor; validation is
 automated via scheduled CI. `fluxopt-tsam`'s pin policy is blocked on an
-architectural decision — if period primitives live in core, tsam stays
+architectural decision — if representative-period primitives live in core, tsam stays
 a thin adapter (loose pin); if they live in tsam, the package owns deep
 round-trip behavior (tight pin).
 

--- a/README.md
+++ b/README.md
@@ -93,40 +93,8 @@ Companion packages depend on core — core has no knowledge of companions.
 | Stats accessor | **Semi-stable** | Breaking changes allowed between minor versions with changelog entry. |
 | `fluxopt-yaml` | **Experimental** | Own versioning. YAML schema may change. |
 | `fluxopt-plot` | **Experimental** | Own versioning. Method signatures may change. |
-| `fluxopt-marimo` | **Experimental** | CalVer (`YYYY.MM.PATCH`). Validated against each `fluxopt` minor; apps are templates, widgets/CLI are the contract. |
+| `fluxopt-marimo` | **Experimental** | CalVer. Apps are templates, not a stable API. |
 | `fluxopt-tsam` | **Independent** | Fully independent semver. |
-
-### Versioning & stability
-
-Most companion packages follow semver; `fluxopt-marimo` is the exception
-and uses **CalVer** (`YYYY.MM.PATCH`). Versions communicate *when* a
-snapshot was validated, not the severity of changes — appropriate because
-the package's primary deliverable is *templates*, not a stable API.
-
-**Compatibility with `fluxopt`** — `fluxopt-marimo` pins the core
-dependency at minor granularity (`fluxopt>=A.B,<A.C`). Every new
-`fluxopt` minor triggers a new `fluxopt-marimo` release; the bump *is*
-the validation. A scheduled CI job runs the apps against the latest
-`fluxopt` release — passing runs auto-PR a pin bump and tag a release;
-failing runs alert the maintainer to fix before tagging. The CHANGELOG
-records the validation result for every release, even when no code
-changed. The coupling is operational only — `fluxopt` core has no
-dependency on any companion.
-
-Other dependencies (marimo, plotly, …) carry only lower bounds — users
-own those versions.
-
-**Contract tiers within `fluxopt-marimo`:**
-
-| Surface | Contract |
-|---------|----------|
-| `apps/*.py` (marimo apps) | None — templates to fork and own. |
-| Widget helpers (Python API) | Minimal surface; breaking changes documented per release. |
-| CLI commands (`fluxopt-explore`, …) | Command names stable from first release. |
-
-While in Experimental tier, breaking changes are allowed in any release
-with a CHANGELOG entry — no deprecation cycle promised until 1.0 (and
-1.0 is not on the roadmap).
 
 See [#47](https://github.com/FBumann/fluxopt/issues/47) for the full architecture discussion.
 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,40 @@ Companion packages depend on core — core has no knowledge of companions.
 | Stats accessor | **Semi-stable** | Breaking changes allowed between minor versions with changelog entry. |
 | `fluxopt-yaml` | **Experimental** | Own versioning. YAML schema may change. |
 | `fluxopt-plot` | **Experimental** | Own versioning. Method signatures may change. |
-| `fluxopt-marimo` | **Experimental** | Own versioning. App templates, not a stable API. |
+| `fluxopt-marimo` | **Experimental** | CalVer (`YYYY.MM.PATCH`). Validated against each `fluxopt` minor; apps are templates, widgets/CLI are the contract. |
 | `fluxopt-tsam` | **Independent** | Fully independent semver. |
+
+### Versioning & stability
+
+Most companion packages follow semver; `fluxopt-marimo` is the exception
+and uses **CalVer** (`YYYY.MM.PATCH`). Versions communicate *when* a
+snapshot was validated, not the severity of changes — appropriate because
+the package's primary deliverable is *templates*, not a stable API.
+
+**Compatibility with `fluxopt`** — `fluxopt-marimo` pins the core
+dependency at minor granularity (`fluxopt>=A.B,<A.C`). Every new
+`fluxopt` minor triggers a new `fluxopt-marimo` release; the bump *is*
+the validation. A scheduled CI job runs the apps against the latest
+`fluxopt` release — passing runs auto-PR a pin bump and tag a release;
+failing runs alert the maintainer to fix before tagging. The CHANGELOG
+records the validation result for every release, even when no code
+changed. The coupling is operational only — `fluxopt` core has no
+dependency on any companion.
+
+Other dependencies (marimo, plotly, …) carry only lower bounds — users
+own those versions.
+
+**Contract tiers within `fluxopt-marimo`:**
+
+| Surface | Contract |
+|---------|----------|
+| `apps/*.py` (marimo apps) | None — templates to fork and own. |
+| Widget helpers (Python API) | Minimal surface; breaking changes documented per release. |
+| CLI commands (`fluxopt-explore`, …) | Command names stable from first release. |
+
+While in Experimental tier, breaking changes are allowed in any release
+with a CHANGELOG entry — no deprecation cycle promised until 1.0 (and
+1.0 is not on the roadmap).
 
 See [#47](https://github.com/FBumann/fluxopt/issues/47) for the full architecture discussion.
 

--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ print(result.flow_rates)
 fluxopt is evolving into a family of packages with a lean core and optional companions:
 
 ```
-                  ┌──────────────┐
-                  │   fluxopt    │  core: model building, solving, results, IO
-                  └──────┬───────┘
-          ┌───────────┬──┴──────────┬────────────────┐
-          │           │             │                 │
-   fluxopt-plot  fluxopt-yaml  fluxopt-tsam     (examples)
-    plotting      YAML+CSV      time series     cross-package
-   (plotly)       loader       aggregation       notebooks
+                          ┌──────────────┐
+                          │   fluxopt    │  core: model building, solving, results, IO
+                          └──────┬───────┘
+        ┌──────────────┬─────────┼──────────────┬──────────────┐
+        │              │         │              │              │
+ fluxopt-plot   fluxopt-yaml  fluxopt-tsam  fluxopt-marimo  (examples)
+   plotting      YAML+CSV    time series    interactive     cross-package
+   (plotly)       loader     aggregation       apps          notebooks
 ```
 
 Companion packages depend on core — core has no knowledge of companions.
@@ -81,6 +81,7 @@ Companion packages depend on core — core has no knowledge of companions.
 | `fluxopt-plot` package | Interactive plotly visualization as companion package | [Scaffolded](https://fbumann.github.io/fluxopt-plot/latest/) | [#51](https://github.com/FBumann/fluxopt/issues/51) |
 | `fluxopt-yaml` package | Declarative model definition via YAML + CSV | [Scaffolded](https://fbumann.github.io/fluxopt-yaml/latest/) | [#52](https://github.com/FBumann/fluxopt/issues/52) |
 | `fluxopt-tsam` package | Time series aggregation preprocessing | Planned | — |
+| `fluxopt-marimo` package | Interactive marimo apps for result exploration & dashboards | Planned | — |
 | ReadTheDocs migration | Automatic versioned docs from git tags | Planned | [#53](https://github.com/FBumann/fluxopt/issues/53) |
 | Remove plotly from core | Keep core lean — plotting deps in `fluxopt-plot` only | Planned | [#54](https://github.com/FBumann/fluxopt/issues/54) |
 
@@ -92,6 +93,7 @@ Companion packages depend on core — core has no knowledge of companions.
 | Stats accessor | **Semi-stable** | Breaking changes allowed between minor versions with changelog entry. |
 | `fluxopt-yaml` | **Experimental** | Own versioning. YAML schema may change. |
 | `fluxopt-plot` | **Experimental** | Own versioning. Method signatures may change. |
+| `fluxopt-marimo` | **Experimental** | Own versioning. App templates, not a stable API. |
 | `fluxopt-tsam` | **Independent** | Fully independent semver. |
 
 See [#47](https://github.com/FBumann/fluxopt/issues/47) for the full architecture discussion.

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ Energy system optimization with [linopy](https://github.com/PyPSA/linopy) — de
 
     ---
 
-    Lean core, optional companions for [plotting](https://fbumann.github.io/fluxopt-plot/latest/) and [YAML loading](https://fbumann.github.io/fluxopt-yaml/latest/).
+    Lean core, optional companions for [plotting](https://fbumann.github.io/fluxopt-plot/latest/), [YAML loading](https://fbumann.github.io/fluxopt-yaml/latest/), and (planned) interactive marimo apps.
 
 </div>
 


### PR DESCRIPTION
## Summary

- Adds `fluxopt-marimo` as a planned companion package in the README roadmap (ASCII tree, milestones table, stability tiers table) and mentions it in the docs landing page.
- Low-maintenance framing: deliverable is single-file marimo apps plus maybe some thin widget helpers; no core fluxopt API changes (no `Result` accessor needed).

## Test plan

- [ ] Render README on GitHub and confirm the ASCII tree, milestones row, and stability-tiers row render cleanly.
- [ ] Render docs locally with mkdocs if needed to confirm the landing card text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a new planned companion package to the ecosystem, documented in the roadmap with experimental status and independent versioning.
  * Updated marketing materials to highlight the new companion offering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->