### PR TITLE
chore: upgrade to linopy 0.7.0

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -9,7 +9,7 @@
       "bump-minor-for-major-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "changelog-path": "CHANGELOG.md",
-      "initial-version": "0.0.2-alpha.0"
+      "initial-version": "0.0.2"
     }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,11 @@ classifiers = [
 ]
 dependencies = [
     "highspy>=1.13.1,!=1.14.0",  # 1.14.0 has MIP presolve bug (ERGO-Code/HiGHS#2975)
-    "linopy @ git+https://github.com/PyPSA/linopy.git@2d2e851dd2f444ac4b0c9b82ed09f5863856195d",
+    "linopy>=0.7.0",
     "netcdf4>=1.6.0",
     "numpy>=1.26",
     "pandas>=2.1",
-    "xarray>=2024.1.0,<2026.4.0",  # 2026.4.0 breaks linopy (Dataset-as-data_vars)
+    "xarray>=2024.1.0",
 ]
 
 [project.urls]

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -907,8 +907,10 @@ class FlowSystem:
         Per-converter availability is enforced separately as
         ``flow_rate <= avail * max_bp * active``.
         """
+        import warnings
         from typing import cast
 
+        from linopy import EvolvingAPIWarning
         from linopy.piecewise import add_piecewise_formulation
 
         from fluxopt.types import PiecewiseMethod
@@ -941,13 +943,17 @@ class FlowSystem:
                 )
                 pairs.append((expr, bps) if bound == '==' else (expr, bps, bound))
 
-            formulation = add_piecewise_formulation(
-                self.m,
-                *pairs,
-                method=method,
-                active=active,
-                name=f'pw_{conv_id}',
-            )
+            # fluxopt owns the API risk of add_piecewise_formulation — surface it
+            # in our changelog instead of leaking warnings into user output.
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', EvolvingAPIWarning)
+                formulation = add_piecewise_formulation(
+                    self.m,
+                    *pairs,
+                    method=method,
+                    active=active,
+                    name=f'pw_{conv_id}',
+                )
             self._piecewise[conv_id] = formulation
 
             # Availability constraint: scale upper envelope, not the curve.


### PR DESCRIPTION
## Summary
- Replace the git-commit pin (`2d2e851d`, `0.6.4.post1.dev80`) with the released `linopy>=0.7.0`. **This unblocks PyPI publication** — PyPI rejects direct URL deps, so the git pin was the actual blocker, not the alpha version suffix.
- Drop the `xarray<2026.4.0` cap — [PyPSA/linopy#647](https://github.com/PyPSA/linopy/pull/647) fixes the Dataset-as-data_vars regression in 0.7.0; xarray now resolves to 2026.4.0 locally.
- Silence `linopy.EvolvingAPIWarning` inside `_create_piecewise_constraints` so users don't see it on every solve — fluxopt owns the API-stability risk of `add_piecewise_formulation` and will surface it in its own changelog instead.
- Cosmetic: drop `-alpha.0` from `initial-version` in `.release-please-config.json` (bootstrap-only field, no functional effect).

Our existing `PiecewiseConversion` wiring already matches the unified v0.7.0 API ([PyPSA/linopy#638](https://github.com/PyPSA/linopy/pull/638)) — `(expr, breaks)` / `(expr, breaks, sign)` tuples, `method="auto"|"sos2"|"incremental"|"lp"`, `active=` gate. No code changes needed there.

The release-please manifest (`0.0.7-alpha.0`) and the `3 - Alpha` classifier are intentionally left alone — the next release-please cycle will drop the prerelease suffix on its own now that `prerelease`/`prerelease-type` are gone from the config (already done in #163).

## Test plan
- [x] `uv sync --group dev` resolves linopy 0.7.0 + xarray 2026.4.0
- [x] `uv run pytest` — 469 passed, 227 skipped (full piecewise suite green)
- [x] `uv run mypy src/` — clean
- [x] `uv run ruff check .` — clean
- [x] `EvolvingAPIWarning` no longer appears in pytest warning summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)