### PR TITLE
chore: migrate from ty to pyrefly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,8 +41,8 @@ jobs:
       - name: Install
         run: uv sync --group dev
 
-      - name: Ty
-        run: uv run ty check src/
+      - name: Pyrefly
+        run: uv run pyrefly check src/
 
   test:
     name: Test (Python ${{ matrix.python-version }})

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,9 +19,9 @@ repos:
 
   - repo: local
     hooks:
-      - id: ty
-        name: ty
-        entry: uv run ty check src/
+      - id: pyrefly
+        name: pyrefly
+        entry: uv run pyrefly check src/
         language: system
         pass_filenames: false
         files: ^src/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Key runtime deps: xarray, linopy, numpy, pandas.
 - **src layout** — `src/fluxopt/`, enforcing proper installation
 - **hatchling + hatch-vcs** — version from git tags
 - **ruff** replaces flake8, isort, pyupgrade, black
-- **ty** — Astral's type checker, enforced from day one
+- **pyrefly** — Meta's type checker, enforced from day one
 - **No lock file** — `uv.lock` is gitignored
 
 ## Common Commands
@@ -40,7 +40,7 @@ uv sync --group dev      # Install runtime + dev deps
 uv run pytest -v         # Run tests
 uv run ruff check .      # Lint
 uv run ruff format .     # Format
-uv run ty check src/     # Type check
+uv run pyrefly check src/ # Type check
 ```
 
 ## Code Style

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,8 @@ dev = [
     "pytest==9.0.2",
     "pytest-cov==7.0.0",
     "pytest-xdist==3.8.0",
+    "pyrefly==1.0.0",
     "ruff==0.15.12",
-    "ty==0.0.35",
 ]
 docs = [
     "plotly>=6",
@@ -126,22 +126,27 @@ docstring-code-format = true
 [tool.ruff.lint.pyupgrade]
 keep-runtime-typing = false
 
-[tool.ty.environment]
+[tool.pyrefly]
 python-version = "3.12"
+project-includes = ["src"]
+preset = "strict"
 
-[tool.ty.src]
-include = ["src"]
-
-[tool.ty.rules]
-ambiguous-protocol-member = "error"
-deprecated = "error"
-division-by-zero = "error"
-ignore-comment-unknown-rule = "error"
-ineffective-final = "error"
-invalid-enum-member-annotation = "error"
-invalid-ignore-comment = "error"
-invalid-legacy-positional-parameter = "error"
-invalid-named-tuple-override = "error"
+# Promote warn-by-default rules to error so regressions fail CI.
+[tool.pyrefly.errors]
+deprecated = true
+implicit-import = true
+missing-import = true
+non-exhaustive-match = true
+not-required-key-access = true
+redundant-cast = true
+redundant-condition = true
+unknown-name = true
+unnecessary-comparison = true
+unnecessary-type-conversion = true
+unreachable = true
+unresolvable-dunder-all = true
+untyped-import = true
+variance-mismatch = true
 
 [tool.pytest.ini_options]
 addopts = "-n auto"

--- a/src/fluxopt/constraints/status.py
+++ b/src/fluxopt/constraints/status.py
@@ -49,7 +49,7 @@ def compute_previous_duration(
 
     if isinstance(dt, xr.DataArray):
         return float(dt.values[-count:].sum()) if count > 0 else 0.0
-    return float(dt) * count
+    return dt * count
 
 
 def add_duration_tracking(

--- a/src/fluxopt/model.py
+++ b/src/fluxopt/model.py
@@ -659,10 +659,7 @@ class FlowSystem:
                 else:
                     # With lifetime: active for lt_int periods after build
                     # active[p] = sum_{tau: p in [tau, tau+lt)} build[tau] + (1 if prior and p < lt)
-                    contributing = []
-                    for t_idx in range(n_periods):
-                        if t_idx <= p_idx < t_idx + lt_int:
-                            contributing.append(period_vals[t_idx])
+                    contributing = [period_vals[t_idx] for t_idx in range(n_periods) if t_idx <= p_idx < t_idx + lt_int]
                     rhs = b_sel.sel(period=contributing).sum('period') if contributing else 0
                     if has_prior and p_idx < lt_int:
                         self.m.add_constraints(a_sel == rhs + 1, name=f'invest_active_{fid}_p{p}')

--- a/src/fluxopt/model_data.py
+++ b/src/fluxopt/model_data.py
@@ -548,7 +548,7 @@ class FlowsData:
             elif isinstance(f.size, Investment):
                 invest_items.append((f.id, f.size))
             elif f.size is not None:
-                size_vals[i] = float(f.size)
+                size_vals[i] = f.size
 
             if f.fixed_relative_profile is not None:
                 profiles.append(as_dataarray(f.fixed_relative_profile, envelope_coords))
@@ -951,7 +951,7 @@ class PiecewiseData:
             all_flows_zero = is_zero.isel(pw_pair=mask).all('pw_pair')  # (breakpoint, time)
             if bool(all_flows_zero.any().item()):
                 warnings.warn(
-                    f'PiecewiseConversion on converter {str(conv_id)!r} has Status, '
+                    f'PiecewiseConversion on converter {conv_id!r} has Status, '
                     'but the curve includes a (0, ..., 0) breakpoint. The '
                     'optimizer can sit at zero with status=on, decoupling the '
                     'binary from the actual operating state — Status features '
@@ -1025,7 +1025,7 @@ class EffectsData:
             elif f.name in ds.attrs:
                 kwargs[f.name] = ds.attrs[f.name]
             # else: rely on dataclass default (e.g. None for optional fields)
-        return cls(**kwargs)  # ty: ignore[invalid-argument-type]
+        return cls(**kwargs)  # pyrefly: ignore[bad-argument-type]
 
     @classmethod
     def build(
@@ -1302,7 +1302,7 @@ def _compute_period_weights(
         Tuple of (period_index, period_weights DataArray).
     """
     idx = pd.Index(periods, name='period')
-    if not np.issubdtype(idx.dtype, np.integer):  # ty: ignore[invalid-argument-type]
+    if not np.issubdtype(idx.dtype, np.integer):  # pyrefly: ignore[bad-argument-type]
         raise TypeError(f'periods must be integer, got {idx.dtype}')
     if not idx.is_monotonic_increasing or not idx.is_unique:
         raise ValueError('periods must be monotonically increasing and unique')

--- a/src/fluxopt/results.py
+++ b/src/fluxopt/results.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Literal
 import xarray as xr
 
 try:
-    from fluxopt_plot.accessor import PlotAccessor  # ty: ignore[unresolved-import]
+    from fluxopt_plot.accessor import PlotAccessor  # pyrefly: ignore[missing-import]
 except ImportError:
     PlotAccessor = None
 

--- a/src/fluxopt/types.py
+++ b/src/fluxopt/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Literal, Protocol, overload, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, overload, override, runtime_checkable
 
 import numpy as np
 import pandas as pd
@@ -86,6 +86,7 @@ class IdList[T: Identified]:
     def __add__(self, other: IdList[T]) -> IdList[T]:
         return IdList([*self._items, *other._items])
 
+    @override
     def __repr__(self) -> str:
         return f'IdList({list(self._items)!r})'
 
@@ -171,7 +172,7 @@ def as_dataarray(
     elif isinstance(value, (pd.Series, pd.DataFrame)):
         # Mirror linopy: pandas axes already carry coords; use axis.name as dim.
         # Fall back to length-matching only when no axis is named.
-        named = [a.name for a in value.axes if a.name is not None]  # ty: ignore[not-iterable]
+        named = [a.name for a in value.axes if a.name is not None]
         if len(named) == value.ndim:
             da = xr.DataArray(value)
         elif value.ndim == 1 and not named:
@@ -179,7 +180,7 @@ def as_dataarray(
         else:
             raise ValueError(
                 f'{type(value).__name__} requires axis.name set on every axis '
-                f'(got {[a.name for a in value.axes]!r}). '  # ty: ignore[not-iterable]
+                f'(got {[a.name for a in value.axes]!r}). '
                 f"Set e.g. df.index.name='time', df.columns.name='period'."
             )
     elif isinstance(value, np.ndarray):
@@ -312,7 +313,7 @@ def compute_dt(timesteps: TimeIndex, dt: float | list[float] | None) -> xr.DataA
         elif isinstance(dt, list):
             if len(dt) != n:
                 raise ValueError(f'dt length {len(dt)} does not match timesteps length {n}')
-            values = np.array([float(v) for v in dt])
+            values = np.array(dt, dtype=float)
         else:
             raise TypeError(f'Unsupported dt type: {type(dt)}')
         return xr.DataArray(values, dims=['time'], coords={'time': timesteps}, name='dt')


### PR DESCRIPTION
## Summary
- Replace ty 0.0.35 (Astral, preview) with [pyrefly](https://github.com/facebook/pyrefly) 1.0.0 (Meta, stable). Pyrefly hits >90% typing-spec conformance — higher than mypy and ty — and is the default checker for Instagram, PyTorch, NumPy, Pandas stubs, and JAX.
- Use `preset = "strict"` + promotion of 14 warn-default rules to error so regressions fail CI.
- Net diagnostic changes vs. the ty migration:
  - **Dropped** 2 stale ignores (pandas `Series \| DataFrame.axes` now resolves correctly).
  - **Fixed** 2 real issues pyrefly caught that ty missed: missing `@override` on `IdList.__repr__`, implicit-Any empty list in `model.py`.
  - **Fixed** 4 `unnecessary-type-conversion` cases (redundant `float()` / `str()` calls).
  - **Converted** 3 remaining ignores from `# ty: ignore[...]` to `# pyrefly: ignore[...]`.

## Notes
- No official pre-commit hook from Meta — local hook calls `uv run pyrefly check src/` (same pattern as the ty PR).
- CI step name stays `Type check` (branch protection); inner step renamed `Ty` → `Pyrefly`.
- The `cast`-vs-`match` refactor in `_iter_normalized` from the ty PR remains the right shape and stays.

## Why now
ty was a defensible call when picked, but pyrefly v1.0 landed days later. v1.0 stability commitment + higher conformance + production validation at Meta-scale dissolves the main concern about pre-1.0 churn.

## Test plan
- [x] `uv run pyrefly check src/` → `0 errors`
- [x] `uv run pytest` → 469 passed, 227 skipped
- [x] pre-commit hooks pass on commit
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling and CI/CD pipelines.

* **Refactor**
  * Simplified internal code logic and type annotations for improved maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FBumann/fluxopt/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->