### PR TITLE
fix: exclude all highspy 1.14.x versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "highspy>=1.13.1,!=1.14.0",  # 1.14.0 has MIP presolve bug (ERGO-Code/HiGHS#2975)
+    "highspy>=1.13.1,!=1.14.*",  # 1.14.x has MIP presolve bug producing wrong results (ERGO-Code/HiGHS#2975)
     "linopy>=0.7.0",
     "netcdf4>=1.6.0",
     "numpy>=1.26",


### PR DESCRIPTION
## Summary
- Widen highspy exclusion from `!=1.14.0` to `!=1.14.*` — the entire 1.14.x line ships the MIP presolve bug that produces wrong results (ERGO-Code/HiGHS#2975), not only 1.14.0.

## Test plan
- [ ] `uv sync --group dev` resolves a non-1.14.x highspy
- [ ] `uv run pytest -v` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `highspy` dependency constraint to exclude the entire 1.14 series.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FBumann/fluxopt/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->